### PR TITLE
Pattern support

### DIFF
--- a/src/lean/pattern.rs
+++ b/src/lean/pattern.rs
@@ -1,0 +1,97 @@
+use noirc_frontend::{ast::Ident, hir_def::{expr::HirIdent, stmt::HirPattern}, Type};
+
+#[derive(Clone, Debug)]
+enum PatType {
+    Tuple(usize),
+    Struct { struct_type: Type, field: Ident },
+}
+
+#[derive(Clone, Debug)]
+struct PatCtx {
+    stack: Vec<PatType>,
+    is_mut: bool,
+}
+
+impl Default for PatCtx {
+    fn default() -> Self {
+        Self { stack: Vec::new(), is_mut: false }
+    }
+}
+
+impl PatCtx {
+    fn push(&mut self, pat_type: PatType) {
+        self.stack.push(pat_type);
+    }
+
+    fn pop(&mut self) {
+        self.stack.pop();
+    }
+
+    fn set_mut(&mut self, is_mut: bool) {
+        self.is_mut = is_mut;
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PatRes(HirIdent, PatCtx);
+
+
+fn parse_pattern(pat: &HirPattern, ctx: &mut PatCtx) -> Vec<PatRes> {
+    match pat {
+        HirPattern::Identifier(hir_ident) => {
+            vec![PatRes(hir_ident.clone(), ctx.clone())]
+        },
+        // A `mut` pattern makes the whole sub-pattern mutable.
+        // Note that nested mut patterns are unnecessary, and they are forbidden by the compiler.
+        HirPattern::Mutable(sub_pat, ..) => {
+            ctx.set_mut(true);
+            let res = parse_pattern(sub_pat, ctx);
+            ctx.set_mut(false);
+            res
+        },
+        HirPattern::Tuple(sub_pats, ..) => {
+            let mut res = Vec::new();
+            for (i, pat) in sub_pats.iter().enumerate() {
+                ctx.push(PatType::Tuple(i));
+                res.extend(parse_pattern(pat, ctx));
+                ctx.pop();
+            }
+            res
+        },
+        HirPattern::Struct(struct_type, sub_pats, ..) => {
+            let mut res = Vec::new();
+            for (ident, pat) in sub_pats.iter() {
+                ctx.push(PatType::Struct { struct_type: struct_type.clone(), field: ident.clone() });
+                res.extend(parse_pattern(pat, ctx));
+                ctx.pop();
+            }
+            res
+        },
+    }
+}
+
+/// Emits the Lean code corresponding to a Noir pattern as a series of `let` or `let mut` bindings.
+pub(super) fn format_pattern(pat: &HirPattern, pat_rhs: &str, emitter: &super::LeanEmitter) -> Vec<String> {
+    let mut ctx = PatCtx::default();
+     parse_pattern(pat, &mut ctx).into_iter().map(|pat_res| {
+        let PatRes(id, ctx) = pat_res;
+        let lhs = emitter.context.def_interner.definition_name(id.id).to_string();
+        let mut rhs = pat_rhs.to_string();
+        for pat_type in ctx.stack {
+            match pat_type {
+                PatType::Tuple(i) => {
+                    rhs = super::syntax::expr::format_tuple_access(&rhs, &format!("{}", i));
+                },
+                PatType::Struct { struct_type, field } => {
+                    let struct_name = emitter.emit_fully_qualified_type(&struct_type);
+                    rhs = super::syntax::expr::format_member_access(&struct_name, &rhs, &field.to_string());
+                },
+            }
+        }
+        if ctx.is_mut {
+            super::syntax::stmt::format_let_mut_in(&lhs, &rhs)
+        } else {
+            super::syntax::stmt::format_let_in(&lhs, &rhs)
+        }
+    }).collect()
+}

--- a/src/lean/pattern.rs
+++ b/src/lean/pattern.rs
@@ -6,6 +6,8 @@ enum PatType {
     Struct { struct_type: Type, field: Ident },
 }
 
+/// The context of a pattern which contains all the necessary information to convert a nested `HirPattern::Identifier` pattern into a let (mut) binding.
+/// This means, it contains the stack of tuple and struct patterns that the identifier is nested in, and whether the identifier is mutable.
 #[derive(Clone, Debug)]
 struct PatCtx {
     stack: Vec<PatType>,
@@ -33,8 +35,7 @@ impl PatCtx {
 }
 
 #[derive(Clone, Debug)]
-struct PatRes(HirIdent, PatCtx);
-
+struct PatRes(/** lhs **/ HirIdent, /** rhs **/ PatCtx);
 
 fn parse_pattern(pat: &HirPattern, ctx: &mut PatCtx) -> Vec<PatRes> {
     match pat {
@@ -67,6 +68,24 @@ fn parse_pattern(pat: &HirPattern, ctx: &mut PatCtx) -> Vec<PatRes> {
             }
             res
         },
+    }
+}
+
+/// Emits the Lean code corresponding to a Noir pattern as a single `let` or `let mut` binding, along with the `HirIdent` at the lhs of the pattern.
+/// Returns `None` if the pattern is not simple enough to be expressed as a single binding.
+pub(super) fn try_format_simple_pattern(pat: &HirPattern, pat_rhs: &str, emitter: &super::LeanEmitter) -> Option<(String, HirIdent)> {
+    match pat {
+        HirPattern::Identifier(ident) => {
+            format_pattern(pat, pat_rhs, emitter).pop().map(|pat| (pat, ident.clone()))
+        }
+        HirPattern::Mutable(sub_pat, ..)  => {
+            if let HirPattern::Identifier(ident) = sub_pat.as_ref() {
+                format_pattern(pat, pat_rhs, emitter).pop().map(|pat| (pat, ident.clone()))
+            } else {
+                None
+            }
+        }
+        _ => None
     }
 }
 

--- a/src/lean/syntax.rs
+++ b/src/lean/syntax.rs
@@ -291,7 +291,7 @@ pub(super) mod expr {
     }
 
     #[inline]
-    pub fn format_lambda(_captures: &str, args: &str, body: &str, ret_type: &str) -> String {
+    pub fn format_lambda(args: &str, body: &str, ret_type: &str) -> String {
         format!("|{args}| -> {ret_type} {body}")
     }
 }
@@ -301,9 +301,15 @@ pub(super) mod stmt {
     use super::*;
 
     #[inline]
-    pub fn format_let_in(pat: &str, _binding_type: &str, bound_expr: &str) -> String {
-        format!("let {pat} = {bound_expr}")
+    pub fn format_let_in(lhs: &str, rhs: &str) -> String {
+        format!("let {lhs} = {rhs}")
     }
+
+    #[inline]
+    pub fn format_let_mut_in(lhs: &str, rhs: &str) -> String {
+        format!("let mut {lhs} = {rhs}")
+    }
+
 
     #[inline]
     pub fn format_for_loop(loop_var: &str, loop_start: &str, loop_end: &str, body: &str) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,10 @@ mod test {
             fn pattern_test() {
                 let opt = Option2::some(true);
                 let t = (1, opt, 3);
-                let (x, Option2 { _is_some, _value }, z) = t;
+                let (x, mut Option2 { _is_some, _value }, mut z) = t;
+                let lam = |(x, mut y, z) : (bool, bool, bool), k : Field| -> bool {
+                    x
+                };
             }
 
         "#;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,12 @@ mod test {
                 x
             }
 
+            fn pattern_test() {
+                let opt = Option2::some(true);
+                let t = (1, opt, 3);
+                let (x, Option2 { _is_some, _value }, z) = t;
+            }
+
         "#;
 
         let source = Source::new(file_name, source);


### PR DESCRIPTION
This PR aims to add pattern support. Patterns are only handled at the extractor side -- all the patterns are converted to either `let` or `let mut` bindings. 

For example, the statement 
```rust
let (mut x, y) = (1, 2)
```

is converted to

```
let param#0 = `(1, 2);
let mut x = param#0.0;
let y = param#0.1;
```