### PR TITLE
globals

### DIFF
--- a/Lampe/Tests/Globals.lean
+++ b/Lampe/Tests/Globals.lean
@@ -1,0 +1,13 @@
+import Lampe
+
+open Lampe
+
+nr_def «FOOS»<>() -> [Field; 2] {
+    [(@FOO<> as λ() → Field)(), #fAdd((@FOO<> as λ() → Field)(), 1 : Field) : Field]
+}
+
+nr_def «FOO»<>() -> Field {
+    42 : Field
+}
+
+

--- a/src/error/emit.rs
+++ b/src/error/emit.rs
@@ -13,4 +13,7 @@ pub enum Error {
 
     #[error("Indentation level cannot be decreased below zero")]
     CannotDecreaseIndentLevel,
+
+    #[error("Global {_0} is not extracted as a let statement")]
+    GlobalStatementNotLet(String),
 }

--- a/src/error/emit.rs
+++ b/src/error/emit.rs
@@ -14,6 +14,6 @@ pub enum Error {
     #[error("Indentation level cannot be decreased below zero")]
     CannotDecreaseIndentLevel,
 
-    #[error("Global {_0} is not extracted as a let statement")]
-    GlobalStatementNotLet(String),
+    #[error("Global is not extracted as a let statement")]
+    GlobalStatementNotLet,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,4 +279,28 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn globals() -> anyhow::Result<()> {
+        let file_name = Path::new("main.nr");
+        let source = r#"
+            global FOOS: [Field; 2] = [FOO, FOO + 1];
+
+            global FOO: Field  = 42;
+
+            fn main() -> pub Field {
+                FOOS[1]
+            }
+        "#;
+
+        let source = Source::new(file_name, source);
+
+        let project = Project::new(Path::new(""), source);
+
+        let source = noir_to_lean(project)?.take();
+
+        println!("{source}");
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
This PR closes #58. 

The solution is a little bit of a hack, but it works: Export globals as top level functions with no inputs that return the global value. The whole implementation is done on the extractor side.