### PR TITLE
Github actions (CI)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ jobs:
     build-lake:
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout current repo
+            - name: Checkout current branch (sparse)
               uses: actions/checkout@v4
               with:
                 sparse-checkout: |
@@ -24,11 +24,11 @@ jobs:
     build-cargo:
       runs-on: ubuntu-latest
       steps:
-          - name: Checkout current repo
+          - name: Checkout current branch
             uses: actions/checkout@v4
             with:
               path: lampe
-          - name: Checkout reilabs/noir
+          - name: "Checkout reilabs/noir (branch: lampe)"
             uses: actions/checkout@v4
             with:
               path: noir

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,9 +6,13 @@ jobs:
         steps:
             - name: Cheeckout repository
               uses: actions/checkout@v4
+              with:
+                sparse-checkout: |
+                  Lampe
             - name: Set up Lean 4
               uses: leanprover/lean-action@v1
               with:
+                lake-package-directory: Lampe
                 build: "true"
                 test: "true"
                 lint: "true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
                   Lampe
             - name: Set up Lean 4
               uses: leanprover/lean-action@v1
-              continue-on-error: true
               with:
+                build: true
+                use-mathlib-cache: true
                 lake-package-directory: Lampe
-                use-mathlib-cache: "true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 on: [push, pull_request]
 jobs:
-    build:
+    check-lean:
         runs-on: ubuntu-latest
         steps:
             - name: Cheeckout repository
@@ -18,10 +18,23 @@ jobs:
                 lint: false
                 use-mathlib-cache: true
                 lake-package-directory: Lampe
-            - name: Build Lampe
+            - name: Build (lake)
               uses: leanprover/lean-action@v1
               with:
                 auto-config: true
                 use-mathlib-cache: true
                 lake-package-directory: Lampe
+    check-cargo:
+      runs-on: ubuntu-latest
+      steps:
+          - name: Cheeckout repository
+            uses: actions/checkout@v4
+          - name: Set up Rust
+            uses: actions-rs/toolchain@v1
+            with:
+              toolchain: stable
+          - name: Build (cargo)
+            run: cargo build --release
+          - name: Test (cargo)
+            run: cargo test
   

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,9 +59,6 @@ jobs:
           uses: actions-rs/toolchain@v1
           with:
             toolchain: stable
-        - name: Build (cargo)
-          working-directory: lampe
-          run: cargo build --release
         - name: Test (cargo)
           working-directory: lampe
           run: cargo test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,16 @@ jobs:
             - name: Set up Lean 4
               uses: leanprover/lean-action@v1
               with:
-                build: true
+                auto-config: false
+                build: false
+                test: false
+                lint: false
                 use-mathlib-cache: true
                 lake-package-directory: Lampe
+            - name: Build Lampe
+              uses: leanprover/lean-action@v1
+              with:
+                auto-config: true
+                use-mathlib-cache: true
+                lake-package-directory: Lampe
+  

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,4 @@ jobs:
               continue-on-error: true
               with:
                 lake-package-directory: Lampe
-                build: "true"
-                test: "true"
-                lint: "true"
                 use-mathlib-cache: "true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 on: [push, pull_request]
 jobs:
-    check-lean:
+    build-lake:
         runs-on: ubuntu-latest
         steps:
             - name: Cheeckout repository
@@ -19,12 +19,9 @@ jobs:
                 use-mathlib-cache: true
                 lake-package-directory: Lampe
             - name: Build (lake)
-              uses: leanprover/lean-action@v1
-              with:
-                auto-config: true
-                use-mathlib-cache: true
-                lake-package-directory: Lampe
-    check-cargo:
+              working-directory: Lampe
+              run: lake build
+    build-cargo:
       runs-on: ubuntu-latest
       steps:
           - name: Cheeckout repository
@@ -34,7 +31,4 @@ jobs:
             with:
               toolchain: stable
           - name: Build (cargo)
-            run: cargo build --release
-          - name: Test (cargo)
-            run: cargo test
-  
+            run: cargo build --release  

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,4 +40,29 @@ jobs:
               toolchain: stable
           - name: Build (cargo)
             working-directory: lampe
-            run: cargo build --release  
+            run: cargo build --release
+    test-cargo:
+      needs: build-cargo
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout current branch
+          uses: actions/checkout@v4
+          with:
+            path: lampe
+        - name: "Checkout reilabs/noir (branch: lampe)"
+          uses: actions/checkout@v4
+          with:
+            path: noir
+            ref: lampe
+            repository: reilabs/noir
+        - name: Set up Rust
+          uses: actions-rs/toolchain@v1
+          with:
+            toolchain: stable
+        - name: Build (cargo)
+          working-directory: lampe
+          run: cargo build --release
+        - name: Test (cargo)
+          working-directory: lampe
+          run: cargo test
+          

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ jobs:
     build-lake:
         runs-on: ubuntu-latest
         steps:
-            - name: Cheeckout repository
+            - name: Checkout current repo
               uses: actions/checkout@v4
               with:
                 sparse-checkout: |
@@ -24,11 +24,20 @@ jobs:
     build-cargo:
       runs-on: ubuntu-latest
       steps:
-          - name: Cheeckout repository
+          - name: Checkout current repo
             uses: actions/checkout@v4
+            with:
+              path: lampe
+          - name: Checkout reilabs/noir
+            uses: actions/checkout@v4
+            with:
+              path: noir
+              ref: lampe
+              repository: reilabs/noir
           - name: Set up Rust
             uses: actions-rs/toolchain@v1
             with:
               toolchain: stable
           - name: Build (cargo)
+            working-directory: lampe
             run: cargo build --release  

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,15 @@
+name: CI
+on: [push, pull_request]
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Cheeckout repository
+              uses: actions/checkout@v4
+            - name: Set up Lean 4
+              uses: leanprover/lean-action@v1
+              with:
+                build: "true"
+                test: "true"
+                lint: "true"
+                use-mathlib-cache: "true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
                   Lampe
             - name: Set up Lean 4
               uses: leanprover/lean-action@v1
+              continue-on-error: true
               with:
                 lake-package-directory: Lampe
                 build: "true"


### PR DESCRIPTION
A new github workflow added at `.github/workflows/ci.yaml` with three jobs:
- `build-cargo`: Sets up Rust toolchain (stable), checks out the current repository, places `reilabs/noir` at the appropriate folder, and finally runs `cargo build --release`.
- `test-cargo`: Depends on `build-cargo`. Runs the same steps, except the final step is replaced by a `cargo test` run.
- `build-lake`: Sets up Lean4 toolchain, checks out the current repository sparsely (i.e., only the `Lake` folder is fetched) and runs `lake build`.