### PR TITLE
Minimize Mathlib imports

### DIFF
--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -1,3 +1,4 @@
+import Mathlib
 import Lampe.Basic
 open Lampe
 

--- a/Lampe/Lampe/Ast.lean
+++ b/Lampe/Lampe/Ast.lean
@@ -1,5 +1,3 @@
-import Mathlib
-
 import Lampe.Tp
 import Lampe.Data.HList
 import Lampe.SeparationLogic.ValHeap

--- a/Lampe/Lampe/Builtin/Basic.lean
+++ b/Lampe/Lampe/Builtin/Basic.lean
@@ -2,7 +2,7 @@ import Lampe.SeparationLogic.ValHeap
 import Lampe.Data.Field
 import Lampe.Data.HList
 import Lampe.Builtin.Helpers
-import Mathlib
+import Mathlib.Tactic.Lemma
 
 lemma List.replicate_head (hl : x :: xs = List.replicate n a) : x = a := by
   unfold List.replicate at hl

--- a/Lampe/Lampe/Builtin/Helpers.lean
+++ b/Lampe/Lampe/Builtin/Helpers.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Tactic.Linarith
 
 namespace Lampe
 

--- a/Lampe/Lampe/Builtin/Slice.lean
+++ b/Lampe/Lampe/Builtin/Slice.lean
@@ -7,7 +7,7 @@ def replaceSlice' (s : Tp.denote p $ .slice tp) (i : Fin s.length) (v : Tp.denot
   List.modifyNth (fun _ => v) i s
 
 @[simp]
-lemma replaceSlice_length_eq_length :
+theorem replaceSlice_length_eq_length :
     (replaceSlice' s i v).length = s.length := by
   simp_all [List.length_modifyNth]
 

--- a/Lampe/Lampe/Builtin/Struct.lean
+++ b/Lampe/Lampe/Builtin/Struct.lean
@@ -1,3 +1,5 @@
+import Mathlib.Algebra.PUnitInstances.Algebra -- TODO: This import is necessary for the
+                                              -- `CommRing Unit` instance, but shouldn't be needed
 import Lampe.Builtin.Basic
 
 namespace Lampe.Builtin

--- a/Lampe/Lampe/Data/Field.lean
+++ b/Lampe/Lampe/Data/Field.lean
@@ -1,4 +1,4 @@
-import Mathlib
+import Mathlib.Algebra.Algebra.ZMod
 import Lampe.Data.Integers
 
 namespace Lampe

--- a/Lampe/Lampe/Data/Integers.lean
+++ b/Lampe/Lampe/Data/Integers.lean
@@ -1,5 +1,3 @@
-import Mathlib
-
 namespace Lampe
 
 abbrev U (n : Nat) := BitVec (n)

--- a/Lampe/Lampe/Semantics.lean
+++ b/Lampe/Lampe/Semantics.lean
@@ -1,5 +1,3 @@
-import Mathlib
-
 import Lampe.Ast
 import Lampe.Tp
 import Lampe.Data.Field

--- a/Lampe/Lampe/SeparationLogic/LawfulHeap.lean
+++ b/Lampe/Lampe/SeparationLogic/LawfulHeap.lean
@@ -1,5 +1,3 @@
-import Lampe.Tp
-
 namespace Lampe
 
 class LawfulHeap (α : Type _) where

--- a/Lampe/Lampe/SeparationLogic/SLP.lean
+++ b/Lampe/Lampe/SeparationLogic/SLP.lean
@@ -1,3 +1,6 @@
+import Mathlib.Tactic.Tauto
+import Mathlib.Tactic.Use
+import Lampe.Data.Field
 import Lampe.Tactic.IntroCases
 import Lampe.SeparationLogic.LawfulHeap
 

--- a/Lampe/Lampe/SeparationLogic/ValHeap.lean
+++ b/Lampe/Lampe/SeparationLogic/ValHeap.lean
@@ -1,5 +1,7 @@
+import Mathlib.Data.Finmap
 import Lampe.SeparationLogic.LawfulHeap
 import Lampe.SeparationLogic.SLP
+import Lampe.Tp
 
 lemma Finmap.insert_eq_singleton_union [DecidableEq α] {ref : α}:
     m.insert ref v = Finmap.singleton ref v ∪ m := by rfl

--- a/Lampe/Lampe/Syntax.lean
+++ b/Lampe/Lampe/Syntax.lean
@@ -1,8 +1,7 @@
-import Mathlib
 import Lean
-import Lampe.Ast
 import Qq
 
+import Lampe.Ast
 import Lampe.Builtin.Arith
 import Lampe.Builtin.Array
 import Lampe.Builtin.BigInt

--- a/Lampe/Lampe/Tp.lean
+++ b/Lampe/Lampe/Tp.lean
@@ -1,5 +1,3 @@
-import Mathlib
-
 import Lampe.Data.Integers
 import Lampe.Data.Field
 import Lampe.Data.HList


### PR DESCRIPTION
This PR minimizes the usage of `import Mathlib` and replaces it with more targeted `Mathlib` imports

I noticed some slow compilation issues (likely related to [this Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/import.20Mathlib.20slows.20down.20loading)) while I was going through and first getting familiar with the library structure, and this fixes it to a certain extent.

Some downsides of this:
* There are some unexpected outcomes in downstream files when one takes away `import Mathlib`
* Certain typeclass instance/coercions were unexpectedly being used in certain places
  - One in particular was `OfNat ((Fp p) × Unit) 5` which went through deducing `CommRing Unit` in 
    `Lampe.Builtin.Struct` was a surprising one.

The only occurence of `import Mathlib` that remains is in `Lampe.lean` which has a bunch of examples. That rely on `aesop` to function. Perhaps these examples could be moved to a separate example file, and `Lampe.lean` could be the root of the library for end-users to import?