### PR TITLE
Format Strings (kind of)

### DIFF
--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -16,6 +16,7 @@ import Lampe.Builtin.Struct
 import Lampe.Data.Field
 import Lampe.Data.HList
 import Lampe.Data.Integers
+import Lampe.Data.Strings
 import Lampe.Hoare.Builtins
 import Lampe.Hoare.SepTotal
 import Lampe.Hoare.Total

--- a/Lampe/Lampe/Ast.lean
+++ b/Lampe/Lampe/Ast.lean
@@ -1,6 +1,5 @@
 import Lampe.Tp
 import Lampe.Data.HList
-import Lampe.Data.Strings
 import Lampe.SeparationLogic.ValHeap
 import Lampe.Builtin.Basic
 
@@ -24,6 +23,7 @@ structure TraitMethodImplRef where
 inductive Expr (rep : Tp → Type) : Tp → Type where
 | litNum : (tp : Tp) → Nat → Expr rep tp
 | litStr : (len : U 32) → FixedLenStr len.toNat → Expr rep (.str len)
+| fmtStr : (len : U 32) → (tps : List Tp) → FormatString len tps → Expr rep (.fmtStr len tps)
 | fn : (argTps : List Tp) → (outTp : Tp) → (r : FuncRef argTps outTp) → Expr rep (.fn argTps outTp)
 | var : rep tp → Expr rep tp
 | letIn : Expr rep t₁ → (rep t₁ → Expr rep t₂) → Expr rep t₂

--- a/Lampe/Lampe/Ast.lean
+++ b/Lampe/Lampe/Ast.lean
@@ -1,5 +1,6 @@
 import Lampe.Tp
 import Lampe.Data.HList
+import Lampe.Data.Strings
 import Lampe.SeparationLogic.ValHeap
 import Lampe.Builtin.Basic
 
@@ -22,7 +23,7 @@ structure TraitMethodImplRef where
 
 inductive Expr (rep : Tp → Type) : Tp → Type where
 | litNum : (tp : Tp) → Nat → Expr rep tp
-| litStr : (len : U 32) → List.Vector Char len.toNat → Expr rep (.str len)
+| litStr : (len : U 32) → FixedLenStr len.toNat → Expr rep (.str len)
 | fn : (argTps : List Tp) → (outTp : Tp) → (r : FuncRef argTps outTp) → Expr rep (.fn argTps outTp)
 | var : rep tp → Expr rep tp
 | letIn : Expr rep t₁ → (rep t₁ → Expr rep t₂) → Expr rep t₂

--- a/Lampe/Lampe/Data/Strings.lean
+++ b/Lampe/Lampe/Data/Strings.lean
@@ -1,0 +1,5 @@
+import Mathlib.Data.Vector.Defs
+import Lampe.Data.HList
+
+abbrev FixedLenStr (n : Nat) := List.Vector Char n
+

--- a/Lampe/Lampe/Semantics.lean
+++ b/Lampe/Lampe/Semantics.lean
@@ -35,6 +35,7 @@ inductive TraitResolution (Γ : Env) : TraitImplRef → List (Ident × Function)
 inductive Omni : Env → State p → Expr (Tp.denote p) tp → (Option (State p × Tp.denote p tp) → Prop) → Prop where
 | litField {Q} : Q (some (st, n)) → Omni Γ st (.litNum .field n) Q
 | litStr {Q} : Q (some (st, ns)) → Omni Γ st (.litStr u ns) Q
+| fmtStr {Q} : Q (some (st, ns)) → Omni Γ st (.fmtStr _ _ ns) Q
 | litFalse {Q} : Q (some (st, false)) → Omni Γ st (.litNum .bool 0) Q
 | litTrue {Q} : Q (some (st, true)) → Omni Γ st (.litNum .bool 1) Q
 | litU {Q} : Q (some (st, ↑n)) → Omni Γ st (.litNum (.u s) n) Q
@@ -127,6 +128,7 @@ theorem Omni.frame {p Γ tp} {st₁ st₂ : State p} {e : Expr (Tp.denote p) tp}
   induction h with
   | litField hq
   | litStr hq
+  | fmtStr hq
   | litFalse hq
   | litTrue hq
   | litU hq

