### PR TITLE
If-then-else support

### DIFF
--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -60,25 +60,15 @@ example {self that : Tp.denote P (.slice tp)} : STHoare P Γ ⟦⟧ (sliceAppend
   simp_all [Nat.mod_eq_of_lt]
 
 nr_def simple_if<>(x : Field, y : Field) -> u32 {
-  let z = if #eq(x, y) : bool { 0 : u32 } else { 1 : u32 };
-  3 : u32
+  let y = if #eq(x, y) : bool { 4 : u32 } else { 6 : u32 };
+  y
 }
 
-example : STHoare p Γ ⟦⟧ (simple_if.fn.body _ h![] h![x, y])
-  fun v => v =  BitVec.ofNat _ 3 := by
+example {p Γ x y}: STHoare p Γ ⟦x = y⟧ (simple_if.fn.body (Tp.denote p) h![] h![x, y])
+  fun v => v = BitVec.ofNat 32 4 := by
   simp only [simple_if]
   steps
   simp_all
-  rename_i cnd
-  cases cnd <;> simp_all
-  . steps
-    simp only [Nat.cast_zero, BitVec.ofNat_eq_ofNat, SLP.true_star]
-    tauto
-  . simp only [beq_false, Bool.not_eq_true', eq_iff_iff]
-    intros
-    steps
-    . simp only [Bool.false_eq_true, false_iff, SLP.true_star]
-      tauto
-    . simp only [Nat.cast_one, BitVec.ofNat_eq_ofNat, SLP.true_star]
-      tauto
-  . aesop
+  all_goals tauto
+  sorry
+  sorry

--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -59,13 +59,23 @@ example {self that : Tp.denote P (.slice tp)} : STHoare P Γ ⟦⟧ (sliceAppend
   steps
   simp_all [Nat.mod_eq_of_lt]
 
-nr_def simple_if<>(x : Field, y : Field) -> u32 {
-  let y = if #eq(x, y) : bool { 4 : u32 } else { 4 : u32 };
-  4 : u32
+nr_def simple_if<>(x : Field, y : Field) -> Field {
+  let z = if #eq(x, x) : bool { x } else { y };
+  z
 }
 
-example {p Γ x y}: STHoare p Γ ⟦x = y⟧ (simple_if.fn.body (Tp.denote p) h![] h![x, y])
-  fun v => v = BitVec.ofNat 32 4 := by
+example {p Γ x y}: STHoare p Γ ⟦⟧ (simple_if.fn.body (Tp.denote p) h![] h![x, y])
+  fun v => v = x := by
   simp only [simple_if]
   steps
-  sorry
+  simp_all
+  tauto
+  simp_all
+  . unfold SLP.entails
+    unfold SLP.lift
+    tauto
+  . simp_all
+    sl
+    intro
+    subst_vars
+    rfl

--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -72,7 +72,8 @@ example {p Γ x y}: STHoare p Γ ⟦⟧ (simple_if.fn.body (Tp.denote p) h![] h!
   simp only [simple_if]
   steps <;> tauto
   . sl
-  . sorry -- we need skip_intro
+  . sl
+    simp_all
   . subst_vars
     rfl
 

--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -58,3 +58,27 @@ example {self that : Tp.denote P (.slice tp)} : STHoare P Γ ⟦⟧ (sliceAppend
   · simp_all
   steps
   simp_all [Nat.mod_eq_of_lt]
+
+nr_def simple_if<>(x : Field, y : Field) -> u32 {
+  let z = if #eq(x, y) : bool { 0 : u32 } else { 1 : u32 };
+  3 : u32
+}
+
+example : STHoare p Γ ⟦⟧ (simple_if.fn.body _ h![] h![x, y])
+  fun v => v =  BitVec.ofNat _ 3 := by
+  simp only [simple_if]
+  steps
+  simp_all
+  rename_i cnd
+  cases cnd <;> simp_all
+  . steps
+    simp only [Nat.cast_zero, BitVec.ofNat_eq_ofNat, SLP.true_star]
+    tauto
+  . simp only [beq_false, Bool.not_eq_true', eq_iff_iff]
+    intros
+    steps
+    . simp only [Bool.false_eq_true, false_iff, SLP.true_star]
+      tauto
+    . simp only [Nat.cast_one, BitVec.ofNat_eq_ofNat, SLP.true_star]
+      tauto
+  . aesop

--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -60,22 +60,31 @@ example {self that : Tp.denote P (.slice tp)} : STHoare P Γ ⟦⟧ (sliceAppend
   simp_all [Nat.mod_eq_of_lt]
 
 nr_def simple_if<>(x : Field, y : Field) -> Field {
-  let z = if #eq(x, x) : bool { x } else { y };
+  let mut z = x;
+  if #eq(x, x) : bool {
+    z = y
+   }; -- else ()
   z
 }
 
 example {p Γ x y}: STHoare p Γ ⟦⟧ (simple_if.fn.body (Tp.denote p) h![] h![x, y])
-  fun v => v = x := by
+  fun v => v = y := by
   simp only [simple_if]
-  steps
-  simp_all
-  tauto
-  simp_all
-  . unfold SLP.entails
-    unfold SLP.lift
-    tauto
-  . simp_all
-    sl
-    intro
-    subst_vars
+  steps <;> tauto
+  . sl
+  . sorry -- we need skip_intro
+  . subst_vars
     rfl
+
+
+nr_def simple_if_else<>(x : Field, y : Field) -> Field {
+  let z = if #eq(x, x) : bool { x } else { y };
+  z
+}
+
+example {p Γ x y}: STHoare p Γ ⟦⟧ (simple_if_else.fn.body (Tp.denote p) h![] h![x, y])
+  fun v => v = x := by
+  simp only [simple_if_else]
+  steps
+  . contradiction
+  . simp_all

--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -60,15 +60,12 @@ example {self that : Tp.denote P (.slice tp)} : STHoare P Γ ⟦⟧ (sliceAppend
   simp_all [Nat.mod_eq_of_lt]
 
 nr_def simple_if<>(x : Field, y : Field) -> u32 {
-  let y = if #eq(x, y) : bool { 4 : u32 } else { 6 : u32 };
-  y
+  let y = if #eq(x, y) : bool { 4 : u32 } else { 4 : u32 };
+  4 : u32
 }
 
 example {p Γ x y}: STHoare p Γ ⟦x = y⟧ (simple_if.fn.body (Tp.denote p) h![] h![x, y])
   fun v => v = BitVec.ofNat 32 4 := by
   simp only [simple_if]
   steps
-  simp_all
-  all_goals tauto
-  sorry
   sorry

--- a/Lampe/Lampe/Hoare/SepTotal.lean
+++ b/Lampe/Lampe/Hoare/SepTotal.lean
@@ -336,4 +336,26 @@ theorem loop_inv_intro (Inv : (i : U s) → (lo ≤ i) → (i ≤ hi) → SLP p)
           apply h
           simp [*]
 
+theorem iteTrue_intro :
+    STHoare p Γ P mainBody Q →
+    STHoare p Γ P (.ite true mainBody elseBody) Q := by
+  tauto
+
+theorem iteFalse_intro :
+    STHoare p Γ P elseBody Q →
+    STHoare p Γ P (.ite false mainBody elseBody) Q := by
+  tauto
+
+theorem ite_intro :
+  (cnd == true → STHoare p Γ P mainBody Q) →
+  (cnd == false → STHoare p Γ P elseBody Q) →
+  STHoare p Γ P (.ite cnd mainBody elseBody) Q := by
+  unfold STHoare
+  intros
+  cases cnd
+  . apply iteFalse_intro
+    tauto
+  . apply iteTrue_intro
+    tauto
+
 end Lampe.STHoare

--- a/Lampe/Lampe/Hoare/SepTotal.lean
+++ b/Lampe/Lampe/Hoare/SepTotal.lean
@@ -358,4 +358,17 @@ theorem ite_intro {cnd : Bool}
   . apply iteTrue_intro
     tauto
 
+theorem skip_intro :
+  STHoare p Γ ⟦⟧ (.skip) (fun v => v = ()) := by
+  unfold STHoare
+  intros
+  simp only [SLP.true_star]
+  unfold THoare
+  intros
+  constructor
+  simp only
+  . apply SLP.ent_star_top
+    tauto
+  . exact ()
+
 end Lampe.STHoare

--- a/Lampe/Lampe/Hoare/SepTotal.lean
+++ b/Lampe/Lampe/Hoare/SepTotal.lean
@@ -369,6 +369,5 @@ theorem skip_intro :
   simp only
   . apply SLP.ent_star_top
     tauto
-  . exact ()
 
 end Lampe.STHoare

--- a/Lampe/Lampe/Hoare/SepTotal.lean
+++ b/Lampe/Lampe/Hoare/SepTotal.lean
@@ -347,8 +347,8 @@ theorem iteFalse_intro :
   tauto
 
 theorem ite_intro :
-  (cnd == true → STHoare p Γ P mainBody Q) →
-  (cnd == false → STHoare p Γ P elseBody Q) →
+  ((cnd = true → STHoare p Γ P mainBody Q) ∧
+  (cnd = false → STHoare p Γ P elseBody Q)) →
   STHoare p Γ P (.ite cnd mainBody elseBody) Q := by
   unfold STHoare
   intros

--- a/Lampe/Lampe/Hoare/SepTotal.lean
+++ b/Lampe/Lampe/Hoare/SepTotal.lean
@@ -346,9 +346,9 @@ theorem iteFalse_intro :
     STHoare p Γ P (.ite false mainBody elseBody) Q := by
   tauto
 
-theorem ite_intro :
-  ((cnd = true → STHoare p Γ P mainBody Q) ∧
-  (cnd = false → STHoare p Γ P elseBody Q)) →
+theorem ite_intro {cnd : Bool}
+  (h₁ : cnd = true → STHoare p Γ P mainBody Q)
+  (h₂ : cnd = false → STHoare p Γ P elseBody Q) :
   STHoare p Γ P (.ite cnd mainBody elseBody) Q := by
   unfold STHoare
   intros

--- a/Lampe/Lampe/Semantics.lean
+++ b/Lampe/Lampe/Semantics.lean
@@ -23,7 +23,7 @@ inductive Omni : Env → State P → Expr (Tp.denote P) tp → (Option (State P 
 | litTrue : Q (some (st, true)) → Omni Γ st (.lit .bool 1) Q
 | litU {Q} : Q (some (st, ↑n)) → Omni Γ st (.lit (.u s) n) Q
 | var : Q (some (st, v)) → Omni Γ st (.var v) Q
-| skip : ∀ st v, Q (some (st, v)) → Omni Γ st (.skip) Q
+| skip : Q (some (st, ())) → Omni Γ st (.skip) Q
 | iteTrue {mainBranch elseBranch} :
   Omni Γ st mainBranch Q →
   Omni Γ st (Expr.ite true mainBranch elseBranch) Q

--- a/Lampe/Lampe/Semantics.lean
+++ b/Lampe/Lampe/Semantics.lean
@@ -23,6 +23,12 @@ inductive Omni : Env → State P → Expr (Tp.denote P) tp → (Option (State P 
 | litTrue : Q (some (st, true)) → Omni Γ st (.lit .bool 1) Q
 | litU {Q} : Q (some (st, ↑n)) → Omni Γ st (.lit (.u s) n) Q
 | var : Q (some (st, v)) → Omni Γ st (.var v) Q
+| iteTrue {mainBranch elseBranch} :
+  Omni Γ st mainBranch Q →
+  Omni Γ st (Expr.ite true mainBranch elseBranch) Q
+| iteFalse {mainBranch elseBranch} :
+  Omni Γ st elseBranch Q →
+  Omni Γ st (Expr.ite false mainBranch elseBranch) Q
 | letIn :
     Omni Γ st e Q₁ →
     (∀v s, Q₁ (some (s, v)) → Omni Γ s (b v) Q) →
@@ -111,5 +117,11 @@ theorem Omni.frame {p Γ tp st₁ st₂} {e : Expr (Tp.denote p) tp} {Q}:
     intro
     apply loopNext (by assumption)
     tauto
+  | iteTrue _ ih
+  | iteFalse _ ih =>
+    intro
+    constructor
+    apply ih
+    assumption
 
 end Lampe

--- a/Lampe/Lampe/Semantics.lean
+++ b/Lampe/Lampe/Semantics.lean
@@ -23,6 +23,7 @@ inductive Omni : Env → State P → Expr (Tp.denote P) tp → (Option (State P 
 | litTrue : Q (some (st, true)) → Omni Γ st (.lit .bool 1) Q
 | litU {Q} : Q (some (st, ↑n)) → Omni Γ st (.lit (.u s) n) Q
 | var : Q (some (st, v)) → Omni Γ st (.var v) Q
+| skip : ∀ st v, Q (some (st, v)) → Omni Γ st (.skip) Q
 | iteTrue {mainBranch elseBranch} :
   Omni Γ st mainBranch Q →
   Omni Γ st (Expr.ite true mainBranch elseBranch) Q
@@ -80,6 +81,7 @@ theorem Omni.frame {p Γ tp st₁ st₂} {e : Expr (Tp.denote p) tp} {Q}:
   intro h
   induction h with
   | litField hq
+  | skip
   | litFalse hq
   | litTrue hq
   | litU _

--- a/Lampe/Lampe/Syntax.lean
+++ b/Lampe/Lampe/Syntax.lean
@@ -187,6 +187,11 @@ partial def mkExpr [MonadSyntax m] (e : TSyntax `nr_expr) (vname : Option Lean.I
   mkExpr e none fun eVal => do
     wrapSimple (←`(Lampe.Expr.writeRef $v $eVal)) vname k
 | `(nr_expr| ( $e )) => mkExpr e vname k
+| `(nr_expr| if $cond $mainBody else $elseBody) => do
+    mkExpr cond none fun cond => do
+      let mainBody ← mkExpr mainBody none fun x => ``(Lampe.Expr.var $x)
+      let elseBody ← mkExpr elseBody none fun x => ``(Lampe.Expr.var $x)
+      wrapSimple (←`(Lampe.Expr.ite $cond $mainBody $elseBody)) vname k
 | _ => throwUnsupportedSyntax
 
 end

--- a/Lampe/Lampe/Syntax.lean
+++ b/Lampe/Lampe/Syntax.lean
@@ -192,6 +192,10 @@ partial def mkExpr [MonadSyntax m] (e : TSyntax `nr_expr) (vname : Option Lean.I
       let mainBody ← mkExpr mainBody none fun x => ``(Lampe.Expr.var $x)
       let elseBody ← mkExpr elseBody none fun x => ``(Lampe.Expr.var $x)
       wrapSimple (←`(Lampe.Expr.ite $cond $mainBody $elseBody)) vname k
+| `(nr_expr| if $cond $mainBody) => do
+    mkExpr cond none fun cond => do
+      let mainBody ← mkExpr mainBody none fun x => ``(Lampe.Expr.var $x)
+      wrapSimple (←`(Lampe.Expr.ite $cond $mainBody Lampe.Expr.skip)) vname k
 | _ => throwUnsupportedSyntax
 
 end

--- a/Lampe/Lampe/Syntax.lean
+++ b/Lampe/Lampe/Syntax.lean
@@ -195,7 +195,7 @@ partial def mkExpr [MonadSyntax m] (e : TSyntax `nr_expr) (vname : Option Lean.I
 | `(nr_expr| if $cond $mainBody) => do
     mkExpr cond none fun cond => do
       let mainBody ← mkExpr mainBody none fun x => ``(Lampe.Expr.var $x)
-      wrapSimple (←`(Lampe.Expr.ite $cond $mainBody Lampe.Expr.skip)) vname k
+      wrapSimple (←`(Lampe.Expr.ite $cond $mainBody (Lampe.Expr.skip))) vname k
 | _ => throwUnsupportedSyntax
 
 end

--- a/Lampe/Lampe/Tactic/SeparationLogic.lean
+++ b/Lampe/Lampe/Tactic/SeparationLogic.lean
@@ -183,7 +183,7 @@ partial def parseSLExpr (e: Expr): TacticM SLTerm := do
   else if e.isAppOf ``SLP.lift then
     let args := e.getAppArgs
     return SLTerm.lift (←args[1]?)
-  else if e.isMVar then
+  else if e.getAppFn.isMVar then
     return SLTerm.mvar e
   else if e.isAppOf ``SLP.forall' then
     let args := e.getAppArgs

--- a/Lampe/Lampe/Tactic/SeparationLogic.lean
+++ b/Lampe/Lampe/Tactic/SeparationLogic.lean
@@ -455,6 +455,7 @@ macro "stephelper1" : tactic => `(tactic|(
     | apply sliceLen_intro
     | apply sliceIndex_intro
     | apply slicePushBack_intro
+    | apply ite_intro
   )
 ))
 
@@ -471,6 +472,7 @@ macro "stephelper2" : tactic => `(tactic|(
     | apply consequence_frame_left sliceLen_intro
     | apply consequence_frame_left sliceIndex_intro
     | apply consequence_frame_left slicePushBack_intro
+    | apply consequence_frame_left ite_intro
   )
   repeat sl
 ))
@@ -488,6 +490,7 @@ macro "stephelper3" : tactic => `(tactic|(
     | apply ramified_frame_top sliceLen_intro
     | apply ramified_frame_top sliceIndex_intro
     | apply ramified_frame_top slicePushBack_intro
+    | apply ramified_frame_top ite_intro
   )
   repeat sl
 ))

--- a/Lampe/Lampe/Tactic/SeparationLogic.lean
+++ b/Lampe/Lampe/Tactic/SeparationLogic.lean
@@ -458,6 +458,7 @@ macro "stephelper1" : tactic => `(tactic|(
     | apply sliceLen_intro
     | apply sliceIndex_intro
     | apply slicePushBack_intro
+    | apply skip_intro
   )
 ))
 
@@ -474,6 +475,7 @@ macro "stephelper2" : tactic => `(tactic|(
     | apply consequence_frame_left sliceLen_intro
     | apply consequence_frame_left sliceIndex_intro
     | apply consequence_frame_left slicePushBack_intro
+    -- | apply consequence_frame_left skip_intro
   )
   repeat sl
 ))
@@ -491,6 +493,7 @@ macro "stephelper3" : tactic => `(tactic|(
     | apply ramified_frame_top sliceLen_intro
     | apply ramified_frame_top sliceIndex_intro
     | apply ramified_frame_top slicePushBack_intro
+    | apply ramified_frame_top skip_intro
   )
   repeat sl
 ))

--- a/Lampe/Lampe/Tactic/SeparationLogic.lean
+++ b/Lampe/Lampe/Tactic/SeparationLogic.lean
@@ -400,6 +400,9 @@ partial def solveEntailment (goal : MVarId): TacticM (List MVarId) := do
     let (_, newGoal) ← newGoal.intro1
     let gls ← solveEntailment newGoal
     return gls ++ newGoals
+  | SLTerm.top => do
+    let newGoals ← goal.apply (←mkConstWithFreshMVarLevels ``SLP.entails_top)
+    return newGoals
   | _ => pure ()
 
   match post with


### PR DESCRIPTION
This PR aims to implement the if-then-else semantics, and it closes #9.
- `Syntax.lean`: If-then-else expressions are now parsed. If no "else" body is found, then it is substituted by an `Expr.skip`.
- `Semantics.lean`: Three new `Omni` cases added: `skip`, `iteTrue`, and `iteFalse`.
- `Hoare/SepTotal.lean`: Added introduction rules `ite_intro` and `skip_intro`.
- `Tactics/SeparationLogic.lean`: Updated the `steps` tactic to handle the `ite` expressions. Added `skip_intro` to `stephelper1` and `stephelper3`.
- `Lampe.lean`: Some examples utilizing if-then-else expressions.

