### PR TITLE
TraitAsType support

### DIFF
--- a/Lampe/Lampe/Syntax.lean
+++ b/Lampe/Lampe/Syntax.lean
@@ -38,6 +38,7 @@ syntax "[" nr_type ";" num "]" : nr_type -- Array
 syntax "`(" nr_type,* ")" : nr_type -- Tuple
 syntax "&" nr_type : nr_type -- Reference
 syntax "λ(" nr_type,* ")" "→" nr_type : nr_type -- Function
+syntax "_" : nr_type -- Placeholder
 
 syntax ident ":" nr_type : nr_param_decl
 
@@ -140,6 +141,7 @@ partial def mkNrType [Monad m] [MonadQuotation m] [MonadExceptOf Exception m] [M
   let paramTps ← (mkListLit (←paramTps.getElems.toList.mapM mkNrType))
   let outTp ← mkNrType outTp
   `(Tp.fn $paramTps $outTp)
+| `(nr_type | _) => `(_)
 | _ => throwUnsupportedSyntax
 
 def mkBuiltin [Monad m] [MonadQuotation m] [MonadExceptOf Exception m] [MonadError m] (i : String) : m (TSyntax `term) :=

--- a/src/lean/context.rs
+++ b/src/lean/context.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+use noirc_frontend::{
+    hir::def_map::ModuleData,
+    hir_def::{expr::HirExpression, stmt::HirStatement},
+    node_interner::NodeInterner,
+    Type,
+};
+
+pub struct EmitterCtx {
+    // Maps an impl parameter type to a type variable name.
+    impl_param_overrides: HashMap<Type, String>,
+    // Maps an impl return type to the concrete type of the function body.
+    impl_ret_overrides: HashMap<Type, Type>,
+}
+
+/// Returns true if and only if `typ` is an `impl` type.
+pub(super) fn is_impl(typ: &Type) -> bool {
+    match typ {
+        Type::TypeVariable(_) | Type::TraitAsType(_, _, _) | Type::NamedGeneric(_, _)
+            if typ.to_string().starts_with("impl") =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+
+impl EmitterCtx {
+    /// Builds the context from the module.
+    pub fn from_module(module: &ModuleData, interner: &NodeInterner) -> Self {
+        let mut impl_param_overrides = HashMap::new();
+        let mut impl_ret_overrides = HashMap::new();
+        // Get the function definitions from the module.
+        let module_fns = module.value_definitions().flat_map(|value_def| match value_def {
+            noirc_frontend::hir::def_map::ModuleDefId::FunctionId(func_id) => Some(func_id),
+            _ => None,
+        });
+        // Iterate over the the functions in the module.
+        for fn_id in module_fns {
+            let fn_meta = interner.function_meta(&fn_id);
+            // Override the parameters.
+            let params = fn_meta.parameters.0.iter();
+            for (param_idx, (_, typ, _)) in params.enumerate() {
+                if is_impl(typ) {
+                    let var_name = format!("I#{param_idx}");
+                    impl_param_overrides.insert(typ.clone(), var_name);
+                }
+            }
+            // Override the return type with the concrete type of the body.
+            let ret_type = fn_meta.return_type();
+            if is_impl(ret_type) {
+                let fn_body = interner.function(&fn_id).as_expr();
+                let fn_body_ret = interner.id_type(fn_body);
+                match &fn_body_ret {
+                    Type::TypeVariable(tv) | Type::NamedGeneric(tv, ..) => {
+                        let fn_body_last_expr = match &interner.expression(&fn_body) {
+                            HirExpression::Block(block_expr) => match block_expr
+                                .statements()
+                                .last()
+                                .map(|stmt_id| interner.statement(stmt_id))
+                            {
+                                Some(HirStatement::Expression(expr_id)) => expr_id,
+                                _ => fn_body,
+                            },
+                            _ => fn_body,
+                        };
+                        let bindings = interner.try_get_instantiation_bindings(fn_body_last_expr);
+                        if let Some((_, _, subst_typ)) =
+                            bindings.and_then(|bindings| bindings.get(&tv.id()))
+                        {
+                            if impl_param_overrides.contains_key(subst_typ) {
+                                panic!("oh no!");
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+                impl_ret_overrides.insert(ret_type.clone(), fn_body_ret);
+            }
+        }
+        EmitterCtx {
+            impl_param_overrides,
+            impl_ret_overrides,
+        }
+    }
+
+    pub fn get_impl_param<'a>(&'a self, typ: &Type) -> Option<&'a str> {
+        self.impl_param_overrides.get(typ).map(|s| s.as_str())
+    }
+
+    pub fn get_impl_return<'a>(&'a self, typ: &Type) -> Option<&'a Type> {
+        self.impl_ret_overrides.get(typ)
+    }
+}

--- a/src/lean/mod.rs
+++ b/src/lean/mod.rs
@@ -929,9 +929,9 @@ impl LeanEmitter {
                 {
                     syntax::expr::format_builtin_call(builtin_name, &args_str, &out_ty_str)
                 } else {
-                    let fn_type =
+                    let fn_typ_str =
                         self.emit_fully_qualified_type(&self.id_bound_type(call.func), ctx);
-                    syntax::expr::format_call(&func_expr_str, &args_str, &fn_type)
+                    syntax::expr::format_call(&func_expr_str, &args_str, &fn_typ_str)
                 }
             }
             HirExpression::Ident(ident, generics) => {
@@ -1011,7 +1011,7 @@ impl LeanEmitter {
                                 } else {
                                     format!("{fq_mod_name}::{fn_name}")
                                 };
-                                let call_generics = func_meta
+                                let ident_generics = func_meta
                                     .all_generics
                                     .iter()
                                     .flat_map(|t| bindings.get(&t.type_var.id()))
@@ -1019,7 +1019,7 @@ impl LeanEmitter {
                                     .chain(impl_generics)
                                     .join(", ");
 
-                                syntax::expr::format_decl_func_ident(&fq_func_name, &call_generics)
+                                syntax::expr::format_decl_func_ident(&fq_func_name, &ident_generics)
                             }
                         }
                     }

--- a/src/lean/syntax.rs
+++ b/src/lean/syntax.rs
@@ -154,12 +154,6 @@ pub(super) mod r#type {
     }
 
     #[inline]