--- a/Lampe/Lampe/Semantics.lean
+++ b/Lampe/Lampe/Semantics.lean
@@ -128,11 +128,11 @@ theorem Omni.frame {p Γ tp} {st₁ st₂ : State p} {e : Expr (Tp.denote p) tp}
   induction h with
   | litField hq
   | litStr hq
-  | fmtStr hq
   | litFalse hq
   | litTrue hq
   | litU hq
   | litUnit
+  | fmtStr hq
   | skip hq
   | fn
   | var hq =>

--- a/Lampe/Lampe/Tactic/SeparationLogic.lean
+++ b/Lampe/Lampe/Tactic/SeparationLogic.lean
@@ -75,7 +75,15 @@ theorem Lampe.STHoare.litField_intro: STHoare p Γ ⟦⟧ (.litNum .field n) fun
   apply SLP.ent_star_top
   assumption
 
-theorem Lampe.STHoare.litStr_intro: STHoare p Γ ⟦⟧ (.litStr u s) fun v => v = s := by
+theorem Lampe.STHoare.litStr_intro : STHoare p Γ ⟦⟧ (.litStr u s) fun v => v = s := by
+  unfold STHoare THoare
+  intro H st hp
+  constructor
+  simp only
+  apply SLP.ent_star_top
+  assumption
+
+theorem Lampe.STHoare.fmtStr_intro : STHoare p Γ ⟦⟧ (.fmtStr _ _ s) fun v => v = s := by
   unfold STHoare THoare
   intro H st hp
   constructor
