### PR TITLE
`arrayAsSlice` builtin

### DIFF
--- a/Lampe/Lampe/Hoare/Builtins.lean
+++ b/Lampe/Lampe/Hoare/Builtins.lean
@@ -215,7 +215,7 @@ theorem uShl_intro : STHoarePureBuiltin p Γ Builtin.uShl (by tauto) h![a, b] :=
   apply pureBuiltin_intro_consequence <;> try tauto
   tauto
 
-theorem uShr_intro : STHoarePureBuiltin p Γ Builtin.uShl (by tauto) h![a, b] := by
+theorem uShr_intro : STHoarePureBuiltin p Γ Builtin.uShr (by tauto) h![a, b] := by
   apply pureBuiltin_intro_consequence <;> try tauto
   tauto
 

--- a/Lampe/Lampe/Tactic/SeparationLogic.lean
+++ b/Lampe/Lampe/Tactic/SeparationLogic.lean
@@ -627,6 +627,9 @@ macro "stephelper1" : tactic => `(tactic|(
     -- lens
     | apply modifyLens_intro
     | apply getLens_intro
+    -- bitwise
+    | apply uShr_intro
+    | apply uShl_intro
   )
 ))
 
@@ -699,6 +702,9 @@ macro "stephelper2" : tactic => `(tactic|(
     -- lens
     | apply consequence_frame_left modifyLens_intro
     | apply consequence_frame_left getLens_intro
+    -- bitwise
+    | apply consequence_frame_left uShr_intro
+    | apply consequence_frame_left uShl_intro
   )
   repeat sl
 ))
@@ -774,6 +780,9 @@ macro "stephelper3" : tactic => `(tactic|(
     -- lens
     | apply ramified_frame_top modifyLens_intro
     | apply ramified_frame_top getLens_intro
+    --- bitwise
+    | apply ramified_frame_top uShr_intro
+    | apply ramified_frame_top uShl_intro
   )
   repeat sl
 ))

--- a/src/lean/builtin.rs
+++ b/src/lean/builtin.rs
@@ -106,6 +106,7 @@ pub fn try_func_expr_into_builtin_name(func_expr: &str) -> Option<BuiltinName> {
         ("@std::slice::pop_back", "slicePopBack"),
         ("@std::slice::pop_front", "slicePopFront"),
         ("@std::array::len", "arrayLen"),
+        ("@std::array::as_slice", "arrayAsSlice"),
         ("@std::mem::zeroed", "zeroed"),
     ];
     for (prefix, builtin) in builtin_names {


### PR DESCRIPTION
Last couple fixes I've run into:
* Add `uShr` and `uShl` builtin support to `steps` automation.
* Fix the type signature of `uShr_intro` (this was a nasty bug to track down)
* One last builtin that's already implemented [here](https://github.com/reilabs/lampe/blob/b9f946d00b4020c29c26ba9fd2c848f26377c227/Lampe/Lampe/Builtin/Array.lean#L115-L118) but didn't get added to the list in the extractor.