### PR TITLE
Higher order functions

### DIFF
--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -146,7 +146,8 @@ example {p} {arg : Tp.denote p Tp.field} :
   simp only [simple_trait_call]
   steps
   . apply STHoare.callTrait_intro
-    apply SLP.ent_star_top
+    sl
+    tauto
     try_impls_all [] simpleTraitEnv
     all_goals tauto
     simp only
@@ -182,7 +183,8 @@ example {p} {x : Tp.denote p Tp.field} :
   simp only [generic_trait_call]
   steps
   . apply STHoare.callTrait_intro
-    apply SLP.ent_star_top
+    sl
+    tauto
     try_impls_all [Tp.field] genericTraitEnv
     tauto
     all_goals try rfl
@@ -239,12 +241,8 @@ example : STHoare p ⟨[(add_two_fields.name, add_two_fields.fn)], []⟩ ⟦⟧ 
   simp only [call_decl]
   steps
   apply STHoare.callDecl_intro
-  . rename_i v₁ v₂ v₃
-    rw [SLP.star_comm (H := ⟦v₁ = _⟧), ←SLP.star_assoc]
-    rw [SLP.star_comm (H := ⟦v₁ = _⟧), SLP.star_assoc]
-    apply SLP.star_mono
-    apply SLP.entails_self
-    apply SLP.entails_top
+  . sl
+    tauto
   on_goal 3 => exact add_two_fields.fn
   all_goals tauto
   on_goal 3 => exact fun v => v = 3