@@ -554,6 +562,7 @@ macro "stephelper1" : tactic => `(tactic|(
     | apply Lampe.STHoare.litU_intro
     | apply Lampe.STHoare.litField_intro
     | apply Lampe.STHoare.litStr_intro
+    | apply Lampe.STHoare.fmtStr_intro
     | apply Lampe.STHoare.litTrue_intro
     | apply Lampe.STHoare.litFalse_intro
     | apply Lampe.STHoare.litUnit_intro
@@ -626,6 +635,7 @@ macro "stephelper2" : tactic => `(tactic|(
     | apply consequence_frame_left Lampe.STHoare.litU_intro
     | apply consequence_frame_left Lampe.STHoare.litField_intro
     | apply consequence_frame_left Lampe.STHoare.litStr_intro
+    | apply consequence_frame_left Lampe.STHoare.fmtStr_intro
     | apply consequence_frame_left Lampe.STHoare.litTrue_intro
     | apply consequence_frame_left Lampe.STHoare.litFalse_intro
     | apply consequence_frame_left Lampe.STHoare.litUnit_intro
@@ -698,6 +708,7 @@ macro "stephelper3" : tactic => `(tactic|(
     | apply ramified_frame_top Lampe.STHoare.litU_intro
     | apply ramified_frame_top Lampe.STHoare.litField_intro
     | apply ramified_frame_top Lampe.STHoare.litStr_intro
+    | apply ramified_frame_top Lampe.STHoare.fmtStr_intro
     | apply ramified_frame_top Lampe.STHoare.litTrue_intro
     | apply ramified_frame_top Lampe.STHoare.litFalse_intro
     | apply ramified_frame_top Lampe.STHoare.litUnit_intro

--- a/Lampe/Lampe/Tactic/SeparationLogic.lean
+++ b/Lampe/Lampe/Tactic/SeparationLogic.lean
@@ -75,7 +75,7 @@ theorem Lampe.STHoare.litField_intro: STHoare p Γ ⟦⟧ (.litNum .field n) fun
   apply SLP.ent_star_top
   assumption
 
-theorem Lampe.STHoare.litStr_intro : STHoare p Γ ⟦⟧ (.litStr u s) fun v => v = s := by
+theorem Lampe.STHoare.litStr_intro: STHoare p Γ ⟦⟧ (.litStr u s) fun v => v = s := by
   unfold STHoare THoare
   intro H st hp
   constructor
@@ -83,7 +83,7 @@ theorem Lampe.STHoare.litStr_intro : STHoare p Γ ⟦⟧ (.litStr u s) fun v => 
   apply SLP.ent_star_top
   assumption
 
-theorem Lampe.STHoare.fmtStr_intro : STHoare p Γ ⟦⟧ (.fmtStr _ _ s) fun v => v = s := by
+theorem Lampe.STHoare.fmtStr_intro : STHoare p Γ ⟦⟧ (.fmtStr u tps s) fun v => v = s := by
   unfold STHoare THoare
   intro H st hp
   constructor

--- a/Lampe/Lampe/Tp.lean
+++ b/Lampe/Lampe/Tp.lean
@@ -22,7 +22,7 @@ inductive Tp where
 | bool
 | unit
 | str (size: U 32)
-| fmtStr (size : U 32) (elems : List Tp)
+| fmtStr (size : U 32) (argTps : List Tp)
 | field
 | slice (element : Tp)
 | array (element: Tp) (size: U 32)
@@ -76,7 +76,7 @@ def tpDecEq (a b : Tp) : Decidable (a = b) := by
     cases (tpsDecEq tps₁ tps₂) <;> cases h
     all_goals try { left; simp_all; }
     right; subst_vars; rfl
-  case fmtStr.fmtStr =>
+  case fmtStr.fmtStr => -- TODO: Is there a way of combining this with the above?
     rename_i n₁ tps₁ n₂ tps₂
     have h : Decidable (n₁ = n₂) := inferInstance
     cases (tpsDecEq tps₁ tps₂) <;> cases h
@@ -104,7 +104,8 @@ inductive FuncRef (argTps : List Tp) (outTp : Tp) where
   (traitName : String) (traitKinds : List Kind) (traitGenerics : HList Kind.denote traitKinds)
   (fnName : String) (fnKinds : List Kind) (fnGenerics : HList Kind.denote fnKinds)
 
-structure FormatString (n : U 32) (valTypes : Type) where
+/-- TODO: Actually implement this at some point -/
+def FormatString (_len : U 32) (_argTps : List Tp) := Unit
 
 mutual
 
@@ -121,7 +122,7 @@ def Tp.denote : Tp → Type
 | .bool => Bool
 | .unit => Unit
 | .str n => FixedLenStr n.toNat
-| .fmtStr n x => FormatString n (denoteArgs x)
+| .fmtStr n tps => FormatString n tps
 | .field => Fp p
 | .slice tp => List (denote tp)
 | .array tp n => List.Vector (denote tp) n.toNat

--- a/Lampe/Tests/Tests.lean
+++ b/Lampe/Tests/Tests.lean
@@ -438,6 +438,6 @@ example : STHoare p ⟨[(simple_func.name, simple_func.fn), (call.name, call.fn)
 
 nr_def fmtstr_test<>() -> Field {
   let y = 3 : Field;
-  let x = #format("y:{}", y);
+  let _x = #format("y: {}", (y : Field));
   y
 }

--- a/Lampe/Tests/Tests.lean
+++ b/Lampe/Tests/Tests.lean
@@ -438,6 +438,6 @@ example : STHoare p ⟨[(simple_func.name, simple_func.fn), (call.name, call.fn)
 
 nr_def fmtstr_test<>() -> Field {
   let y = 3 : Field;
-  let _x = #format("y: {}", (y : Field));
+  let _x = #format("y: {}", y);
   y
 }

--- a/Lampe/Tests/Tests.lean
+++ b/Lampe/Tests/Tests.lean
@@ -435,3 +435,9 @@ example : STHoare p ⟨[(simple_func.name, simple_func.fn), (call.name, call.fn)
       simp_all
   steps
   simp_all
+
+nr_def fmtstr_test<>() -> Field {
+  let y = 3 : Field;
+  let x = #format("y:{}", y);
+  y
+}

--- a/src/lean/mod.rs
+++ b/src/lean/mod.rs
@@ -1339,7 +1339,12 @@ impl LeanEmitter {
                     vars.iter()
                         .try_fold(String::new(), |mut acc, &var_id| -> Result<String> {
                             let var_name = self.emit_expr(ind, var_id)?;
-                            acc.push_str(&var_name);
+                            let var_type = self.id_bound_type(var_id);
+                            acc.push_str(&format!(
+                                "({} : {})",
+                                &var_name,
+                                self.emit_fully_qualified_type(&var_type)
+                            ));
                             acc.push_str(", ");
                             Ok(acc)
                         })?;

--- a/src/lean/mod.rs
+++ b/src/lean/mod.rs
@@ -1339,12 +1339,7 @@ impl LeanEmitter {
                     vars.iter()
                         .try_fold(String::new(), |mut acc, &var_id| -> Result<String> {
                             let var_name = self.emit_expr(ind, var_id)?;
-                            let var_type = self.id_bound_type(var_id);
-                            acc.push_str(&format!(
-                                "({} : {})",
-                                &var_name,
-                                self.emit_fully_qualified_type(&var_type)
-                            ));
+                            acc.push_str(&format!("{}", &var_name,));
                             acc.push_str(", ");
                             Ok(acc)
                         })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,14 +187,6 @@ mod test {
                 x
             }
 
-            fn pattern_test() {
-                let opt = Option2::some(true);
-                let t = (1, opt, 3);
-                let (x, mut Option2 { _is_some, _value }, mut z) = t;
-                let lam = |(x, mut y, z) : (bool, bool, bool), k : Field| -> bool {
-                    x
-                };
-
             fn fmtstr_test(x: Field, y: pub Field) -> pub Field {
                 assert(x != y);
                 let _a: fmtstr<37, (Field, Field)> = f"this is first:{x}  this is second:{y}";
@@ -216,9 +208,13 @@ mod test {
                 tpl.0 = 2;
             }
 
-            fn string_test() -> str<5> {
-                let x : str<5> = "Hello";
-                x
+            fn pattern_test() {
+                let opt = Option2::some(true);
+                let t = (1, opt, 3);
+                let (x, mut Option2 { _is_some, _value }, mut z) = t;
+                let lam = |(x, mut y, z) : (bool, bool, bool), k : Field| -> bool {
+                    x
+                };
             }
 
         "#;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,16 @@ mod test {
                 }
             }
 
+            fn string_test() -> str<5> {
+                let x : str<5> = "Hello";
+                x
+            }
+
+            fn fmtstr_test(x: Field, y: pub Field) -> pub Field {
+                assert(x != y);
+                let _a: fmtstr<37, (Field, Field)> = f"this is first:{x}  this is second:{y}";
+                x + y
+            }
 
             fn main() {
                 let mut op1 = Option2::some(5);
@@ -210,6 +220,11 @@ mod test {
                 let lam = |(x, mut y, z) : (bool, bool, bool), k : Field| -> bool {
                     x
                 };
+
+            fn fmtstr_test(x: Field, y: pub Field) -> pub Field {
+                assert(x != y);
+                let _a: fmtstr<37, (Field, Field)> = f"this is first:{x}  this is second:{y}";
+                x + y
             }
 
         "#;
@@ -244,7 +259,7 @@ mod test {
                     true
                 }
             }
-            
+
             fn main() {
                 let x = true;
                 print(x.foo());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,14 @@ mod test {
                 x
             }
 
+            fn pattern_test() {
+                let opt = Option2::some(true);
+                let t = (1, opt, 3);
+                let (x, mut Option2 { _is_some, _value }, mut z) = t;
+                let lam = |(x, mut y, z) : (bool, bool, bool), k : Field| -> bool {
+                    x
+                };
+
             fn fmtstr_test(x: Field, y: pub Field) -> pub Field {
                 assert(x != y);
                 let _a: fmtstr<37, (Field, Field)> = f"this is first:{x}  this is second:{y}";
@@ -211,20 +219,6 @@ mod test {
             fn string_test() -> str<5> {
                 let x : str<5> = "Hello";
                 x
-            }
-
-            fn pattern_test() {
-                let opt = Option2::some(true);
-                let t = (1, opt, 3);
-                let (x, mut Option2 { _is_some, _value }, mut z) = t;
-                let lam = |(x, mut y, z) : (bool, bool, bool), k : Field| -> bool {
-                    x
-                };
-
-            fn fmtstr_test(x: Field, y: pub Field) -> pub Field {
-                assert(x != y);
-                let _a: fmtstr<37, (Field, Field)> = f"this is first:{x}  this is second:{y}";
-                x + y
             }
 
         "#;


### PR DESCRIPTION
This PR adds support for Format Strings.

So far the extractor, syntax, and type definitions are defined. Not defined is the concrete type representing format strings, and their semantics.

In the process of writing builtin support I was running into universe issues with some of the naive implementation attempts. That combined with the fact that Noir has minimal support for format strings (as far as I can intuit from my experiments), I decided to stub out the definition and get this PR ready for review sooner rather than later.

I'll make sure to add an issue for full format string semantics eventually.