-    pub fn format_trait_as_type(_trait_name: &str, _generics: &str) -> String {
-        todo!("TraitAsType not implemented yet")
-        // format!("?{trait_name}<{generics}>")
-    }
-
-    #[inline]
     pub fn format_function(param_types: &str, ret_type: &str) -> String {
         format!("λ({param_types}) → {ret_type}")
     }
@@ -309,7 +303,6 @@ pub(super) mod stmt {
     pub fn format_let_mut_in(lhs: &str, rhs: &str) -> String {
         format!("let mut {lhs} = {rhs}")
     }
-
 
     #[inline]
     pub fn format_for_loop(loop_var: &str, loop_start: &str, loop_end: &str, body: &str) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,8 +202,8 @@ mod test {
                 };
             }
 
-            fn impl_test<I : MyTrait>(x: I, y: impl Default) -> impl MyTrait {
-                I
+            fn impl_test(x: impl MyTrait, y: impl Default) -> impl Default {
+                false
             }
 
             fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ mod test {
                 x
             }
 
-            fn fmtstr_test(x: Field, y: pub Field) -> pub Field {
+            fn fmtstr_test(x: Field, y: Field) -> Field {
                 assert(x != y);
                 let _a: fmtstr<37, (Field, Field)> = f"this is first:{x}  this is second:{y}";
                 x + y
@@ -202,8 +202,8 @@ mod test {
                 };
             }
 
-            fn impl_test(x: impl MyTrait, z: impl Default) -> impl MyTrait {
-                x
+            fn impl_test<I : MyTrait>(x: I, y: impl Default) -> impl MyTrait {
+                I
             }
 
             fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,19 @@ mod test {
                 x + y
             }
 
+            fn pattern_test() {
+                let opt = Option2::some(true);
+                let t = (1, opt, 3);
+                let (x, mut Option2 { _is_some, _value }, mut z) = t;
+                let lam = |(x, mut y, z) : (bool, bool, bool), k : Field| -> bool {
+                    x
+                };
+            }
+
+            fn impl_test(x: impl MyTrait, z: impl Default) -> impl MyTrait {
+                x
+            }
+
             fn main() {
                 let mut op1 = Option2::some(5);
                 let op2 = Option2::default();
@@ -206,16 +219,9 @@ mod test {
                 op1._is_some = false;
                 let mut tpl = (1, true);
                 tpl.0 = 2;
+                let impl_res = impl_test(op1, 0);
             }
 
-            fn pattern_test() {
-                let opt = Option2::some(true);
-                let t = (1, opt, 3);
-                let (x, mut Option2 { _is_some, _value }, mut z) = t;
-                let lam = |(x, mut y, z) : (bool, bool, bool), k : Field| -> bool {
-                    x
-                };
-            }
 
         "#;
 


### PR DESCRIPTION
This PR aims to add `TraitAsType` support. They are handled purely at the extractor side. 

If they occur in parameter types, they are replaced by type variables. If they occur in the return type, they are replaced by the concrete type that the function body returns.

I also added a placeholder type at the Lean side, which can be invoked with `_` in the Lean definitions. This might be useful in the future.