--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -89,7 +89,7 @@ example {p Γ x y}: STHoare p Γ ⟦⟧ (simple_if_else.fn.body _ h![] |>.body h
   . simp only [decide_True, exists_const]
     sl
     contradiction
-  . aesop
+  . simp_all [decide_True, exists_const]
 
 nr_def simple_lambda<>(x : Field, y : Field) -> Field {
   let add = |a : Field, b : Field| -> Field { #fAdd(a, b) : Field };
@@ -101,7 +101,7 @@ example {p Γ} {x y : Tp.denote p Tp.field} :
   fun v => v = x + y := by
   simp only [simple_lambda]
   steps
-  . apply STHoare.consequence_frame_left STHoare.callLambda'_intro
+  . apply STHoare.consequence_frame_left STHoare.callLambda_intro
     . rw [SLP.star_assoc, SLP.star_comm, SLP.star_assoc]
       rw [SLP.top_star_top]
       apply SLP.ent_star_top
@@ -145,7 +145,7 @@ example {p} {arg : Tp.denote p Tp.field} :
   STHoare p simpleTraitEnv ⟦⟧ (simple_trait_call.fn.body _ h![.field] |>.body h![arg]) (fun v => v = 2 * arg) := by
   simp only [simple_trait_call]
   steps
-  . apply STHoare.callTrait'_intro
+  . apply STHoare.callTrait_intro
     apply SLP.ent_star_top
     try_impls_all [] simpleTraitEnv
     all_goals tauto
@@ -181,7 +181,7 @@ example {p} {x : Tp.denote p Tp.field} :
   STHoare p genericTraitEnv ⟦⟧ (generic_trait_call.fn.body _ h![] |>.body h![x]) (fun v => v = x) := by
   simp only [generic_trait_call]
   steps
-  . apply STHoare.callTrait'_intro
+  . apply STHoare.callTrait_intro
     apply SLP.ent_star_top
     try_impls_all [Tp.field] genericTraitEnv
     tauto
@@ -238,7 +238,7 @@ example : STHoare p ⟨[(add_two_fields.name, add_two_fields.fn)], []⟩ ⟦⟧ 
   fun (v : Tp.denote p .field) => v = 3 := by
   simp only [call_decl]
   steps
-  apply STHoare.callDecl'_intro
+  apply STHoare.callDecl_intro
   . rename_i v₁ v₂ v₃
     rw [SLP.star_comm (H := ⟦v₁ = _⟧), ←SLP.star_assoc]
     rw [SLP.star_comm (H := ⟦v₁ = _⟧), SLP.star_assoc]
@@ -254,7 +254,7 @@ example : STHoare p ⟨[(add_two_fields.name, add_two_fields.fn)], []⟩ ⟦⟧ 
     intros
     ring
   . steps
-    aesop
+    simp_all
 
 nr_def simple_tuple<>() -> Field {
   let t = `(1 : Field, true, 3 : Field);
@@ -273,7 +273,9 @@ nr_def simple_slice<>() -> bool {
 
 example : STHoare p Γ ⟦⟧ (simple_slice.fn.body _ h![] |>.body h![]) (fun (v : Tp.denote p .bool) => v = false) := by
   simp only [simple_slice, Expr.mkSlice]
-  steps <;> aesop
+  steps
+  rfl
+  aesop
 
 nr_def simple_array<>() -> Field {
   let arr = [1 : Field, 2 : Field];

--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -9,8 +9,8 @@ nr_def simple_muts<>(x : Field) -> Field {
   y
 }
 
-example : STHoare p Γ ⟦⟧ (simple_muts.fn.body _ h![] |>.body h![x]) fun v => v = x := by
-  simp only [simple_muts]
+example : STHoare p Γ ⟦⟧ («fn#simple_muts».fn.body _ h![] |>.body h![x]) fun v => v = x := by
+  simp only [«fn#simple_muts»]
   steps
   simp_all
 
@@ -21,8 +21,8 @@ nr_def weirdEq<I>(x : I, y : I) -> Unit {
   #assert(#fEq(a, y) : bool) : Unit;
 }
 
-example {x y : Tp.denote p .field} : STHoare p Γ ⟦⟧ (weirdEq.fn.body _ h![.field] |>.body h![x, y]) fun _ => x = y := by
-  simp only [weirdEq]
+example {x y : Tp.denote p .field} : STHoare p Γ ⟦⟧ («fn#weirdEq».fn.body _ h![.field] |>.body h![x, y]) fun _ => x = y := by
+  simp only [«fn#weirdEq»]
   steps
   simp_all
 
@@ -39,8 +39,9 @@ lemma BitVec.add_toNat_of_lt_max {a b : BitVec w} (h: a.toNat + b.toNat < 2^w) :
   rw [Nat.mod_eq_of_lt]
   assumption
 
-example {self that : Tp.denote p (.slice tp)} : STHoare p Γ ⟦⟧ (sliceAppend.fn.body _ h![tp] |>.body h![self, that]) fun v => v = self ++ that := by
-  simp only [sliceAppend]
+example {self that : Tp.denote p (.slice tp)} :
+    STHoare p Γ ⟦⟧ («fn#sliceAppend».fn.body _ h![tp] |>.body h![self, that]) fun v => v = self ++ that := by
+  simp only [«fn#sliceAppend»]
   steps
   rename Tp.denote _ tp.slice.ref => selfRef
   loop_inv (fun i _ _ => [selfRef ↦ ⟨.slice tp, self ++ that.take i.toNat⟩])
@@ -66,9 +67,9 @@ nr_def simple_if<>(x : Field, y : Field) -> Field {
   z
 }
 
-example {p Γ x y}: STHoare p Γ ⟦⟧ (simple_if.fn.body _ h![] |>.body h![x, y])
-  fun v => v = y := by
-  simp only [simple_if]
+example {p Γ x y} : STHoare p Γ ⟦⟧ («fn#simple_if».fn.body _ h![] |>.body h![x, y])
+    fun v => v = y := by
+  simp only [«fn#simple_if»]
   steps <;> tauto
   . sl
   . sl
@@ -82,9 +83,9 @@ nr_def simple_if_else<>(x : Field, y : Field) -> Field {
   z
 }
 
-example {p Γ x y}: STHoare p Γ ⟦⟧ (simple_if_else.fn.body _ h![] |>.body h![x, y])
-  fun v => v = x := by
-  simp only [simple_if_else]
+example {p Γ x y} : STHoare p Γ ⟦⟧ («fn#simple_if_else».fn.body _ h![] |>.body h![x, y])
+    fun v => v = x := by
+  simp only [«fn#simple_if_else»]
   steps
   . simp only [decide_True, exists_const]
     sl
@@ -97,9 +98,9 @@ nr_def simple_lambda<>(x : Field, y : Field) -> Field {
 }
 
 example {p Γ} {x y : Tp.denote p Tp.field} :
-  STHoare p Γ ⟦⟧ (simple_lambda.fn.body _ h![] |>.body h![x, y])
-  fun v => v = x + y := by
-  simp only [simple_lambda]
+    STHoare p Γ ⟦⟧ («fn#simple_lambda».fn.body _ h![] |>.body h![x, y])
+    fun v => v = x + y := by
+  simp only [«fn#simple_lambda»]
   steps
   . apply STHoare.consequence_frame_left STHoare.callLambda_intro
     . rw [SLP.star_assoc, SLP.star_comm, SLP.star_assoc]
@@ -142,8 +143,9 @@ nr_def simple_trait_call<I> (x : I) -> I {
 }
 
 example {p} {arg : Tp.denote p Tp.field} :
-  STHoare p simpleTraitEnv ⟦⟧ (simple_trait_call.fn.body _ h![.field] |>.body h![arg]) (fun v => v = 2 * arg) := by
-  simp only [simple_trait_call]
+    STHoare p simpleTraitEnv ⟦⟧ («fn#simple_trait_call».fn.body _ h![.field] |>.body h![arg])
+    fun v => v = 2 * arg := by
+  simp only [«fn#simple_trait_call»]
   steps
   . apply STHoare.callTrait_intro
     sl
@@ -179,8 +181,8 @@ nr_def generic_trait_call<>(x : Field) -> Field {
 }
 
 example {p} {x : Tp.denote p Tp.field} :
-  STHoare p genericTraitEnv ⟦⟧ (generic_trait_call.fn.body _ h![] |>.body h![x]) (fun v => v = x) := by
-  simp only [generic_trait_call]
+    STHoare p genericTraitEnv ⟦⟧ («fn#generic_trait_call».fn.body _ h![] |>.body h![x]) (fun v => v = x) := by
+  simp only [«fn#generic_trait_call»]
   steps
   . apply STHoare.callTrait_intro
     sl
@@ -202,8 +204,8 @@ nr_def struct_construct<>(a : Field, b : Field) -> Pair<Field> {
 }
 
 example {p} {a b : Tp.denote p .field} :
-  STHoare p Γ ⟦⟧ (struct_construct.fn.body _ h![] |>.body h![a, b]) (fun v => v.fst = a ∧ v.snd = (b, ())) := by
-  simp only [struct_construct]
+    STHoare p Γ ⟦⟧ («fn#struct_construct».fn.body _ h![] |>.body h![a, b]) (fun v => v.fst = a ∧ v.snd = (b, ())) := by
+  simp only [«fn#struct_construct»]
   steps
   aesop
 
@@ -213,8 +215,8 @@ nr_def struct_project<>(x : Field, y : Field) -> Field {
 }
 
 example {p} {x y : Tp.denote p .field} :
-  STHoare p Γ ⟦⟧ (struct_project.fn.body _ h![] |>.body h![x, y]) (fun v => v = x) := by
-  simp only [struct_project]
+    STHoare p Γ ⟦⟧ («fn#struct_project».fn.body _ h![] |>.body h![x, y]) (fun v => v = x) := by
+  simp only [«fn#struct_project»]
   steps
   aesop
 
@@ -223,8 +225,8 @@ nr_def basic_cast<>(x : u8) -> Field {
 }
 
 example {p} {x : Tp.denote p $ .u 8} :
-  STHoare p Γ ⟦⟧ (basic_cast.fn.body _ h![] |>.body h![x]) (fun (v : Tp.denote _ .field) => v = x.toNat) := by
-  simp only [basic_cast]
+    STHoare p Γ ⟦⟧ («fn#basic_cast».fn.body _ h![] |>.body h![x]) (fun (v : Tp.denote _ .field) => v = x.toNat) := by
+  simp only [«fn#basic_cast»]
   steps
   aesop
 
@@ -236,17 +238,18 @@ nr_def call_decl<>() -> Field {
   @add_two_fields<>(1 : Field, 2 : Field)
 }
 
-example : STHoare p ⟨[(add_two_fields.name, add_two_fields.fn)], []⟩ ⟦⟧ (call_decl.fn.body _ h![] |>.body h![])
-  fun (v : Tp.denote p .field) => v = 3 := by
-  simp only [call_decl]
+example : STHoare p ⟨[(«fn#add_two_fields».name, «fn#add_two_fields».fn)], []⟩ ⟦⟧
+    («fn#call_decl».fn.body _ h![] |>.body h![])
+    fun (v : Tp.denote p .field) => v = 3 := by
+  simp only [«fn#call_decl»]
   steps
   apply STHoare.callDecl_intro
   . sl
     tauto
-  on_goal 3 => exact add_two_fields.fn
+  on_goal 3 => exact «fn#add_two_fields».fn
   all_goals tauto
   on_goal 3 => exact fun v => v = 3
-  . simp only [add_two_fields]
+  . simp only [«fn#add_two_fields»]
     steps
     simp_all
     intros
@@ -259,8 +262,8 @@ nr_def simple_tuple<>() -> Field {
   t.2
 }
 
-example : STHoare p Γ ⟦⟧ (simple_tuple.fn.body _ h![] |>.body h![]) (fun (v : Tp.denote p .field) => v = 3) := by
-  simp only [simple_tuple]
+example : STHoare p Γ ⟦⟧ («fn#simple_tuple».fn.body _ h![] |>.body h![]) (fun (v : Tp.denote p .field) => v = 3) := by
+  simp only [«fn#simple_tuple»]
   steps
   aesop
 
@@ -269,8 +272,8 @@ nr_def simple_slice<>() -> bool {
   s[[1 : u32]]
 }
 
-example : STHoare p Γ ⟦⟧ (simple_slice.fn.body _ h![] |>.body h![]) (fun (v : Tp.denote p .bool) => v = false) := by
-  simp only [simple_slice, Expr.mkSlice]
+example : STHoare p Γ ⟦⟧ («fn#simple_slice».fn.body _ h![] |>.body h![]) (fun (v : Tp.denote p .bool) => v = false) := by
+  simp only [«fn#simple_slice», Expr.mkSlice]
   steps
   rfl
   aesop
@@ -280,8 +283,8 @@ nr_def simple_array<>() -> Field {
   arr[1 : u32]
 }
 
-example : STHoare p Γ ⟦⟧ (simple_array.fn.body _ h![] |>.body h![]) (fun (v : Tp.denote p .field) => v = 2) := by
-  simp only [simple_array, Expr.mkArray]
+example : STHoare p Γ ⟦⟧ («fn#simple_array».fn.body _ h![] |>.body h![]) (fun (v : Tp.denote p .field) => v = 2) := by
+  simp only [«fn#simple_array», Expr.mkArray]
   steps <;> tauto
   aesop
 
@@ -291,8 +294,8 @@ nr_def tuple_lens<>() -> Field {
   p .0 .1
 }
 
-example : STHoare p Γ ⟦⟧ (tuple_lens.fn.body _ h![] |>.body h![]) fun (v : Tp.denote p .field) => v = 3 := by
-  simp only [tuple_lens]
+example : STHoare p Γ ⟦⟧ («fn#tuple_lens».fn.body _ h![] |>.body h![]) fun (v : Tp.denote p .field) => v = 3 := by
+  simp only [«fn#tuple_lens»]
   steps
   subst_vars
   simp_all only [Access.get, exists_const, Lens.modify, Lens.get, Option.bind_eq_bind,
@@ -306,8 +309,8 @@ nr_def struct_lens<>() -> Field {
   (p .0 as Pair<Field>).b
 }
 
-example : STHoare p Γ ⟦⟧ (struct_lens.fn.body _ h![] |>.body h![]) fun (v : Tp.denote p .field) => v = 3 := by
-  simp only [struct_lens]
+example : STHoare p Γ ⟦⟧ («fn#struct_lens».fn.body _ h![] |>.body h![]) fun (v : Tp.denote p .field) => v = 3 := by
+  simp only [«fn#struct_lens»]
   steps
   aesop
 
@@ -317,8 +320,8 @@ nr_def array_lens<>() -> Field {
   p.0[1 : u32]
 }
 
-example : STHoare p Γ ⟦⟧ (array_lens.fn.body _ h![] |>.body h![]) fun (v : Tp.denote p .field) => v = 3 := by
-  simp only [array_lens]
+example : STHoare p Γ ⟦⟧ («fn#array_lens».fn.body _ h![] |>.body h![]) fun (v : Tp.denote p .field) => v = 3 := by
+  simp only [«fn#array_lens»]
   steps
   rfl
   on_goal 3 => exact (⟨[1, 3], (by rfl)⟩, 3)
@@ -333,8 +336,8 @@ nr_def slice_lens<>() -> Field {
   p .0 [[1 : u32]]
 }
 
-example : STHoare p Γ ⟦⟧ (slice_lens.fn.body _ h![] |>.body h![]) fun (v : Tp.denote p .field) => v = 3 := by
-  simp only [slice_lens]
+example : STHoare p Γ ⟦⟧ («fn#slice_lens».fn.body _ h![] |>.body h![]) fun (v : Tp.denote p .field) => v = 3 := by
+  simp only [«fn#slice_lens»]
   steps
   all_goals try exact ([1, 3], 3)
   all_goals try tauto

--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -9,8 +9,8 @@ nr_def simple_muts<>(x : Field) -> Field {
   y
 }
 
-example : STHoare p Γ ⟦⟧ («fn#simple_muts».fn.body _ h![] |>.body h![x]) fun v => v = x := by
-  simp only [«fn#simple_muts»]
+example : STHoare p Γ ⟦⟧ (simple_muts.fn.body _ h![] |>.body h![x]) fun v => v = x := by
+  simp only [simple_muts]
   steps
   simp_all
 
@@ -22,8 +22,8 @@ nr_def weirdEq<I>(x : I, y : I) -> Unit {
 }
 
 example {x y : Tp.denote p .field} :
-  STHoare p Γ ⟦⟧ («fn#weirdEq».fn.body _ h![.field] |>.body h![x, y]) fun _ => x = y := by
-  simp only [«fn#weirdEq»]
+  STHoare p Γ ⟦⟧ (weirdEq.fn.body _ h![.field] |>.body h![x, y]) fun _ => x = y := by
+  simp only [weirdEq]
   steps
   simp_all
 
@@ -42,9 +42,9 @@ lemma BitVec.add_toNat_of_lt_max {a b : BitVec w} (h: a.toNat + b.toNat < 2^w) :
   assumption
 
 example {self that : Tp.denote p (.slice tp)} :
-    STHoare p Γ ⟦⟧ («fn#sliceAppend».fn.body _ h![tp] |>.body h![self, that])
+    STHoare p Γ ⟦⟧ (sliceAppend.fn.body _ h![tp] |>.body h![self, that])
     fun v => v = self ++ that := by
-  simp only [«fn#sliceAppend»]
+  simp only [sliceAppend]
   steps
   rename Tp.denote _ tp.slice.ref => selfRef
   loop_inv (fun i _ _ => [selfRef ↦ ⟨.slice tp, self ++ that.take i.toNat⟩])
@@ -70,9 +70,9 @@ nr_def simple_if<>(x : Field, y : Field) -> Field {
   z
 }
 
-example {p Γ x y} : STHoare p Γ ⟦⟧ («fn#simple_if».fn.body _ h![] |>.body h![x, y])
+example {p Γ x y} : STHoare p Γ ⟦⟧ (simple_if.fn.body _ h![] |>.body h![x, y])
     fun v => v = y := by
-  simp only [«fn#simple_if»]
+  simp only [simple_if]
   steps <;> tauto
   . sl
   . sl
@@ -86,9 +86,9 @@ nr_def simple_if_else<>(x : Field, y : Field) -> Field {
   z
 }
 
-example {p Γ x y} : STHoare p Γ ⟦⟧ («fn#simple_if_else».fn.body _ h![] |>.body h![x, y])
+example {p Γ x y} : STHoare p Γ ⟦⟧ (simple_if_else.fn.body _ h![] |>.body h![x, y])
     fun v => v = x := by
-  simp only [«fn#simple_if_else»]
+  simp only [simple_if_else]
   steps
   . simp only [decide_True, exists_const]
     sl
@@ -101,9 +101,9 @@ nr_def simple_lambda<>(x : Field, y : Field) -> Field {
 }
 
 example {p Γ} {x y : Tp.denote p Tp.field} :
-    STHoare p Γ ⟦⟧ («fn#simple_lambda».fn.body _ h![] |>.body h![x, y])
+    STHoare p Γ ⟦⟧ (simple_lambda.fn.body _ h![] |>.body h![x, y])
     fun v => v = x + y := by
-  simp only [«fn#simple_lambda»]
+  simp only [simple_lambda]
   steps
   . apply STHoare.consequence_frame_left STHoare.callLambda_intro
     . rw [SLP.star_assoc, SLP.star_comm, SLP.star_assoc]
@@ -146,9 +146,9 @@ nr_def simple_trait_call<I> (x : I) -> I {
 }
 
 example {p} {arg : Tp.denote p Tp.field} :
-    STHoare p simpleTraitEnv ⟦⟧ («fn#simple_trait_call».fn.body _ h![.field] |>.body h![arg])
+    STHoare p simpleTraitEnv ⟦⟧ (simple_trait_call.fn.body _ h![.field] |>.body h![arg])
     fun v => v = 2 * arg := by
-  simp only [«fn#simple_trait_call»]
+  simp only [simple_trait_call]
   steps
   . apply STHoare.callTrait_intro
     sl
@@ -184,9 +184,9 @@ nr_def generic_trait_call<>(x : Field) -> Field {
 }
 
 example {p} {x : Tp.denote p Tp.field} :
-    STHoare p genericTraitEnv ⟦⟧ («fn#generic_trait_call».fn.body _ h![] |>.body h![x])
+    STHoare p genericTraitEnv ⟦⟧ (generic_trait_call.fn.body _ h![] |>.body h![x])
     fun v => v = x := by
-  simp only [«fn#generic_trait_call»]
+  simp only [generic_trait_call]
   steps
   . apply STHoare.callTrait_intro
     sl
@@ -208,9 +208,9 @@ nr_def struct_construct<>(a : Field, b : Field) -> Pair<Field> {
 }
 
 example {p} {a b : Tp.denote p .field} :
-    STHoare p Γ ⟦⟧ («fn#struct_construct».fn.body _ h![] |>.body h![a, b])
+    STHoare p Γ ⟦⟧ (struct_construct.fn.body _ h![] |>.body h![a, b])
     fun v => v.fst = a ∧ v.snd = (b, ()) := by
-  simp only [«fn#struct_construct»]
+  simp only [struct_construct]
   steps
   aesop
 
@@ -220,9 +220,9 @@ nr_def struct_project<>(x : Field, y : Field) -> Field {
 }
 
 example {p} {x y : Tp.denote p .field} :
-    STHoare p Γ ⟦⟧ («fn#struct_project».fn.body _ h![] |>.body h![x, y])
+    STHoare p Γ ⟦⟧ (struct_project.fn.body _ h![] |>.body h![x, y])
     fun v => v = x := by
-  simp only [«fn#struct_project»]
+  simp only [struct_project]
   steps
   aesop
 
@@ -231,9 +231,9 @@ nr_def basic_cast<>(x : u8) -> Field {
 }
 
 example {p} {x : Tp.denote p $ .u 8} :
-    STHoare p Γ ⟦⟧ («fn#basic_cast».fn.body _ h![] |>.body h![x])
+    STHoare p Γ ⟦⟧ (basic_cast.fn.body _ h![] |>.body h![x])
     fun (v : Tp.denote p .field) => v = x.toNat := by
-  simp only [«fn#basic_cast»]
+  simp only [basic_cast]
   steps
   aesop
 
@@ -245,18 +245,18 @@ nr_def call_decl<>() -> Field {
   (@add_two_fields<> as λ(Field, Field) → Field)(1 : Field, 2 : Field)
 }
 
-example : STHoare p ⟨[(«fn#add_two_fields».name, «fn#add_two_fields».fn)], []⟩ ⟦⟧
-    («fn#call_decl».fn.body _ h![] |>.body h![])
+example : STHoare p ⟨[(add_two_fields.name, add_two_fields.fn)], []⟩ ⟦⟧
+    (call_decl.fn.body _ h![] |>.body h![])
     fun (v : Tp.denote p .field) => v = 3 := by
-  simp only [«fn#call_decl»]
+  simp only [call_decl]
   steps
   apply STHoare.callDecl_intro
   . sl
     tauto
-  on_goal 3 => exact «fn#add_two_fields».fn
+  on_goal 3 => exact add_two_fields.fn
   all_goals tauto
   on_goal 3 => exact fun v => v = 3
-  . simp only [«fn#add_two_fields»]
+  . simp only [add_two_fields]
     steps
     simp_all
     intros
@@ -269,9 +269,9 @@ nr_def simple_tuple<>() -> Field {
   t.2
 }
 
-example : STHoare p Γ ⟦⟧ («fn#simple_tuple».fn.body _ h![] |>.body h![])
+example : STHoare p Γ ⟦⟧ (simple_tuple.fn.body _ h![] |>.body h![])
     fun (v : Tp.denote p .field) => v = 3 := by
-  simp only [«fn#simple_tuple»]
+  simp only [simple_tuple]
   steps
   aesop
 
@@ -280,9 +280,9 @@ nr_def simple_slice<>() -> bool {
   s[[1 : u32]]
 }
 
-example : STHoare p Γ ⟦⟧ («fn#simple_slice».fn.body _ h![] |>.body h![])
+example : STHoare p Γ ⟦⟧ (simple_slice.fn.body _ h![] |>.body h![])
     fun (v : Tp.denote p .bool) => v = false := by
-  simp only [«fn#simple_slice», Expr.mkSlice]
+  simp only [simple_slice, Expr.mkSlice]
   steps
   rfl
   aesop
@@ -292,9 +292,9 @@ nr_def simple_array<>() -> Field {
   arr[1 : u32]
 }
 
-example : STHoare p Γ ⟦⟧ («fn#simple_array».fn.body _ h![] |>.body h![])
+example : STHoare p Γ ⟦⟧ (simple_array.fn.body _ h![] |>.body h![])
     fun (v : Tp.denote p .field) => v = 2 := by
-  simp only [«fn#simple_array», Expr.mkArray]
+  simp only [simple_array, Expr.mkArray]
   steps <;> tauto
   aesop
 
@@ -304,9 +304,9 @@ nr_def tuple_lens<>() -> Field {
   p .0 .1
 }
 
-example : STHoare p Γ ⟦⟧ («fn#tuple_lens».fn.body _ h![] |>.body h![])
+example : STHoare p Γ ⟦⟧ (tuple_lens.fn.body _ h![] |>.body h![])
     fun (v : Tp.denote p .field) => v = 3 := by
-  simp only [«fn#tuple_lens»]
+  simp only [tuple_lens]
   steps
   subst_vars
   simp_all only [Access.get, exists_const, Lens.modify, Lens.get, Option.bind_eq_bind,
@@ -320,9 +320,9 @@ nr_def struct_lens<>() -> Field {
   (p .0 as Pair<Field>).b
 }
 
-example : STHoare p Γ ⟦⟧ («fn#struct_lens».fn.body _ h![] |>.body h![])
+example : STHoare p Γ ⟦⟧ (struct_lens.fn.body _ h![] |>.body h![])
     fun (v : Tp.denote p .field) => v = 3 := by
-  simp only [«fn#struct_lens»]
+  simp only [struct_lens]
   steps
   aesop
 
@@ -332,9 +332,9 @@ nr_def array_lens<>() -> Field {
   p.0[1 : u32]
 }
 
-example : STHoare p Γ ⟦⟧ («fn#array_lens».fn.body _ h![] |>.body h![])
+example : STHoare p Γ ⟦⟧ (array_lens.fn.body _ h![] |>.body h![])
     fun (v : Tp.denote p .field) => v = 3 := by
-  simp only [«fn#array_lens»]
+  simp only [array_lens]
   steps
   rfl
   on_goal 3 => exact (⟨[1, 3], (by rfl)⟩, 3)
@@ -349,9 +349,9 @@ nr_def slice_lens<>() -> Field {
   p .0 [[1 : u32]]
 }
 
-example : STHoare p Γ ⟦⟧ («fn#slice_lens».fn.body _ h![] |>.body h![])
+example : STHoare p Γ ⟦⟧ (slice_lens.fn.body _ h![] |>.body h![])
     fun (v : Tp.denote p .field) => v = 3 := by
-  simp only [«fn#slice_lens»]
+  simp only [slice_lens]
   steps
   all_goals try exact ([1, 3], 3)
   all_goals try tauto
@@ -372,20 +372,20 @@ nr_def simple_hof<>() -> Field {
   (@call<> as λ(λ() → Field) → Field)(func)
 }
 
-example : STHoare p ⟨[(«fn#simple_func».name, «fn#simple_func».fn), («fn#call».name, «fn#call».fn)], []⟩ ⟦⟧
-    («fn#simple_hof».fn.body _ h![] |>.body h![])
+example : STHoare p ⟨[(simple_func.name, simple_func.fn), (call.name, call.fn)], []⟩ ⟦⟧
+    (simple_hof.fn.body _ h![] |>.body h![])
     fun (v : Tp.denote p .field) => v = 10 := by
-  simp only [«fn#simple_hof»]
+  simp only [simple_hof]
   steps
   . apply STHoare.callDecl_intro
     sl
     all_goals tauto
-    simp only [«fn#call»]
+    simp only [call]
     steps
     . apply STHoare.callDecl_intro
       sl
       all_goals tauto
-      simp only [«fn#simple_func»]
+      simp only [simple_func]
       steps
       on_goal 2 => exact fun v => v = 10
       sl

--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -1,8 +1,12 @@
 import Lampe.Basic
 open Lampe
 
+example {a b : Nat} [LawfulHeap α] : (⟦a = 5⟧ ⋆ ⟦b = 4⟧ : SLP α) ⊢ ⟦a = 5⟧ ⋆ ⊤ := by
+  sl
+  simp_all
+
 nr_def simple_fn<>() -> λ(Field, Field) → Field {
-  let x = %(Field as Pair<Field>)::hey<Unit>;
+  let x = %@hey<Unit>;
   → x(1 : Field, 2 : Field)
 }
 

--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -21,7 +21,8 @@ nr_def weirdEq<I>(x : I, y : I) -> Unit {
   #assert(#fEq(a, y) : bool) : Unit;
 }
 
-example {x y : Tp.denote p .field} : STHoare p Γ ⟦⟧ («fn#weirdEq».fn.body _ h![.field] |>.body h![x, y]) fun _ => x = y := by
+example {x y : Tp.denote p .field} :
+  STHoare p Γ ⟦⟧ («fn#weirdEq».fn.body _ h![.field] |>.body h![x, y]) fun _ => x = y := by
   simp only [«fn#weirdEq»]
   steps
   simp_all
@@ -34,13 +35,15 @@ nr_def sliceAppend<I>(x: [I], y: [I]) -> [I] {
   self
 }
 
-lemma BitVec.add_toNat_of_lt_max {a b : BitVec w} (h: a.toNat + b.toNat < 2^w) : (a + b).toNat = a.toNat + b.toNat := by
+lemma BitVec.add_toNat_of_lt_max {a b : BitVec w} (h: a.toNat + b.toNat < 2^w) :
+    (a + b).toNat = a.toNat + b.toNat := by
   simp only [BitVec.add_def, BitVec.toNat_ofNat]
   rw [Nat.mod_eq_of_lt]
   assumption
 
 example {self that : Tp.denote p (.slice tp)} :
-    STHoare p Γ ⟦⟧ («fn#sliceAppend».fn.body _ h![tp] |>.body h![self, that]) fun v => v = self ++ that := by
+    STHoare p Γ ⟦⟧ («fn#sliceAppend».fn.body _ h![tp] |>.body h![self, that])
+    fun v => v = self ++ that := by
   simp only [«fn#sliceAppend»]
   steps
   rename Tp.denote _ tp.slice.ref => selfRef
@@ -139,7 +142,7 @@ def simpleTraitEnv : Env := {
 }
 
 nr_def simple_trait_call<I> (x : I) -> I {
-  (I as Bulbulize<>)::bulbulize<>(x)
+  ((I as Bulbulize<>)::bulbulize<> as λ(I) → I)(x)
 }
 
 example {p} {arg : Tp.denote p Tp.field} :
@@ -177,11 +180,12 @@ def genericTraitEnv : Env := {
 }
 
 nr_def generic_trait_call<>(x : Field) -> Field {
-  (Field as Me<>)::me<>(x)
+  ((Field as Me<>)::me<> as λ(Field) → Field)(x)
 }
 
 example {p} {x : Tp.denote p Tp.field} :
-    STHoare p genericTraitEnv ⟦⟧ («fn#generic_trait_call».fn.body _ h![] |>.body h![x]) (fun v => v = x) := by
+    STHoare p genericTraitEnv ⟦⟧ («fn#generic_trait_call».fn.body _ h![] |>.body h![x])
+    fun v => v = x := by
   simp only [«fn#generic_trait_call»]
   steps
   . apply STHoare.callTrait_intro
@@ -204,7 +208,8 @@ nr_def struct_construct<>(a : Field, b : Field) -> Pair<Field> {
 }
 
 example {p} {a b : Tp.denote p .field} :
-    STHoare p Γ ⟦⟧ («fn#struct_construct».fn.body _ h![] |>.body h![a, b]) (fun v => v.fst = a ∧ v.snd = (b, ())) := by
+    STHoare p Γ ⟦⟧ («fn#struct_construct».fn.body _ h![] |>.body h![a, b])
+    fun v => v.fst = a ∧ v.snd = (b, ()) := by
   simp only [«fn#struct_construct»]
   steps
   aesop
@@ -215,7 +220,8 @@ nr_def struct_project<>(x : Field, y : Field) -> Field {
 }
 
 example {p} {x y : Tp.denote p .field} :
-    STHoare p Γ ⟦⟧ («fn#struct_project».fn.body _ h![] |>.body h![x, y]) (fun v => v = x) := by
+    STHoare p Γ ⟦⟧ («fn#struct_project».fn.body _ h![] |>.body h![x, y])
+    fun v => v = x := by
   simp only [«fn#struct_project»]
   steps
   aesop
@@ -225,7 +231,8 @@ nr_def basic_cast<>(x : u8) -> Field {
 }
 
 example {p} {x : Tp.denote p $ .u 8} :
-    STHoare p Γ ⟦⟧ («fn#basic_cast».fn.body _ h![] |>.body h![x]) (fun (v : Tp.denote _ .field) => v = x.toNat) := by
+    STHoare p Γ ⟦⟧ («fn#basic_cast».fn.body _ h![] |>.body h![x])
+    fun (v : Tp.denote p .field) => v = x.toNat := by
   simp only [«fn#basic_cast»]
   steps
   aesop
@@ -235,7 +242,7 @@ nr_def add_two_fields<>(a : Field, b : Field) -> Field {
 }
 
 nr_def call_decl<>() -> Field {
-  @add_two_fields<>(1 : Field, 2 : Field)
+  (@add_two_fields<> as λ(Field, Field) → Field)(1 : Field, 2 : Field)
 }
 
 example : STHoare p ⟨[(«fn#add_two_fields».name, «fn#add_two_fields».fn)], []⟩ ⟦⟧
@@ -262,7 +269,8 @@ nr_def simple_tuple<>() -> Field {
   t.2
 }
 
-example : STHoare p Γ ⟦⟧ («fn#simple_tuple».fn.body _ h![] |>.body h![]) (fun (v : Tp.denote p .field) => v = 3) := by
+example : STHoare p Γ ⟦⟧ («fn#simple_tuple».fn.body _ h![] |>.body h![])
+    fun (v : Tp.denote p .field) => v = 3 := by
   simp only [«fn#simple_tuple»]
   steps
   aesop
@@ -272,7 +280,8 @@ nr_def simple_slice<>() -> bool {
   s[[1 : u32]]
 }
 
-example : STHoare p Γ ⟦⟧ («fn#simple_slice».fn.body _ h![] |>.body h![]) (fun (v : Tp.denote p .bool) => v = false) := by
+example : STHoare p Γ ⟦⟧ («fn#simple_slice».fn.body _ h![] |>.body h![])
+    fun (v : Tp.denote p .bool) => v = false := by
   simp only [«fn#simple_slice», Expr.mkSlice]
   steps
   rfl
@@ -283,7 +292,8 @@ nr_def simple_array<>() -> Field {
   arr[1 : u32]
 }
 
-example : STHoare p Γ ⟦⟧ («fn#simple_array».fn.body _ h![] |>.body h![]) (fun (v : Tp.denote p .field) => v = 2) := by
+example : STHoare p Γ ⟦⟧ («fn#simple_array».fn.body _ h![] |>.body h![])
+    fun (v : Tp.denote p .field) => v = 2 := by
   simp only [«fn#simple_array», Expr.mkArray]
   steps <;> tauto
   aesop
@@ -294,7 +304,8 @@ nr_def tuple_lens<>() -> Field {
   p .0 .1
 }
 
-example : STHoare p Γ ⟦⟧ («fn#tuple_lens».fn.body _ h![] |>.body h![]) fun (v : Tp.denote p .field) => v = 3 := by
+example : STHoare p Γ ⟦⟧ («fn#tuple_lens».fn.body _ h![] |>.body h![])
+    fun (v : Tp.denote p .field) => v = 3 := by
   simp only [«fn#tuple_lens»]
   steps
   subst_vars
@@ -309,7 +320,8 @@ nr_def struct_lens<>() -> Field {
   (p .0 as Pair<Field>).b
 }
 
-example : STHoare p Γ ⟦⟧ («fn#struct_lens».fn.body _ h![] |>.body h![]) fun (v : Tp.denote p .field) => v = 3 := by
+example : STHoare p Γ ⟦⟧ («fn#struct_lens».fn.body _ h![] |>.body h![])
+    fun (v : Tp.denote p .field) => v = 3 := by
   simp only [«fn#struct_lens»]
   steps
   aesop
@@ -320,7 +332,8 @@ nr_def array_lens<>() -> Field {
   p.0[1 : u32]
 }
 
-example : STHoare p Γ ⟦⟧ («fn#array_lens».fn.body _ h![] |>.body h![]) fun (v : Tp.denote p .field) => v = 3 := by
+example : STHoare p Γ ⟦⟧ («fn#array_lens».fn.body _ h![] |>.body h![])
+    fun (v : Tp.denote p .field) => v = 3 := by
   simp only [«fn#array_lens»]
   steps
   rfl
@@ -336,7 +349,8 @@ nr_def slice_lens<>() -> Field {
   p .0 [[1 : u32]]
 }
 
-example : STHoare p Γ ⟦⟧ («fn#slice_lens».fn.body _ h![] |>.body h![]) fun (v : Tp.denote p .field) => v = 3 := by
+example : STHoare p Γ ⟦⟧ («fn#slice_lens».fn.body _ h![] |>.body h![])
+    fun (v : Tp.denote p .field) => v = 3 := by
   simp only [«fn#slice_lens»]
   steps
   all_goals try exact ([1, 3], 3)
@@ -344,3 +358,41 @@ example : STHoare p Γ ⟦⟧ («fn#slice_lens».fn.body _ h![] |>.body h![]) fu
   . simp_all
     rfl
   . simp_all [Builtin.indexTpl]
+
+nr_def simple_func<>() -> Field {
+  10 : Field
+}
+
+nr_def call<>(f : λ() → Field) -> Field {
+  f()
+}
+
+nr_def simple_hof<>() -> Field {
+  let func = @simple_func<> as λ() → Field;
+  (@call<> as λ(λ() → Field) → Field)(func)
+}
+
+example : STHoare p ⟨[(«fn#simple_func».name, «fn#simple_func».fn), («fn#call».name, «fn#call».fn)], []⟩ ⟦⟧
+    («fn#simple_hof».fn.body _ h![] |>.body h![])
+    fun (v : Tp.denote p .field) => v = 10 := by
+  simp only [«fn#simple_hof»]
+  steps
+  . apply STHoare.callDecl_intro
+    sl
+    all_goals tauto
+    simp only [«fn#call»]
+    steps
+    . apply STHoare.callDecl_intro
+      sl
+      all_goals tauto
+      simp only [«fn#simple_func»]
+      steps
+      on_goal 2 => exact fun v => v = 10
+      sl
+      simp_all
+    . steps
+      on_goal 2 => exact fun v => v = 10
+      sl
+      simp_all
+  steps
+  simp_all

--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -1,6 +1,15 @@
 import Lampe.Basic
 open Lampe
 
+nr_def simple_fn<>() -> λ(Field, Field) → Field {
+  let x = %(Field as Pair<Field>)::hey<Unit>;
+  → x(1 : Field, 2 : Field)
+}
+
+example : STHoare p Γ ⟦⟧ (simple_fn.fn.body _ h![] |>.body h![]) fun v => v = x := by
+  simp only [simple_fn]
+  steps
+
 nr_def simple_muts<>(x : Field) -> Field {
   let mut y = x;
   let mut z = x;

--- a/Lampe/Lampe/Ast.lean
+++ b/Lampe/Lampe/Ast.lean
@@ -33,10 +33,11 @@ inductive FunctionIdent (rep : Tp → Type) : Type where
 
 inductive Expr (rep : Tp → Type) : Tp → Type where
 | lit : (tp : Tp) → Nat → Expr rep tp
+| fn : (argTps : List Tp) → (outTp : Tp) → (r : FuncRef argTps outTp) → Expr rep (.fn argTps outTp)
 | var : rep tp → Expr rep tp
 | letIn : Expr rep t₁ → (rep t₁ → Expr rep t₂) → Expr rep t₂
 | call : HList Kind.denote tyKinds → (argTypes : List Tp) → (res : Tp) → FunctionIdent rep → HList rep argTypes → Expr rep res
-| callUni : (argTps : List Tp) → (outTp : Tp) → FuncRef argTps outTp → (args : HList rep argTps) → Expr rep outTp
+| callUni : (argTps : List Tp) → (outTp : Tp) → (rep $ .fn argTps outTp) → (args : HList rep argTps) → Expr rep outTp
 | ite : rep .bool → Expr rep a → Expr rep a → Expr rep a
 | skip : Expr rep .unit
 | loop : rep (.u s) → rep (.u s) → (rep (.u s) → Expr rep r) → Expr rep .unit

--- a/Lampe/Lampe/Ast.lean
+++ b/Lampe/Lampe/Ast.lean
@@ -41,7 +41,7 @@ inductive Expr (rep : Tp → Type) : Tp → Type where
 | ite : rep .bool → Expr rep a → Expr rep a → Expr rep a
 | skip : Expr rep .unit
 | loop : rep (.u s) → rep (.u s) → (rep (.u s) → Expr rep r) → Expr rep .unit
-| lambda : (argTps : List Tp) → (outTp : Tp) → (HList rep argTps → Expr rep outTp) → Expr rep .lambdaRef
+| lam : (argTps : List Tp) → (outTp : Tp) → (HList rep argTps → Expr rep outTp) → Expr rep (.fn argTps outTp)
 
 structure Lambda (rep : Tp → Type) where
   argTps : List Tp

--- a/Lampe/Lampe/Ast.lean
+++ b/Lampe/Lampe/Ast.lean
@@ -36,6 +36,7 @@ inductive Expr (rep : Tp → Type) : Tp → Type where
 | var : rep tp → Expr rep tp
 | letIn : Expr rep t₁ → (rep t₁ → Expr rep t₂) → Expr rep t₂
 | call : HList Kind.denote tyKinds → (argTypes : List Tp) → (res : Tp) → FunctionIdent rep → HList rep argTypes → Expr rep res
+| callUni : (argTps : List Tp) → (outTp : Tp) → FuncRef argTps outTp → (args : HList rep argTps) → Expr rep outTp
 | ite : rep .bool → Expr rep a → Expr rep a → Expr rep a
 | skip : Expr rep .unit
 | loop : rep (.u s) → rep (.u s) → (rep (.u s) → Expr rep r) → Expr rep .unit

--- a/Lampe/Lampe/Ast.lean
+++ b/Lampe/Lampe/Ast.lean
@@ -9,9 +9,6 @@ namespace Lampe
 
 abbrev Ident := String
 
-/-- A reference to a lambda is represented as a reference to a unit type -/
-abbrev Tp.lambdaRef := Tp.ref .unit
-
 structure TraitRef where
   name : Ident
   traitGenericKinds : List Kind
@@ -25,19 +22,13 @@ structure TraitMethodImplRef where
   trait : TraitImplRef
   method : Ident
 
-inductive FunctionIdent (rep : Tp → Type) : Type where
-| builtin : Builtin → FunctionIdent rep
-| decl : Ident → FunctionIdent rep
-| lambda : rep .lambdaRef → FunctionIdent rep
-| trait : TraitMethodImplRef → FunctionIdent rep
-
 inductive Expr (rep : Tp → Type) : Tp → Type where
 | lit : (tp : Tp) → Nat → Expr rep tp
 | fn : (argTps : List Tp) → (outTp : Tp) → (r : FuncRef argTps outTp) → Expr rep (.fn argTps outTp)
 | var : rep tp → Expr rep tp
 | letIn : Expr rep t₁ → (rep t₁ → Expr rep t₂) → Expr rep t₂
-| call : HList Kind.denote tyKinds → (argTypes : List Tp) → (res : Tp) → FunctionIdent rep → HList rep argTypes → Expr rep res
-| callUni : (argTps : List Tp) → (outTp : Tp) → (rep $ .fn argTps outTp) → (args : HList rep argTps) → Expr rep outTp
+| call : (argTps : List Tp) → (outTp : Tp) → (rep $ .fn argTps outTp) → (args : HList rep argTps) → Expr rep outTp
+| callBuiltin : (argTps : List Tp) → (outTp : Tp) → (b : Builtin) → (args : HList rep argTps) → Expr rep outTp
 | ite : rep .bool → Expr rep a → Expr rep a → Expr rep a
 | skip : Expr rep .unit
 | loop : rep (.u s) → rep (.u s) → (rep (.u s) → Expr rep r) → Expr rep .unit

--- a/Lampe/Lampe/Hoare/Builtins.lean
+++ b/Lampe/Lampe/Hoare/Builtins.lean
@@ -21,7 +21,7 @@ Introduction rule for pure builtins.
 theorem pureBuiltin_intro {A : Type} {a : A} {sgn desc args} :
   STHoare p Γ
     ⟦⟧
-    (.call h![] (sgn a).fst (sgn a).snd (.builtin (Builtin.newGenericPureBuiltin sgn desc)) args)
+    (.callBuiltin (sgn a).fst (sgn a).snd (Builtin.newGenericPureBuiltin sgn desc) args)
     (fun v => ∃h, (v = (desc a args).snd h)) := by
   unfold STHoare
   intro H
@@ -44,7 +44,7 @@ lemma pureBuiltin_intro_consequence
     (h2 : outTp = (sgn a).snd)
     (hp : (h: (desc a (h1 ▸ args)).fst) → Q (h2 ▸ (desc a (h1 ▸ args)).snd h)) :
     STHoare p Γ ⟦⟧
-      (.call h![] argTps outTp (.builtin (Builtin.newGenericPureBuiltin sgn desc)) args)
+      (.callBuiltin argTps outTp (Builtin.newGenericPureBuiltin sgn desc) args)
       fun v => Q v := by
   subst_vars
   dsimp only at *
@@ -369,7 +369,7 @@ theorem strAsBytes_intro : STHoarePureBuiltin p Γ Builtin.strAsBytes (by tauto)
 theorem ref_intro :
     STHoare p Γ
       ⟦⟧
-      (.call h![] [tp] (Tp.ref tp) (.builtin .ref) h![v])
+      (.callBuiltin [tp] (.ref tp) .ref h![v])
       (fun r => [r ↦ ⟨tp, v⟩]) := by
   unfold STHoare
   intro H
@@ -393,7 +393,7 @@ theorem ref_intro :
 theorem readRef_intro :
     STHoare p Γ
     [r ↦ ⟨tp, v⟩]
-    (.call h![] [tp.ref] tp (.builtin .readRef) h![r])
+    (.callBuiltin [.ref tp] tp .readRef h![r])
     (fun v' => ⟦v' = v⟧ ⋆ [r ↦ ⟨tp, v⟩]) := by
   unfold STHoare
   intro H
@@ -426,7 +426,7 @@ theorem readRef_intro :
 theorem writeRef_intro :
     STHoare p Γ
     [r ↦ ⟨tp, v⟩]
-    (.call h![] [tp.ref, tp] .unit (.builtin .writeRef) h![r, v'])
+    (.callBuiltin [.ref tp, tp] .unit .writeRef h![r, v'])
     (fun _ => [r ↦ ⟨tp, v'⟩]) := by
   unfold STHoare
   intro H
@@ -471,7 +471,7 @@ theorem projectTuple_intro : STHoarePureBuiltin p Γ (Builtin.projectTuple mem) 
 theorem readLens_intro {lens : Lens (Tp.denote p) tp₁ tp₂} :
     STHoare p Γ
     [r ↦ ⟨tp₁, s⟩]
-    (.call h![] [tp₁.ref] tp₂ (.builtin $ .readLens lens) h![r])
+    (.callBuiltin [tp₁.ref] tp₂ (.readLens lens) h![r])
     (fun v' => ⟦lens.get s = some v'⟧ ⋆ [r ↦ ⟨tp₁, s⟩]) := by
   unfold STHoare THoare
   intros H st h
@@ -491,7 +491,7 @@ theorem readLens_intro {lens : Lens (Tp.denote p) tp₁ tp₂} :
  theorem modifyLens_intro {lens : Lens (Tp.denote p) tp₁ tp₂} {s : Tp.denote p tp₁} {v : Tp.denote p tp₂} :
     STHoare p Γ
     [r ↦ ⟨tp₁, s⟩]
-    (.call h![] [tp₁.ref, tp₂] .unit (.builtin $ .modifyLens lens) h![r, v])
+    (.callBuiltin [tp₁.ref, tp₂] .unit (.modifyLens lens) h![r, v])
     (fun _ => ∃∃h, [r ↦ ⟨tp₁, lens.modify s v |>.get h⟩]) := by
   unfold STHoare THoare
   intros H st h
@@ -528,7 +528,7 @@ theorem readLens_intro {lens : Lens (Tp.denote p) tp₁ tp₂} :
 theorem getLens_intro {lens : Lens (Tp.denote p) tp₁ tp₂} :
     STHoare p Γ
     ⟦⟧
-    (.call h![] [tp₁] tp₂ (.builtin $ .getLens lens) h![s])
+    (.callBuiltin [tp₁] tp₂ (.getLens lens) h![s])
     (fun v => ⟦lens.get s = some v⟧) := by
   unfold STHoare THoare
   intros H st h
@@ -547,7 +547,7 @@ theorem assert_intro : STHoarePureBuiltin p Γ Builtin.assert (by tauto) h![a] (
   apply pureBuiltin_intro_consequence <;> tauto
   tauto
 
-theorem cast_intro [Builtin.CastTp tp tp'] : STHoare p Γ ⟦⟧ (.call h![] [tp] tp' (.builtin .cast) h![v])
+theorem cast_intro [Builtin.CastTp tp tp'] : STHoare p Γ ⟦⟧ (.callBuiltin [tp] tp' .cast h![v])
    (fun v' => ∃∃ h, ⟦@Builtin.CastTp.cast tp tp' _ p v h = v'⟧) := by
    unfold STHoare THoare
    intros

--- a/Lampe/Lampe/Hoare/SepTotal.lean
+++ b/Lampe/Lampe/Hoare/SepTotal.lean
@@ -442,19 +442,27 @@ theorem callDecl'_intro
    apply Omni.callDecl' <;> tauto
 
 theorem callTrait'_intro {impl}
-    (h_trait : TraitResolution Γ ⟨⟨traitName, kinds, generics⟩, selfTp⟩ impl)
+    (h_trait : TraitResolution Γ ⟨⟨traitName, traitKinds, traitGenerics⟩, selfTp⟩ impl)
     (h_fn : (fnName, fn) ∈ impl)
     (hkc : fn.generics = kinds)
     (htci : (fn.body _ (hkc ▸ generics) |>.argTps) = argTps)
     (htco : (fn.body _ (hkc ▸ generics) |>.outTp) = outTp)
     (h_hoare: STHoare p Γ H (htco ▸ (fn.body _ (hkc ▸ generics) |>.body (htci ▸ args))) Q) :
     STHoare p Γ H
-      (Expr.callUni argTps outTp (.trait selfTp traitName fnName kinds generics) args)
+      (Expr.callUni argTps outTp (.trait selfTp traitName traitKinds traitGenerics fnName kinds generics) args)
       Q := by
   unfold STHoare THoare
   intros
   apply Omni.callTrait' <;> try assumption
   apply_assumption
+  assumption
+
+theorem fn_intro : STHoare p Γ ⟦⟧ (.fn argTps outTp r) fun v => v = r := by
+  unfold STHoare THoare
+  intro H st hp
+  constructor
+  simp only
+  apply SLP.ent_star_top
   assumption
 
 end Lampe.STHoare

--- a/Lampe/Lampe/Hoare/SepTotal.lean
+++ b/Lampe/Lampe/Hoare/SepTotal.lean
@@ -395,16 +395,20 @@ theorem callDecl_intro {fname fn}
    intros
    apply Omni.callDecl <;> tauto
 
-theorem callLambda'_intro {lambdaBody} {P : SLP (State p)} {Q : Tp.denote p outTp → SLP (State p)} :
+theorem callLambda'_intro {lambdaBody}
+  {P : SLP (State p)}
+  {Q : Tp.denote p outTp → SLP (State p)}
+  {fnRef : Tp.denote p (.fn argTps outTp)}
+  {href : fnRef = (.lambda ref)} :
   @STHoare outTp p Γ P (lambdaBody args) Q →
   STHoare p Γ (P ⋆ [λref ↦ ⟨argTps, outTp, lambdaBody⟩])
-    (Expr.callUni argTps outTp (.lambda ref) args)
+    (Expr.callUni argTps outTp fnRef args)
     (fun v => (Q v) ⋆ [λref ↦ ⟨argTps, outTp, lambdaBody⟩]) := by
   intros
   rename_i h
   unfold STHoare THoare
   intros
-  constructor <;> tauto
+  apply Omni.callLambda' <;> tauto
   unfold SLP.star at *
   . rename_i st h
     obtain ⟨st₁, ⟨st₂, ⟨_, h₂, h₃, _⟩⟩⟩ := h
@@ -428,20 +432,20 @@ theorem callLambda'_intro {lambdaBody} {P : SLP (State p)} {Q : Tp.denote p outT
     exact h
     simp only [SLP.true_star, SLP.entails_self]
 
-theorem callDecl'_intro
-     (h_fn : (fnName, fn) ∈ Γ.functions)
-     (hkc : fn.generics = kinds)
-     (htci : (fn.body _ (hkc ▸ generics) |>.argTps) = argTps)
-     (htco : (fn.body _ (hkc ▸ generics) |>.outTp) = outTp)
-     (h_hoare: STHoare p Γ H (htco ▸ (fn.body _ (hkc ▸ generics) |>.body (htci ▸ args))) Q) :
-     STHoare p Γ H
-       (Expr.callUni argTps outTp (.decl fnName kinds generics) args)
-       Q := by
+theorem callDecl'_intro {fnRef : Tp.denote p (.fn argTps outTp)}
+    {href : fnRef = (.decl fnName kinds generics)}
+    (h_fn : (fnName, fn) ∈ Γ.functions)
+    (hkc : fn.generics = kinds)
+    (htci : (fn.body _ (hkc ▸ generics) |>.argTps) = argTps)
+    (htco : (fn.body _ (hkc ▸ generics) |>.outTp) = outTp)
+    (h_hoare: STHoare p Γ H (htco ▸ (fn.body _ (hkc ▸ generics) |>.body (htci ▸ args))) Q) :
+    STHoare p Γ H (Expr.callUni argTps outTp fnRef args) Q := by
    unfold STHoare THoare
    intros
    apply Omni.callDecl' <;> tauto
 
-theorem callTrait'_intro {impl}
+theorem callTrait'_intro {impl} {fnRef : Tp.denote p (.fn argTps outTp)}
+    {href : fnRef = (.trait selfTp traitName traitKinds traitGenerics fnName kinds generics)}
     (h_trait : TraitResolution Γ ⟨⟨traitName, traitKinds, traitGenerics⟩, selfTp⟩ impl)
     (h_fn : (fnName, fn) ∈ impl)
     (hkc : fn.generics = kinds)
@@ -449,7 +453,7 @@ theorem callTrait'_intro {impl}
     (htco : (fn.body _ (hkc ▸ generics) |>.outTp) = outTp)
     (h_hoare: STHoare p Γ H (htco ▸ (fn.body _ (hkc ▸ generics) |>.body (htci ▸ args))) Q) :
     STHoare p Γ H
-      (Expr.callUni argTps outTp (.trait selfTp traitName traitKinds traitGenerics fnName kinds generics) args)
+      (Expr.callUni argTps outTp fnRef args)
       Q := by
   unfold STHoare THoare
   intros

--- a/Lampe/Lampe/Hoare/Total.lean
+++ b/Lampe/Lampe/Hoare/Total.lean
@@ -45,7 +45,7 @@ theorem letIn_intro {P Q}
 theorem ref_intro {v P} :
     THoare p Γ
       (fun st => ∀r, r ∉ st → P r ⟨(st.vals.insert r ⟨tp, v⟩), st.lambdas⟩)
-      (.call h![] [tp] (Tp.ref tp) (.builtin .ref) h![v])
+      (.callBuiltin [tp] (.ref tp) .ref h![v])
       P := by
   unfold THoare
   intros
@@ -56,7 +56,7 @@ theorem ref_intro {v P} :
 theorem readRef_intro {ref} :
     THoare p Γ
       (fun st => st.vals.lookup ref = some ⟨tp, v⟩ ∧ P v st)
-      (.call h![] [tp.ref] tp (.builtin .readRef) h![ref])
+      (.callBuiltin [.ref tp] tp .readRef h![ref])
       P := by
   unfold THoare
   intros
@@ -66,7 +66,7 @@ theorem readRef_intro {ref} :
 theorem writeRef_intro {ref v} :
     THoare p Γ
       (fun st => ref ∈ st ∧ P () ⟨(st.vals.insert ref ⟨tp, v⟩), st.lambdas⟩)
-      (.call h![] [tp.ref, tp] .unit (.builtin .writeRef) h![ref, v])
+      (.callBuiltin [.ref tp, tp] .unit .writeRef h![ref, v])
       P := by
   unfold THoare
   intros
@@ -76,7 +76,7 @@ theorem writeRef_intro {ref v} :
 theorem fresh_intro {P} :
     THoare p Γ
       (∀∀v, P v)
-      (.call h![] [] tp (.builtin .fresh) h![])
+      (.callBuiltin [] tp .fresh h![])
       P := by
   unfold THoare
   intro st h

--- a/Lampe/Lampe/Semantics.lean
+++ b/Lampe/Lampe/Semantics.lean
@@ -14,8 +14,8 @@ structure Env where
   functions : List (Ident × Function)
   traits : List (Ident × TraitImpl)
 
-inductive TraitResolvable (Γ : Env): TraitImplRef → Prop where
-| ok {ref impl}:
+inductive TraitResolvable (Γ : Env) : TraitImplRef → Prop where
+| ok {ref impl} :
   (ref.trait.name, impl) ∈ Γ.traits →
   (ktc : ref.trait.traitGenericKinds = impl.traitGenericKinds) →
   (implGenerics : HList Kind.denote impl.implGenericKinds) →
@@ -24,7 +24,7 @@ inductive TraitResolvable (Γ : Env): TraitImplRef → Prop where
   (∀constraint ∈ impl.constraints implGenerics, TraitResolvable Γ constraint) →
   TraitResolvable Γ ref
 
-inductive TraitResolution (Γ : Env): TraitImplRef → List (Ident × Function) → Prop where
+inductive TraitResolution (Γ : Env) : TraitImplRef → List (Ident × Function) → Prop where
 | ok {ref impl}
   (h_mem : (ref.trait.name, impl) ∈ Γ.traits)
   (ktc : ref.trait.traitGenericKinds = impl.traitGenericKinds)
@@ -54,25 +54,28 @@ inductive Omni : Env → State p → Expr (Tp.denote p) tp → (Option (State p 
   (∀v st, Q₁ (some (st, v)) → Omni Γ st (b v) Q) →
   (Q₁ none → Q none) →
   Omni Γ st (.letIn e b) Q
-| callLambda' {lambdas : Lambdas p} :
+| callTrait' {fnRef} :
+  fnRef = (.trait selfTp traitName traitKinds traitGenerics fnName kinds generics) →
+  TraitResolution Γ ⟨⟨traitName, traitKinds, traitGenerics⟩, selfTp⟩ impls →
+  (fnName, fn) ∈ impls →
+  (hkc : fn.generics = kinds) →
+  (htci : (fn.body (Tp.denote p) (hkc ▸ generics) |>.argTps) = argTps) →
+  (htco : (fn.body (Tp.denote p) (hkc ▸ generics) |>.outTp) = outTp) →
+  Omni Γ ⟨vh, lambdas⟩ (htco ▸ (fn.body (Tp.denote p) (hkc ▸ generics) |>.body (htci ▸ args))) Q →
+  Omni Γ ⟨vh, lambdas⟩ (Expr.callUni argTps outTp fnRef args) Q
+| callLambda' {fnRef} {lambdaBody : HList (Tp.denote p) argTps → Expr (Tp.denote p) outTp} :
+  fnRef = (.lambda ref) →
   lambdas.lookup ref = some ⟨argTps, outTp, lambdaBody⟩ →
   Omni Γ ⟨vh, lambdas⟩ (lambdaBody args) Q →
-  Omni Γ ⟨vh, lambdas⟩ (Expr.callUni argTps outTp (.lambda ref) args) Q
-| callDecl':
-    (fnName, fn) ∈ Γ.functions →
-    (hkc : fn.generics = kinds) →
-    (htci : (fn.body _ (hkc ▸ generics) |>.argTps) = argTps) →
-    (htco : (fn.body _ (hkc ▸ generics) |>.outTp) = outTp) →
-    Omni Γ st (htco ▸ (fn.body _ (hkc ▸ generics) |>.body (htci ▸ args))) Q →
-    Omni Γ st (Expr.callUni argTps outTp (.decl fnName kinds generics) args) Q
-| callTrait' {impl} :
-    TraitResolution Γ ⟨⟨traitName, traitKinds, traitGenerics⟩, selfTp⟩ impl →
-    (fnName, fn) ∈ impl →
-    (hkc : fn.generics = kinds) →
-    (htci : (fn.body _ (hkc ▸ generics) |>.argTps) = argTps) →
-    (htco : (fn.body _ (hkc ▸ generics) |>.outTp) = outTp) →
-    Omni Γ st (htco ▸ (fn.body _ (hkc ▸ generics) |>.body (htci ▸ args))) Q →
-    Omni Γ st (Expr.callUni argTps outTp (.trait selfTp traitName traitKinds traitGenerics fnName kinds generics) args) Q
+  Omni Γ ⟨vh, lambdas⟩ (Expr.callUni argTps outTp fnRef args) Q
+| callDecl' {fnRef} :
+  fnRef = (.decl fnName kinds generics) →
+  (fnName, fn) ∈ Γ.functions →
+  (hkc : fn.generics = kinds) →
+  (htci : (fn.body (Tp.denote p) (hkc ▸ generics) |>.argTps) = argTps) →
+  (htco : (fn.body (Tp.denote p) (hkc ▸ generics) |>.outTp) = outTp) →
+  Omni Γ ⟨vh, lambdas⟩ (htco ▸ (fn.body (Tp.denote p) (hkc ▸ generics) |>.body (htci ▸ args))) Q →
+  Omni Γ ⟨vh, lambdas⟩ (Expr.callUni argTps outTp fnRef args) Q
 | callLambda {lambdas : Lambdas p} :
   lambdas.lookup ref = some ⟨argTps, outTp, lambdaBody⟩ →
   Omni Γ ⟨vh, lambdas⟩ (lambdaBody args) Q →
@@ -81,23 +84,23 @@ inductive Omni : Env → State p → Expr (Tp.denote p) tp → (Option (State p 
   (∀ ref, ref ∉ lambdas → Q (some (⟨vh, lambdas.insert ref ⟨argTps, outTp, lambdaBody⟩⟩, ref))) →
   Omni Γ ⟨vh, lambdas⟩ (Expr.lambda argTps outTp lambdaBody) Q
 | callBuiltin {Q} :
-    (b.omni p st argTypes resType args (mapToValHeapCondition st.lambdas Q)) →
-    Omni Γ st (Expr.call h![] argTypes resType (.builtin b) args) Q
+  (b.omni p st argTypes resType args (mapToValHeapCondition st.lambdas Q)) →
+  Omni Γ st (Expr.call h![] argTypes resType (.builtin b) args) Q
 | callDecl :
-    (fname, fn) ∈ Γ.functions →
-    (hkc : fn.generics = tyKinds) →
-    (htci : (fn.body _ (hkc ▸ generics) |>.argTps) = argTypes) →
-    (htco : (fn.body _ (hkc ▸ generics) |>.outTp) = res) →
-    Omni Γ st (htco ▸ (fn.body _ (hkc ▸ generics) |>.body (htci ▸ args))) Q →
-    Omni Γ st (@Expr.call _ tyKinds generics argTypes res (.decl fname) args) Q
+  (fname, fn) ∈ Γ.functions →
+  (hkc : fn.generics = tyKinds) →
+  (htci : (fn.body _ (hkc ▸ generics) |>.argTps) = argTypes) →
+  (htco : (fn.body _ (hkc ▸ generics) |>.outTp) = res) →
+  Omni Γ st (htco ▸ (fn.body _ (hkc ▸ generics) |>.body (htci ▸ args))) Q →
+  Omni Γ st (@Expr.call _ tyKinds generics argTypes res (.decl fname) args) Q
 | callTrait {impl} :
-    TraitResolution Γ traitRef impl →
-    (fname, fn) ∈ impl →
-    (hkc : fn.generics = tyKinds) →
-    (htci : (fn.body _ (hkc ▸ generics) |>.argTps) = argTypes) →
-    (htco : (fn.body _ (hkc ▸ generics) |>.outTp) = res) →
-    Omni Γ st (htco ▸ (fn.body _ (hkc ▸ generics) |>.body (htci ▸ args))) Q →
-    Omni Γ st (@Expr.call (Tp.denote p) tyKinds generics argTypes res (.trait ⟨traitRef, fname⟩) args) Q
+  TraitResolution Γ traitRef impl →
+  (fname, fn) ∈ impl →
+  (hkc : fn.generics = tyKinds) →
+  (htci : (fn.body _ (hkc ▸ generics) |>.argTps) = argTypes) →
+  (htco : (fn.body _ (hkc ▸ generics) |>.outTp) = res) →
+  Omni Γ st (htco ▸ (fn.body _ (hkc ▸ generics) |>.body (htci ▸ args))) Q →
+  Omni Γ st (@Expr.call (Tp.denote p) tyKinds generics argTypes res (.trait ⟨traitRef, fname⟩) args) Q
 | loopDone :
   lo ≥ hi →
   Omni Γ st (.loop lo hi body) Q
@@ -106,27 +109,34 @@ inductive Omni : Env → State p → Expr (Tp.denote p) tp → (Option (State p 
   Omni Γ st (.letIn (body lo) (fun _ => .loop (lo + 1) hi body)) Q →
   Omni Γ st (.loop lo hi body) Q
 
-theorem Omni.consequence {p Γ st tp} {e : Expr (Tp.denote p) tp} {Q Q'}:
+theorem Omni.consequence {p Γ st tp} {e : Expr (Tp.denote p) tp} {Q Q'} :
     Omni p Γ st e Q →
     (∀ v, Q v → Q' v) →
     Omni p Γ st e Q' := by
   intro h
-  induction h <;> try (
+  induction h with
+  | callDecl' =>
     intro
-    constructor
-    all_goals tauto
-  )
-  case callBuiltin =>
+    apply Omni.callDecl' <;> tauto
+  | callLambda' =>
+    intro
+    apply Omni.callLambda' <;> tauto
+  | callBuiltin =>
     cases_type Builtin
     intros
     constructor
     tauto
-  case loopNext =>
+  | loopNext =>
     intro
     apply loopNext (by assumption)
     tauto
+  | _ =>
+    intro
+    constructor
+    all_goals tauto
 
-theorem Omni.frame {p Γ tp} {st₁ st₂ : State p} {e : Expr (Tp.denote p) tp} {Q}:
+
+theorem Omni.frame {p Γ tp} {st₁ st₂ : State p} {e : Expr (Tp.denote p) tp} {Q} :
     Omni p Γ st₁ e Q →
     LawfulHeap.disjoint st₁ st₂ →
     Omni p Γ (st₁ ∪ st₂) e (fun stv => match stv with
@@ -163,20 +173,18 @@ theorem Omni.frame {p Γ tp} {st₁ st₂ : State p} {e : Expr (Tp.denote p) tp}
     · simp_all
   | callDecl' =>
     intro
-    apply Omni.callDecl'
-    all_goals (try assumption)
-    tauto
+    apply Omni.callDecl' <;> tauto
   | callTrait' =>
     intro
-    apply Omni.callTrait'
-    all_goals (try assumption)
-    tauto
-  | callLambda' h _ _ =>
+    apply Omni.callTrait' <;> tauto
+  | callLambda' h =>
     intro hd
     apply Omni.callLambda' <;> try tauto
     simp_all
     simp only [LawfulHeap.disjoint] at hd
-    simp only [Finmap.lookup_union_left (Finmap.mem_of_lookup_eq_some h)]
+    rw [Finmap.lookup_union_left]
+    tauto
+    rw [Finmap.mem_iff]
     tauto
   | callBuiltin hq =>
     rename Builtin => b

--- a/Lampe/Lampe/SeparationLogic/SLP.lean
+++ b/Lampe/Lampe/SeparationLogic/SLP.lean
@@ -264,4 +264,10 @@ theorem wand_cancel [LawfulHeap α] {P Q : SLP α} : (P ⋆ (P -⋆ Q)) ⊢ Q :=
 
 end wand
 
+theorem extract_prop [LawfulHeap α] {H₁ H₂ : SLP α} (h₁ : (H₁ ⋆ H₂) st) (h₂ : H₁ ⋆ ⊤ ⊢ ⟦P⟧ ⋆ ⊤) : P := by
+  apply SLP.ent_drop_left at h₁
+  apply h₂ at h₁
+  simp only [SLP.lift, SLP.top, SLP.star] at h₁
+  aesop
+
 end Lampe.SLP

--- a/Lampe/Lampe/SeparationLogic/SLP.lean
+++ b/Lampe/Lampe/SeparationLogic/SLP.lean
@@ -264,7 +264,8 @@ theorem wand_cancel [LawfulHeap α] {P Q : SLP α} : (P ⋆ (P -⋆ Q)) ⊢ Q :=
 
 end wand
 
-theorem extract_prop [LawfulHeap α] {H₁ H₂ : SLP α} (h₁ : (H₁ ⋆ H₂) st) (h₂ : H₁ ⋆ ⊤ ⊢ ⟦P⟧ ⋆ ⊤) : P := by
+theorem extract_prop [LawfulHeap α] {H₁ H₂ : SLP α} (h₁ : (H₁ ⋆ H₂) st) (h₂ : H₁ ⊢ ⟦P⟧ ⋆ ⊤) : P := by
+  apply SLP.star_mono_r at h₂
   apply SLP.ent_drop_left at h₁
   apply h₂ at h₁
   simp only [SLP.lift, SLP.top, SLP.star] at h₁

--- a/Lampe/Lampe/Syntax.lean
+++ b/Lampe/Lampe/Syntax.lean
@@ -48,7 +48,7 @@ def mkStructDefIdent (structName : String) : Lean.Ident :=
    mkIdent $ Name.mkSimple $ "struct" ++ "#" ++ structName
 
 def mkFunctionDefIdent (fnName : String) : Lean.Ident :=
-  mkIdent $ Name.mkSimple $ "fn" ++ "#" ++ fnName
+  mkIdent $ Name.mkSimple fnName
 
 def mkListLit [Monad m] [MonadQuotation m] [MonadExceptOf Exception m] [MonadError m] : List (TSyntax `term) → m (TSyntax `term)
 | [] => `([])

--- a/Lampe/Lampe/Syntax.lean
+++ b/Lampe/Lampe/Syntax.lean
@@ -145,39 +145,39 @@ syntax nr_struct_def := "<" ident,* ">" "{" sepBy(nr_param_decl, ",", ",", allow
 
 @[reducible]
 def Expr.ref (val : rep tp) : Expr rep tp.ref :=
-  Expr.call h![] _ tp.ref (.builtin .ref) h![val]
+  Expr.callBuiltin _ tp.ref .ref h![val]
 
 @[reducible]
 def Expr.readRef (ref : rep tp.ref) : Expr rep tp :=
-  Expr.call h![] _ tp (.builtin .readRef) h![ref]
+  Expr.callBuiltin _ tp .readRef h![ref]
 
 @[reducible]
 def Expr.writeRef (ref : rep tp.ref) (val : rep tp) : Expr rep .unit :=
-  Expr.call h![] _ .unit (.builtin .writeRef) h![ref, val]
+  Expr.callBuiltin _ .unit .writeRef h![ref, val]
 
 @[reducible]
 def Expr.mkSlice (n : Nat) (vals : HList rep (List.replicate n tp)) : Expr rep (.slice tp) :=
-  Expr.call h![] _ (.slice tp) (.builtin $ .mkSlice n) vals
+  Expr.callBuiltin _ (.slice tp) (.mkSlice n) vals
 
 @[reducible]
 def Expr.mkArray (n : Nat) (vals : HList rep (List.replicate n tp)) : Expr rep (.array tp n) :=
-  Expr.call h![] _ (.array tp n) (.builtin $ .mkArray n) vals
+  Expr.callBuiltin _ (.array tp n) (.mkArray n) vals
 
 @[reducible]
 def Expr.mkTuple (name : Option String) (args : HList rep tps) : Expr rep (.tuple name tps) :=
-  Expr.call h![] tps (.tuple name tps) (.builtin .mkTuple) args
+  Expr.callBuiltin tps (.tuple name tps) ( .mkTuple) args
 
 @[reducible]
 def Expr.modifyLens (r : rep $ .ref tp₁) (v : rep tp₂) (lens : Lens rep tp₁ tp₂) : Expr rep .unit :=
-  Expr.call h![] [.ref tp₁, tp₂] .unit (.builtin $ .modifyLens lens) h![r, v]
+  Expr.callBuiltin [.ref tp₁, tp₂] .unit (.modifyLens lens) h![r, v]
 
 @[reducible]
 def Expr.readLens (r : rep $ .ref tp₁) (lens : Lens rep tp₁ tp₂) : Expr rep tp₂ :=
-  Expr.call h![] _ tp₂ (.builtin $ .readLens lens) h![r]
+  Expr.callBuiltin _ tp₂ (.readLens lens) h![r]
 
 @[reducible]
 def Expr.getLens (v : rep tp₁) (lens : Lens rep tp₁ tp₂) : Expr rep tp₂ :=
-  Expr.call h![] _ tp₂ (.builtin $ .getLens lens) h![v]
+  Expr.callBuiltin _ tp₂ (.getLens lens) h![v]
 
 structure DesugarState where
   autoDeref : Name → Bool
@@ -306,7 +306,7 @@ partial def mkExpr [MonadSyntax m] (e : TSyntax `nr_expr) (vname : Option Lean.I
   | some _ => wrapSimple (←`(Expr.var $i)) vname k
 | `(nr_expr| # $i:ident ($args,*): $tp) => do
   mkArgs args.getElems.toList fun argVals => do
-    wrapSimple (←`(Expr.call h![] _ $(←mkNrType tp) (.builtin $(←mkBuiltin i.getId.toString)) $(←mkHListLit argVals))) vname k
+    wrapSimple (←`(Expr.callBuiltin _ $(←mkNrType tp) $(←mkBuiltin i.getId.toString) $(←mkHListLit argVals))) vname k
 | `(nr_expr| for $i in $lo .. $hi $body) => do
   mkExpr lo none fun lo =>
   mkExpr hi none fun hi => do
@@ -373,7 +373,7 @@ partial def mkExpr [MonadSyntax m] (e : TSyntax `nr_expr) (vname : Option Lean.I
   mkExpr fnExpr none fun fnRef => do
     mkArgs args.getElems.toList fun argVals => do
       let args ← mkHListLit argVals
-      wrapSimple (←`(Expr.callUni _ _ $fnRef $args)) vname k
+      wrapSimple (←`(Expr.call _ _ $fnRef $args)) vname k
 | `(nr_expr| ( $_:nr_expr as $_:nr_ident  < $_,* > ) . $_:ident)
 | `(nr_expr| $_:nr_expr . $_:num)
 | `(nr_expr| $_:nr_expr [ $_:nr_expr ])

--- a/Lampe/Lampe/Tactic/SeparationLogic.lean
+++ b/Lampe/Lampe/Tactic/SeparationLogic.lean
@@ -379,19 +379,6 @@ theorem lmbSingleton_star_congr {p} {r} {v₁ v₂ : Lambda _} {R : SLP (State p
   rintro rfl
   apply SLP.entails_self
 
-lemma nested_triple {Q : _ → SLP (State p)}
-  (h_hoare_imp : STHoare p Γ P e₁ Q → STHoare p Γ (P ⋆ H) e₂ (fun v => Q v ⋆ H))
-  (h_hoare : STHoare p Γ P e₁ Q)
-  (h_ent_pre : H ⊢ P ⋆ H) :
-  STHoare p Γ H e₂ Q := by
-  have h_ent_post : ∀ v, ((Q v) ⋆ H) ⋆ ⊤ ⊢ (Q v) ⋆ ⊤ := by
-    simp [SLP.ent_drop_left]
-  have h_hoare' := h_hoare_imp h_hoare
-  apply consequence h_ent_pre (fun v => SLP.entails_self)
-  apply consequence SLP.entails_self h_ent_post
-  tauto
-
-
 def canSolveSingleton (lhs : SLTerm) (rhsV : Expr): Bool :=
   match lhs with
   | SLTerm.singleton v _ => v == rhsV
@@ -556,12 +543,9 @@ macro "stephelper1" : tactic => `(tactic|(
     | apply fresh_intro
     | apply assert_intro
     | apply skip_intro
-    | apply nested_triple STHoare.callLambda_intro
     | apply lam_intro
     | apply cast_intro
     | apply cast_intro
-    | apply callTrait_intro
-    | apply callDecl_intro
     -- memory
     | apply var_intro
     | apply ref_intro
@@ -704,7 +688,6 @@ macro "stephelper3" : tactic => `(tactic|(
     | apply ramified_frame_top skip_intro
     | apply ramified_frame_top lam_intro
     | apply ramified_frame_top cast_intro
-    | apply ramified_frame_top callDecl_intro
     -- memory
     | apply ramified_frame_top var_intro
     | apply ramified_frame_top ref_intro

--- a/Lampe/Lampe/Tactic/SeparationLogic.lean
+++ b/Lampe/Lampe/Tactic/SeparationLogic.lean
@@ -209,11 +209,6 @@ def isLetIn (e : Expr) : Bool := e.isAppOf ``Lampe.Expr.letIn
 
 def isIte (e : Expr) : Bool := e.isAppOf `Lampe.Expr.ite
 
-def isCallTrait (e : Expr) : Bool := e.isAppOf `Lampe.Expr.call &&
-  match (e.getArg? 5) with
-  | some callTarget => callTarget.isAppOf `Lampe.FunctionIdent.trait
-  | _ => false
-
 partial def parseSLExpr (e: Expr): TacticM SLTerm := do
   if e.isAppOf ``SLP.star then
     let args := e.getAppArgs
@@ -561,11 +556,14 @@ macro "stephelper1" : tactic => `(tactic|(
     | apply assert_intro
     | apply skip_intro
     | apply nested_triple STHoare.callLambda_intro
+    | apply nested_triple STHoare.callLambda'_intro
     | apply lam_intro
     | apply cast_intro
     | apply cast_intro
     | apply callTrait_intro
     | apply callDecl_intro
+    | apply callTrait'_intro
+    | apply callDecl'_intro
     -- memory
     | apply var_intro
     | apply ref_intro
@@ -707,6 +705,7 @@ macro "stephelper3" : tactic => `(tactic|(
     | apply ramified_frame_top lam_intro
     | apply ramified_frame_top cast_intro
     | apply ramified_frame_top callDecl_intro
+    | apply ramified_frame_top callDecl'_intro
     -- memory
     | apply ramified_frame_top var_intro
     | apply ramified_frame_top ref_intro

--- a/Lampe/Lampe/Tactic/SeparationLogic.lean
+++ b/Lampe/Lampe/Tactic/SeparationLogic.lean
@@ -552,6 +552,7 @@ macro "stephelper1" : tactic => `(tactic|(
     | apply Lampe.STHoare.litField_intro
     | apply Lampe.STHoare.litTrue_intro
     | apply Lampe.STHoare.litFalse_intro
+    | apply fn_intro
     | apply fresh_intro
     | apply assert_intro
     | apply skip_intro
@@ -629,6 +630,7 @@ macro "stephelper2" : tactic => `(tactic|(
     | apply consequence_frame_left Lampe.STHoare.litField_intro
     | apply consequence_frame_left Lampe.STHoare.litTrue_intro
     | apply consequence_frame_left Lampe.STHoare.litFalse_intro
+    | apply consequence_frame_left fn_intro
     | apply consequence_frame_left fresh_intro
     | apply consequence_frame_left assert_intro
     | apply consequence_frame_left lam_intro
@@ -699,6 +701,7 @@ macro "stephelper3" : tactic => `(tactic|(
     | apply ramified_frame_top Lampe.STHoare.litField_intro
     | apply ramified_frame_top Lampe.STHoare.litTrue_intro
     | apply ramified_frame_top Lampe.STHoare.litFalse_intro
+    | apply ramified_frame_top fn_intro
     | apply ramified_frame_top fresh_intro
     | apply ramified_frame_top assert_intro
     | apply ramified_frame_top skip_intro

--- a/Lampe/Lampe/Tactic/SeparationLogic.lean
+++ b/Lampe/Lampe/Tactic/SeparationLogic.lean
@@ -557,14 +557,11 @@ macro "stephelper1" : tactic => `(tactic|(
     | apply assert_intro
     | apply skip_intro
     | apply nested_triple STHoare.callLambda_intro
-    | apply nested_triple STHoare.callLambda'_intro
     | apply lam_intro
     | apply cast_intro
     | apply cast_intro
     | apply callTrait_intro
     | apply callDecl_intro
-    | apply callTrait'_intro
-    | apply callDecl'_intro
     -- memory
     | apply var_intro
     | apply ref_intro
@@ -708,7 +705,6 @@ macro "stephelper3" : tactic => `(tactic|(
     | apply ramified_frame_top lam_intro
     | apply ramified_frame_top cast_intro
     | apply ramified_frame_top callDecl_intro
-    | apply ramified_frame_top callDecl'_intro
     -- memory
     | apply ramified_frame_top var_intro
     | apply ramified_frame_top ref_intro

--- a/Lampe/Lampe/Tactic/SeparationLogic.lean
+++ b/Lampe/Lampe/Tactic/SeparationLogic.lean
@@ -545,7 +545,6 @@ macro "stephelper1" : tactic => `(tactic|(
     | apply skip_intro
     | apply lam_intro
     | apply cast_intro
-    | apply cast_intro
     -- memory
     | apply var_intro
     | apply ref_intro

--- a/Lampe/Lampe/Tp.lean
+++ b/Lampe/Lampe/Tp.lean
@@ -28,6 +28,17 @@ inductive Tp where
 | array (element: Tp) (size: U 32)
 | tuple (name : Option String) (fields : List Tp)
 | ref (tp : Tp)
+| fn (argTps : List Tp) (outTp : Tp)
+
+@[reducible]
+def Kind.denote : Kind → Type
+| .nat => Nat
+| .type => Tp
+
+inductive FuncRef (argTps : List Tp) (outTp : Tp) where
+| lambda (r : Ref)
+| decl (fnName : String) (kinds : List Kind) (generics : HList Kind.denote kinds)
+| trait (selfTp : Tp) (traitName : String) (fnName : String) (kinds : List Kind) (generics : HList Kind.denote kinds)
 
 mutual
 
@@ -49,13 +60,8 @@ def Tp.denote : Tp → Type
 | .array tp n => Mathlib.Vector (denote tp) n.toNat
 | .ref _ => Ref
 | .tuple _ fields => Tp.denoteArgs fields
+| .fn argTps outTp => FuncRef argTps outTp
 
 end
-
-@[reducible]
-def Kind.denote : Kind → Type
-| .nat => Nat
-| .type => Tp
-
 
 end Lampe

--- a/Lampe/Lampe/Tp.lean
+++ b/Lampe/Lampe/Tp.lean
@@ -38,7 +38,9 @@ def Kind.denote : Kind → Type
 inductive FuncRef (argTps : List Tp) (outTp : Tp) where
 | lambda (r : Ref)
 | decl (fnName : String) (kinds : List Kind) (generics : HList Kind.denote kinds)
-| trait (selfTp : Tp) (traitName : String) (fnName : String) (kinds : List Kind) (generics : HList Kind.denote kinds)
+| trait (selfTp : Tp)
+  (traitName : String) (traitKinds : List Kind) (traitGenerics : HList Kind.denote traitKinds)
+  (fnName : String) (fnKinds : List Kind) (fnGenerics : HList Kind.denote fnKinds)
 
 mutual
 


### PR DESCRIPTION
This PR aims to add higher order function support. 
- A new type is added `Tp.fn`
- Functions are represented by `FuncRef`s
- A new expression is added `Expr.fn` for function idents
- The call expression `Expr.call` is updated to work with a `Tp.fn`
- Call intro rules `callDecl_intro`, `callLambda_intro`, `callTrait_intro` are updated
- Syntax is updated