### PR TITLE
Field generics

### DIFF
--- a/Examples/Merkle/Merkle/Extracted.lean
+++ b/Examples/Merkle/Merkle/Extracted.lean
@@ -8,12 +8,12 @@ nr_struct_def Skyscraper<> {
 
 }
 
-nr_def «SIGMA»<>() -> Field {
-    9915499612839321149637521777990102151350674507940716049588462388200839649614 : Field
-}
-
 nr_def «RC»<>() -> [Field; 8] {
     [-4058822530962036113558957735524994411356374024839875405476791844324326516925 : Field, 5852100059362614845584985098022261541909346143980691326489891671321030921585 : Field, -4840154698573742532565501789862255731956493498174317200418381990571919688651 : Field, 71577923540621522166602308362662170286605786204339342029375621502658138039 : Field, 1630526119629192105940988602003704216811347521589219909349181656165466494167 : Field, 7807402158218786806372091124904574238561123446618083586948014838053032654983 : Field, -8558681900379240296346816806663462402801546068866479372657894196934284905006 : Field, -4916733727805245440019875123169648108733681133486378553671899463457684353318 : Field]
+}
+
+nr_def «SIGMA»<>() -> Field {
+    9915499612839321149637521777990102151350674507940716049588462388200839649614 : Field
 }
 
 nr_trait_impl[impl_405] <> BinaryHasher<Field> for Skyscraper<> where  {
@@ -23,28 +23,16 @@ nr_trait_impl[impl_405] <> BinaryHasher<Field> for Skyscraper<> where  {
 }
 }
 
-nr_def «weird_assert_eq»<>(a : Field, b : Field) -> Unit {
-    let wit =     (@weird_eq_witness<> as λ(Field, Field) → Field)(a, b);
-    #assert(#fEq(wit, a) : bool) : Unit;
-    #assert(#fEq(wit, b) : bool) : Unit;
+nr_def «as_array»<>(self : [u8]) -> [u8; 32] {
+    let mut array = [0 : u8 ; 32];
+    for i in 0 : u32 .. 32 : u32 {
+            array[#cast(i) : u32] = #sliceIndex(self, #cast(i) : u32) : u8;
+    };
+    array;
 }
 
 nr_def «square»<>(a : Field) -> Field {
     #fMul(#fMul(a, a) : Field, (@SIGMA<> as λ() → Field)()) : Field;
-}
-
-nr_def «to_le_bits»<>(self : Field) -> [u1; 256] {
-    let mut val = self;
-    let mut bits = [0 : u1 ; 256];
-    for i in 0 : u32 .. 256 : u32 {
-            bits[#cast(i) : u32] = (@sgn0<> as λ(Field) → u1)(val);
-        if #uEq(#arrayIndex(bits, #cast(i) : u32) : u1, 0 : u1) : bool {
-                val = #fDiv(val, 2 : Field) : Field;
-        } else {
-                val = #fDiv(#fSub(val, 1 : Field) : Field, 2 : Field) : Field;
-        };
-    };
-    bits;
 }
 
 nr_def «from_le_bytes»<>(bytes : [u8; 32]) -> Field {
@@ -57,29 +45,9 @@ nr_def «from_le_bytes»<>(bytes : [u8; 32]) -> Field {
     result;
 }
 
-nr_def «weird_eq_witness»<>(a : Field, b : Field) -> Field {
-    #fresh() : Field
-}
-
-nr_def «as_array»<>(self : [u8]) -> [u8; 32] {
-    let mut array = [0 : u8 ; 32];
-    for i in 0 : u32 .. 32 : u32 {
-            array[#cast(i) : u32] = #sliceIndex(self, #cast(i) : u32) : u8;
-    };
-    array;
-}
-
 nr_def «main»<>(root : Field, proof : [Field; 32], item : Field, idx : [bool; 32]) -> Unit {
-    let calculated_root = (@mtree_recover<Skyscraper<>, 32 : type_u 32> as λ([bool; 32], [Field; 32], Field) → Field)(idx, proof, item);
+    let calculated_root = (@mtree_recover<Skyscraper<>, 32 : u32> as λ([bool; 32], [Field; 32], Field) → Field)(idx, proof, item);
     (@weird_assert_eq<> as λ(Field, Field) → Unit)(root, calculated_root);
-}
-
-nr_def «rotate_left»<>(u : u8, N : u8) -> u8 {
-    let mut result = u;
-    for _? in 0 : u8 .. N {
-            result = (@rl<> as λ(u8) → u8)(result);
-    };
-    result;
 }
 
 nr_def «sbox»<>(v : u8) -> u8 {
@@ -90,53 +58,6 @@ nr_def «sbox»<>(v : u8) -> u8 {
     let x5 = #uAnd(#uAnd(x2, x3) : u8, x4) : u8;
     let x6 = (@rotate_left<> as λ(u8, u8) → u8)(x5, 1 : u8);
     #uXor(v, x6) : u8;
-}
-
-nr_def «sgn0»<>(self : Field) -> u1 {
-    #cast(self) : u1;
-}
-
-nr_def «mtree_recover»<H, @N : type_u 32>(idx : [bool; N], p : [Field; N], item : Field) -> Field {
-    let mut curr_h = item;
-    for i in 0 : u32 .. u@N {
-            let dir = #arrayIndex(idx, #cast(i) : u32) : bool;
-        let sibling_root = #arrayIndex(p, #cast(i) : u32) : Field;
-        if dir {
-                curr_h = ((H as BinaryHasher<Field>)::hash<> as λ(Field, Field) → Field)(sibling_root, curr_h);
-        } else {
-                curr_h = ((H as BinaryHasher<Field>)::hash<> as λ(Field, Field) → Field)(curr_h, sibling_root);
-        };
-    };
-    curr_h;
-}
-
-nr_def «to_le_bytes»<>(self : Field) -> [u8; 32] {
-    let bits = (@to_le_bits<> as λ(Field) → [u1; 256])(self);
-    let mut bytes = [0 : u8 ; 32];
-    for i in 0 : u32 .. 32 : u32 {
-            bytes[#cast(i) : u32] = #uAdd(#uAdd(#uAdd(#uAdd(#uAdd(#uAdd(#uAdd(#cast(#arrayIndex(bits, #cast(#uMul(8 : u32, i) : u32) : u32) : u1) : u8, #uMul(2 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 1 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(4 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 2 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(8 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 3 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(16 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 4 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(32 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 5 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(64 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 6 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(128 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 7 : u32) : u32) : u32) : u1) : u8) : u8) : u8;
-    };
-    bytes;
-}
-
-nr_def «bar»<>(a : Field) -> Field {
-    let bytes = (@to_le_bytes<> as λ(Field) → [u8; 32])(a);
-    let mut new_left = [0 : u8 ; 16];
-    let mut new_right = [0 : u8 ; 16];
-    for i in 0 : u32 .. 16 : u32 {
-            new_left[#cast(i) : u32] = (@sbox<> as λ(u8) → u8)(#arrayIndex(bytes, #cast(i) : u32) : u8);
-    };
-    for i in 0 : u32 .. 16 : u32 {
-            new_right[#cast(i) : u32] = (@sbox<> as λ(u8) → u8)(#arrayIndex(bytes, #cast(#uAdd(16 : u32, i) : u32) : u32) : u8);
-    };
-    let mut new_bytes = #arrayAsSlice(new_right) : [u8];
-        let ζi0 = new_left;
-        for ζi1 in 0 : u32 .. #arrayLen(ζi0) : u32 {
-                let elem = #arrayIndex(ζi0, #cast(ζi1) : u32) : u8;
-                new_bytes = #slicePushBack(new_bytes, elem) : [u8];
-        };
-    let new_bytes_array = (@as_array<> as λ([u8]) → [u8; 32])(new_bytes);
-    (@from_le_bytes<> as λ([u8; 32]) → Field)(new_bytes_array);
 }
 
 nr_def «permute»<>(s : [Field; 2]) -> [Field; 2] {
@@ -176,10 +97,89 @@ nr_def «permute»<>(s : [Field; 2]) -> [Field; 2] {
     [l, r];
 }
 
+nr_def «sgn0»<>(self : Field) -> u1 {
+    #cast(self) : u1;
+}
+
 nr_def «rl»<>(u : u8) -> u8 {
     let top_bit = #uShr(u, 7 : u8) : u8;
     #uOr(#uShl(u, 1 : u8) : u8, top_bit) : u8;
 }
 
+nr_def «mtree_recover»<H, @N : u32>(idx : [bool; N], p : [Field; N], item : Field) -> Field {
+    let mut curr_h = item;
+    for i in 0 : u32 .. u@N {
+            let dir = #arrayIndex(idx, #cast(i) : u32) : bool;
+        let sibling_root = #arrayIndex(p, #cast(i) : u32) : Field;
+        if dir {
+                curr_h = ((H as BinaryHasher<Field>)::hash<> as λ(Field, Field) → Field)(sibling_root, curr_h);
+        } else {
+                curr_h = ((H as BinaryHasher<Field>)::hash<> as λ(Field, Field) → Field)(curr_h, sibling_root);
+        };
+    };
+    curr_h;
+}
 
-def env := Lampe.Env.mk [«as_array», «mtree_recover», «to_le_bits», «permute», «SIGMA», «weird_eq_witness», «main», «from_le_bytes», «RC», «sbox», «bar», «weird_assert_eq», «square», «sgn0», «rotate_left», «to_le_bytes», «rl»] [impl_405]
+nr_def «weird_assert_eq»<>(a : Field, b : Field) -> Unit {
+    let wit =     (@weird_eq_witness<> as λ(Field, Field) → Field)(a, b);
+    #assert(#fEq(wit, a) : bool) : Unit;
+    #assert(#fEq(wit, b) : bool) : Unit;
+}
+
+nr_def «to_le_bits»<>(self : Field) -> [u1; 256] {
+    let mut val = self;
+    let mut bits = [0 : u1 ; 256];
+    for i in 0 : u32 .. 256 : u32 {
+            bits[#cast(i) : u32] = (@sgn0<> as λ(Field) → u1)(val);
+        if #uEq(#arrayIndex(bits, #cast(i) : u32) : u1, 0 : u1) : bool {
+                val = #fDiv(val, 2 : Field) : Field;
+        } else {
+                val = #fDiv(#fSub(val, 1 : Field) : Field, 2 : Field) : Field;
+        };
+    };
+    bits;
+}
+
+nr_def «to_le_bytes»<>(self : Field) -> [u8; 32] {
+    let bits = (@to_le_bits<> as λ(Field) → [u1; 256])(self);
+    let mut bytes = [0 : u8 ; 32];
+    for i in 0 : u32 .. 32 : u32 {
+            bytes[#cast(i) : u32] = #uAdd(#uAdd(#uAdd(#uAdd(#uAdd(#uAdd(#uAdd(#cast(#arrayIndex(bits, #cast(#uMul(8 : u32, i) : u32) : u32) : u1) : u8, #uMul(2 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 1 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(4 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 2 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(8 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 3 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(16 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 4 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(32 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 5 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(64 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 6 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(128 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 7 : u32) : u32) : u32) : u1) : u8) : u8) : u8;
+    };
+    bytes;
+}
+
+nr_def «weird_eq_witness»<>(a : Field, b : Field) -> Field {
+    #fresh() : Field
+}
+
+nr_def «bar»<>(a : Field) -> Field {
+    let bytes = (@to_le_bytes<> as λ(Field) → [u8; 32])(a);
+    let mut new_left = [0 : u8 ; 16];
+    let mut new_right = [0 : u8 ; 16];
+    for i in 0 : u32 .. 16 : u32 {
+            new_left[#cast(i) : u32] = (@sbox<> as λ(u8) → u8)(#arrayIndex(bytes, #cast(i) : u32) : u8);
+    };
+    for i in 0 : u32 .. 16 : u32 {
+            new_right[#cast(i) : u32] = (@sbox<> as λ(u8) → u8)(#arrayIndex(bytes, #cast(#uAdd(16 : u32, i) : u32) : u32) : u8);
+    };
+    let mut new_bytes = #arrayAsSlice(new_right) : [u8];
+        let ζi0 = new_left;
+        for ζi1 in 0 : u32 .. #arrayLen(ζi0) : u32 {
+                let elem = #arrayIndex(ζi0, #cast(ζi1) : u32) : u8;
+                new_bytes = #slicePushBack(new_bytes, elem) : [u8];
+        };
+    let new_bytes_array = (@as_array<> as λ([u8]) → [u8; 32])(new_bytes);
+    (@from_le_bytes<> as λ([u8; 32]) → Field)(new_bytes_array);
+}
+
+nr_def «rotate_left»<>(u : u8, N : u8) -> u8 {
+    let mut result = u;
+    for _? in 0 : u8 .. N {
+            result = (@rl<> as λ(u8) → u8)(result);
+    };
+    result;
+}
+
+
+def env := Lampe.Env.mk [«main», «SIGMA», «weird_assert_eq», «permute», «sbox», «bar», «rl», «mtree_recover», «square», «sgn0», «from_le_bytes», «as_array», «RC», «rotate_left», «to_le_bits», «to_le_bytes», «weird_eq_witness»] [impl_405]

--- a/Examples/Merkle/Merkle/Extracted.lean
+++ b/Examples/Merkle/Merkle/Extracted.lean
@@ -20,7 +20,45 @@ nr_trait_impl[impl_405] <> BinaryHasher<Field> for Skyscraper<> where  {
     fn «hash»<> (a : Field, b : Field) -> Field {
         let x = (@permute<> as λ([Field; 2]) → [Field; 2])([a, b]);
         #fAdd(#arrayIndex(x, #cast(0 : Field) : u32) : Field, a) : Field;
-} 
+}
+}
+
+nr_def «weird_assert_eq»<>(a : Field, b : Field) -> Unit {
+    let wit =     (@weird_eq_witness<> as λ(Field, Field) → Field)(a, b);
+    #assert(#fEq(wit, a) : bool) : Unit;
+    #assert(#fEq(wit, b) : bool) : Unit;
+}
+
+nr_def «square»<>(a : Field) -> Field {
+    #fMul(#fMul(a, a) : Field, (@SIGMA<> as λ() → Field)()) : Field;
+}
+
+nr_def «to_le_bits»<>(self : Field) -> [u1; 256] {
+    let mut val = self;
+    let mut bits = [0 : u1 ; 256];
+    for i in 0 : u32 .. 256 : u32 {
+            bits[#cast(i) : u32] = (@sgn0<> as λ(Field) → u1)(val);
+        if #uEq(#arrayIndex(bits, #cast(i) : u32) : u1, 0 : u1) : bool {
+                val = #fDiv(val, 2 : Field) : Field;
+        } else {
+                val = #fDiv(#fSub(val, 1 : Field) : Field, 2 : Field) : Field;
+        };
+    };
+    bits;
+}
+
+nr_def «from_le_bytes»<>(bytes : [u8; 32]) -> Field {
+    let mut v = 1 : Field;
+    let mut result = 0 : Field;
+    for i in 0 : u32 .. 32 : u32 {
+            result = #fAdd(result, #fMul(#cast(#arrayIndex(bytes, #cast(i) : u32) : u8) : Field, v) : Field) : Field;
+        v = #fMul(v, 256 : Field) : Field;
+    };
+    result;
+}
+
+nr_def «weird_eq_witness»<>(a : Field, b : Field) -> Field {
+    #fresh() : Field
 }
 
 nr_def «as_array»<>(self : [u8]) -> [u8; 32] {
@@ -31,8 +69,9 @@ nr_def «as_array»<>(self : [u8]) -> [u8; 32] {
     array;
 }
 
-nr_def «square»<>(a : Field) -> Field {
-    #fMul(#fMul(a, a) : Field, (@SIGMA<> as λ() → Field)()) : Field;
+nr_def «main»<>(root : Field, proof : [Field; 32], item : Field, idx : [bool; 32]) -> Unit {
+    let calculated_root = (@mtree_recover<Skyscraper<>, 32 : type_u 32> as λ([bool; 32], [Field; 32], Field) → Field)(idx, proof, item);
+    (@weird_assert_eq<> as λ(Field, Field) → Unit)(root, calculated_root);
 }
 
 nr_def «rotate_left»<>(u : u8, N : u8) -> u8 {
@@ -41,6 +80,43 @@ nr_def «rotate_left»<>(u : u8, N : u8) -> u8 {
             result = (@rl<> as λ(u8) → u8)(result);
     };
     result;
+}
+
+nr_def «sbox»<>(v : u8) -> u8 {
+    let x1 = #uNot(v) : u8;
+    let x2 = (@rotate_left<> as λ(u8, u8) → u8)(x1, 1 : u8);
+    let x3 = (@rotate_left<> as λ(u8, u8) → u8)(v, 2 : u8);
+    let x4 = (@rotate_left<> as λ(u8, u8) → u8)(v, 3 : u8);
+    let x5 = #uAnd(#uAnd(x2, x3) : u8, x4) : u8;
+    let x6 = (@rotate_left<> as λ(u8, u8) → u8)(x5, 1 : u8);
+    #uXor(v, x6) : u8;
+}
+
+nr_def «sgn0»<>(self : Field) -> u1 {
+    #cast(self) : u1;
+}
+
+nr_def «mtree_recover»<H, @N : type_u 32>(idx : [bool; N], p : [Field; N], item : Field) -> Field {
+    let mut curr_h = item;
+    for i in 0 : u32 .. u@N {
+            let dir = #arrayIndex(idx, #cast(i) : u32) : bool;
+        let sibling_root = #arrayIndex(p, #cast(i) : u32) : Field;
+        if dir {
+                curr_h = ((H as BinaryHasher<Field>)::hash<> as λ(Field, Field) → Field)(sibling_root, curr_h);
+        } else {
+                curr_h = ((H as BinaryHasher<Field>)::hash<> as λ(Field, Field) → Field)(curr_h, sibling_root);
+        };
+    };
+    curr_h;
+}
+
+nr_def «to_le_bytes»<>(self : Field) -> [u8; 32] {
+    let bits = (@to_le_bits<> as λ(Field) → [u1; 256])(self);
+    let mut bytes = [0 : u8 ; 32];
+    for i in 0 : u32 .. 32 : u32 {
+            bytes[#cast(i) : u32] = #uAdd(#uAdd(#uAdd(#uAdd(#uAdd(#uAdd(#uAdd(#cast(#arrayIndex(bits, #cast(#uMul(8 : u32, i) : u32) : u32) : u1) : u8, #uMul(2 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 1 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(4 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 2 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(8 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 3 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(16 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 4 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(32 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 5 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(64 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 6 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(128 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 7 : u32) : u32) : u32) : u1) : u8) : u8) : u8;
+    };
+    bytes;
 }
 
 nr_def «bar»<>(a : Field) -> Field {
@@ -100,86 +176,10 @@ nr_def «permute»<>(s : [Field; 2]) -> [Field; 2] {
     [l, r];
 }
 
-nr_def «weird_assert_eq»<>(a : Field, b : Field) -> Unit {
-    let wit =     (@weird_eq_witness<> as λ(Field, Field) → Field)(a, b);
-    #assert(#fEq(wit, a) : bool) : Unit;
-    #assert(#fEq(wit, b) : bool) : Unit;
-}
-
-nr_def «to_le_bits»<>(self : Field) -> [u1; 256] {
-    let mut val = self;
-    let mut bits = [0 : u1 ; 256];
-    for i in 0 : u32 .. 256 : u32 {
-            bits[#cast(i) : u32] = (@sgn0<> as λ(Field) → u1)(val);
-        if #uEq(#arrayIndex(bits, #cast(i) : u32) : u1, 0 : u1) : bool {
-                val = #fDiv(val, 2 : Field) : Field;
-        } else {
-                val = #fDiv(#fSub(val, 1 : Field) : Field, 2 : Field) : Field;
-        };
-    };
-    bits;
-}
-
-nr_def «main»<>(root : Field, proof : [Field; 32], item : Field, idx : [bool; 32]) -> Unit {
-    let calculated_root = (@mtree_recover<Skyscraper<>, 32 : 32> as λ([bool; 32], [Field; 32], Field) → Field)(idx, proof, item);
-    (@weird_assert_eq<> as λ(Field, Field) → Unit)(root, calculated_root);
-}
-
-nr_def «to_le_bytes»<>(self : Field) -> [u8; 32] {
-    let bits = (@to_le_bits<> as λ(Field) → [u1; 256])(self);
-    let mut bytes = [0 : u8 ; 32];
-    for i in 0 : u32 .. 32 : u32 {
-            bytes[#cast(i) : u32] = #uAdd(#uAdd(#uAdd(#uAdd(#uAdd(#uAdd(#uAdd(#cast(#arrayIndex(bits, #cast(#uMul(8 : u32, i) : u32) : u32) : u1) : u8, #uMul(2 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 1 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(4 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 2 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(8 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 3 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(16 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 4 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(32 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 5 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(64 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 6 : u32) : u32) : u32) : u1) : u8) : u8) : u8, #uMul(128 : u8, #cast(#arrayIndex(bits, #cast(#uAdd(#uMul(8 : u32, i) : u32, 7 : u32) : u32) : u32) : u1) : u8) : u8) : u8;
-    };
-    bytes;
-}
-
 nr_def «rl»<>(u : u8) -> u8 {
     let top_bit = #uShr(u, 7 : u8) : u8;
     #uOr(#uShl(u, 1 : u8) : u8, top_bit) : u8;
 }
 
-nr_def «from_le_bytes»<>(bytes : [u8; 32]) -> Field {
-    let mut v = 1 : Field;
-    let mut result = 0 : Field;
-    for i in 0 : u32 .. 32 : u32 {
-            result = #fAdd(result, #fMul(#cast(#arrayIndex(bytes, #cast(i) : u32) : u8) : Field, v) : Field) : Field;
-        v = #fMul(v, 256 : Field) : Field;
-    };
-    result;
-}
 
-nr_def «sbox»<>(v : u8) -> u8 {
-    let x1 = #uNot(v) : u8;
-    let x2 = (@rotate_left<> as λ(u8, u8) → u8)(x1, 1 : u8);
-    let x3 = (@rotate_left<> as λ(u8, u8) → u8)(v, 2 : u8);
-    let x4 = (@rotate_left<> as λ(u8, u8) → u8)(v, 3 : u8);
-    let x5 = #uAnd(#uAnd(x2, x3) : u8, x4) : u8;
-    let x6 = (@rotate_left<> as λ(u8, u8) → u8)(x5, 1 : u8);
-    #uXor(v, x6) : u8;
-}
-
-nr_def «mtree_recover»<H, @N : 32>(idx : [bool; N], p : [Field; N], item : Field) -> Field {
-    let mut curr_h = item;
-    for i in 0 : u32 .. @N {
-            let dir = #arrayIndex(idx, #cast(i) : u32) : bool;
-        let sibling_root = #arrayIndex(p, #cast(i) : u32) : Field;
-        if dir {
-                curr_h = ((H as BinaryHasher<Field>)::hash<> as λ(Field, Field) → Field)(sibling_root, curr_h);
-        } else {
-                curr_h = ((H as BinaryHasher<Field>)::hash<> as λ(Field, Field) → Field)(curr_h, sibling_root);
-        };
-    };
-    curr_h;
-}
-
-nr_def «sgn0»<>(self : Field) -> u1 {
-    #cast(self) : u1;
-}
-
-nr_def «weird_eq_witness»<>(a : Field, b : Field) -> Field {
-    #fresh() : Field
-}
-
-
-def env := Lampe.Env.mk [«bar», «square», «permute», «from_le_bytes», «SIGMA», «rl», «to_le_bytes», «sgn0», «RC», «sbox», «weird_eq_witness», «rotate_left», «to_le_bits», «main», «as_array», «mtree_recover», «weird_assert_eq»] [impl_405]
+def env := Lampe.Env.mk [«as_array», «mtree_recover», «to_le_bits», «permute», «SIGMA», «weird_eq_witness», «main», «from_le_bytes», «RC», «sbox», «bar», «weird_assert_eq», «square», «sgn0», «rotate_left», «to_le_bytes», «rl»] [impl_405]

--- a/Lampe/Lampe/Ast.lean
+++ b/Lampe/Lampe/Ast.lean
@@ -23,7 +23,8 @@ structure TraitMethodImplRef where
 inductive Expr (rep : Tp → Type) : Tp → Type where
 | litNum : (tp : Tp) → Int → Expr rep tp
 | litStr : (len : U 32) → FixedLenStr len.toNat → Expr rep (.str len)
-| const : U w → Expr rep (.u w)
+| constFp : (Fp p) → Expr rep .field
+| constU : U w → Expr rep (.u w)
 | fmtStr : (len : U 32) → (tps : List Tp) → FormatString len tps → Expr rep (.fmtStr len tps)
 | fn : (argTps : List Tp) → (outTp : Tp) → (r : FuncRef argTps outTp) → Expr rep (.fn argTps outTp)
 | var : rep tp → Expr rep tp

--- a/Lampe/Lampe/Ast.lean
+++ b/Lampe/Lampe/Ast.lean
@@ -23,7 +23,7 @@ structure TraitMethodImplRef where
 inductive Expr (rep : Tp → Type) : Tp → Type where
 | litNum : (tp : Tp) → Int → Expr rep tp
 | litStr : (len : U 32) → FixedLenStr len.toNat → Expr rep (.str len)
-| constFp : (Fp p) → Expr rep .field
+| constFp : Int → Expr rep .field
 | constU : U w → Expr rep (.u w)
 | fmtStr : (len : U 32) → (tps : List Tp) → FormatString len tps → Expr rep (.fmtStr len tps)
 | fn : (argTps : List Tp) → (outTp : Tp) → (r : FuncRef argTps outTp) → Expr rep (.fn argTps outTp)

--- a/Lampe/Lampe/Hoare/SepTotal.lean
+++ b/Lampe/Lampe/Hoare/SepTotal.lean
@@ -407,7 +407,15 @@ theorem ite_intro {cnd : Bool}
   . apply iteTrue_intro
     tauto
 
-theorem const_intro: STHoare p Γ ⟦⟧ (.const c) fun v => v = c := by
+theorem constU_intro: STHoare p Γ ⟦⟧ (.constU c) fun v => v = c := by
+  unfold STHoare THoare
+  intro H st hp
+  constructor
+  simp only
+  apply SLP.ent_star_top
+  assumption
+
+theorem constFp_intro: STHoare p Γ ⟦⟧ (.constFp c) fun v => v = c := by
   unfold STHoare THoare
   intro H st hp
   constructor

--- a/Lampe/Lampe/Semantics.lean
+++ b/Lampe/Lampe/Semantics.lean
@@ -40,7 +40,7 @@ inductive Omni : Env → State p → Expr (Tp.denote p) tp → (Option (State p 
 | litTrue {Q} : Q (some (st, true)) → Omni Γ st (.litNum .bool 1) Q
 | litU {Q} : Q (some (st, ↑n)) → Omni Γ st (.litNum (.u s) n) Q
 | litUnit {Q} : Q (some (st, ())) → Omni Γ st (.litNum .unit n) Q
-| constFp {Q} {c : Fp p} : Q (some (st, c)) → Omni Γ st (.constFp c) Q
+| constFp {Q} {c : Int} : Q (some (st, c)) → Omni Γ st (.constFp c) Q
 | constU {Q} {c : U w} : Q (some (st, c)) → Omni Γ st (.constU c) Q
 | fn {Q} : Q (some (st, r)) → Omni Γ st (.fn _ _ r) Q
 | var {Q} : Q (some (st, v)) → Omni Γ st (.var v) Q

--- a/Lampe/Lampe/Semantics.lean
+++ b/Lampe/Lampe/Semantics.lean
@@ -40,7 +40,8 @@ inductive Omni : Env → State p → Expr (Tp.denote p) tp → (Option (State p 
 | litTrue {Q} : Q (some (st, true)) → Omni Γ st (.litNum .bool 1) Q
 | litU {Q} : Q (some (st, ↑n)) → Omni Γ st (.litNum (.u s) n) Q
 | litUnit {Q} : Q (some (st, ())) → Omni Γ st (.litNum .unit n) Q
-| const {Q} {c : U w} : Q (some (st, c)) → Omni Γ st (.const c) Q
+| constFp {Q} {c : Fp p} : Q (some (st, c)) → Omni Γ st (.constFp c) Q
+| constU {Q} {c : U w} : Q (some (st, c)) → Omni Γ st (.constU c) Q
 | fn {Q} : Q (some (st, r)) → Omni Γ st (.fn _ _ r) Q
 | var {Q} : Q (some (st, v)) → Omni Γ st (.var v) Q
 | skip {Q} : Q (some (st, ())) → Omni Γ st (.skip) Q
@@ -146,7 +147,8 @@ theorem Omni.frame {p Γ tp} {st₁ st₂ : State p} {e : Expr (Tp.denote p) tp}
   | litTrue hq
   | litU hq
   | litUnit
-  | const
+  | constU
+  | constFp
   | fmtStr hq
   | skip hq
   | fn

--- a/Lampe/Lampe/Syntax.lean
+++ b/Lampe/Lampe/Syntax.lean
@@ -44,12 +44,10 @@ syntax "λ(" nr_type,* ")" "→" nr_type : nr_type -- Function
 syntax "_" : nr_type -- Placeholder
 syntax "@" nr_ident "<" nr_generic,* ">" : nr_type -- Type alias
 
-syntax num ":" "type_u" num : nr_generic
-syntax num ":" "type_fp" : nr_generic
+syntax num ":" ident : nr_generic
 syntax nr_type : nr_generic
 
-syntax "@" ident ":" "type_u" num : nr_generic_def -- Kind.u
-syntax "@" ident ":" "type_fp" : nr_generic_def -- Kind.field
+syntax "@" ident ":" ident : nr_generic_def
 syntax ident : nr_generic_def -- Kind.type
 
 syntax num : nr_const_num
@@ -141,6 +139,27 @@ def mkHListLit [Monad m] [MonadQuotation m] [MonadExceptOf Exception m] [MonadEr
   let tail ← mkHListLit xs
   `(HList.cons $x $tail)
 
+def matchGenericDefs [Monad m] [MonadQuotation m] [MonadExceptOf Exception m] : TSyntax `ident → m (TSyntax `term)
+| `(ident| Field) => `(Kind.field)
+| `(ident| u1) => `(Kind.u 1)
+| `(ident| u8) => `(Kind.u 8)
+| `(ident| u16) => `(Kind.u 16)
+| `(ident| u32) => `(Kind.u 32)
+| `(ident| u64) => `(Kind.u 64)
+| _ => throwUnsupportedSyntax
+
+#check BitVec.ofNat
+
+def mkGenericNum [Monad m] [MonadQuotation m] [MonadExceptOf Exception m] (n : TSyntax `num) :
+    TSyntax `ident → m (TSyntax `term)
+| `(ident| Field) => `($n)
+| `(ident| u1) => `(BitVec.ofNat 1 $n)
+| `(ident| u8) => `(BitVec.ofNat 8 $n)
+| `(ident| u16) => `(BitVec.ofNat 16 $n)
+| `(ident| u32) => `(BitVec.ofNat 32 $n)
+| `(ident| u64) => `(BitVec.ofNat 64 $n)
+| _ => throwUnsupportedSyntax
+
 mutual
 
 partial def mkNrType [Monad m] [MonadQuotation m] [MonadExceptOf Exception m] [MonadError m] : TSyntax `nr_type → m (TSyntax `term)
@@ -183,14 +202,12 @@ partial def mkGenericVals [Monad m] [MonadQuotation m] [MonadExceptOf Exception 
   let kinds ← mkListLit (←generics.mapM fun g =>
     match g with
     | `(nr_generic| $_:nr_type) => `(Kind.type)
-    | `(nr_generic| $_:num : type_u $w) => `(Kind.u $w)
-    | `(nr_generic| $_:num : type_fp) => `(Kind.field)
+    | `(nr_generic| $_:num : $t) => do `($(← matchGenericDefs t))
     | _ => throwUnsupportedSyntax)
   let vals ← mkHListLit (←generics.mapM fun g =>
     match g with
     | `(nr_generic| $t:nr_type) => (mkNrType t)
-    | `(nr_generic| $n:num : type_u $w) => `(BitVec.ofNat $w $n)
-    | `(nr_generic| $n:num : type_fp) => `($n)
+    | `(nr_generic| $n:num : $t:ident) => do `($(← mkGenericNum n t))
     | _ => throwUnsupportedSyntax)
   pure (kinds, vals)
 
@@ -201,14 +218,12 @@ def mkGenericDefs [Monad m] [MonadQuotation m] [MonadExceptOf Exception m] [Mona
   let kinds ← mkListLit (←generics.mapM fun g =>
     match g with
     | `(nr_generic_def| $_:ident) => `(Kind.type)
-    | `(nr_generic_def| @ $_:ident : type_u $w) => `(Kind.u $w)
-    | `(nr_generic_def| @ $_:ident : type_fp) => `(Kind.field)
+    | `(nr_generic_def| @ $_:ident : $t:ident) => do `($(← matchGenericDefs t))
     | _ => throwUnsupportedSyntax)
   let vals ← mkHListLit (←generics.mapM fun g =>
     match g with
     | `(nr_generic_def| $i:ident) => `($i)
-    | `(nr_generic_def| @ $i:ident : type_u $_) => `($i)
-    | `(nr_generic_def| @ $i:ident : type_fp) => `($i)
+    | `(nr_generic_def| @ $i:ident : $_:ident) => `($i)
     | _ => throwUnsupportedSyntax)
   pure (kinds, vals)
 

--- a/Lampe/Lampe/Tactic/Steps.lean
+++ b/Lampe/Lampe/Tactic/Steps.lean
@@ -140,7 +140,7 @@ def tryApplySyntaxes (goal : MVarId) (lemmas : List (TSyntax `term)): TacticM (L
 | n::ns => do
   trace[Lampe.STHoare.Helpers] "trying {n}"
   try
-    evalTacticAt (←`(tactic|apply $n)) goal
+    evalTacticAt (←`(tactic|with_unfolding_all apply $n)) goal
   catch e =>
     trace[Lampe.STHoare.Helpers] "failed {n} with {e.toMessageData}"
     tryApplySyntaxes goal ns

--- a/Lampe/Lampe/Tactic/Steps.lean
+++ b/Lampe/Lampe/Tactic/Steps.lean
@@ -43,7 +43,8 @@ def getClosingTerm (val : Expr) : TacticM (Option (TSyntax `term × Bool)) := wi
     match n with
     | ``Expr.skip => return some (←``(skip_intro), true)
     | ``Expr.var => return some (←``(var_intro), true)
-    | ``Lampe.Expr.const => return some (←``(const_intro), true)
+    | ``Lampe.Expr.constU => return some (←``(constU_intro), true)
+    | ``Lampe.Expr.constFp => return some (←``(constFp_intro), true)
     | ``Lampe.Expr.lam => return some (←``(lam_intro), false)
     | ``Expr.mkTuple => return some (←``(genericTotalPureBuiltin_intro (a := (_,_)) Builtin.mkTuple rfl), true)
     | ``Expr.mkArray =>

--- a/Lampe/Lampe/Tp.lean
+++ b/Lampe/Lampe/Tp.lean
@@ -96,7 +96,7 @@ instance : DecidableEq Tp := tpDecEq
 @[reducible]
 def Kind.denote : Kind → Type
 | .u w  => U w
-| .field => {p : Prime} → Fp p
+| .field => Int
 | .type => Tp
 
 inductive FuncRef (argTps : List Tp) (outTp : Tp) where

--- a/Lampe/Lampe/Tp.lean
+++ b/Lampe/Lampe/Tp.lean
@@ -28,6 +28,7 @@ inductive Tp where
 
 inductive Kind where
 | u (size : Nat)
+| field
 | type
 
 mutual
@@ -95,6 +96,7 @@ instance : DecidableEq Tp := tpDecEq
 @[reducible]
 def Kind.denote : Kind → Type
 | .u w  => U w
+| .field => {p : Prime} → Fp p
 | .type => Tp
 
 inductive FuncRef (argTps : List Tp) (outTp : Tp) where

--- a/Lampe/Tests/FieldGenerics.lean
+++ b/Lampe/Tests/FieldGenerics.lean
@@ -7,12 +7,12 @@ nr_def «A»<>() -> Field {
 }
 
 
-nr_def «foo»<@A : type_fp>() -> Field {
+nr_def «foo»<@A : Field>() -> Field {
     f@A
 }
 
 nr_def «test»<>() -> Field {
-    let a = (@foo<4294967297 : type_fp> as λ() → Field)();
+    let a = (@foo<4294967297 : Field> as λ() → Field)();
     a
 }
 

--- a/Lampe/Tests/FieldGenerics.lean
+++ b/Lampe/Tests/FieldGenerics.lean
@@ -1,0 +1,25 @@
+import Lampe
+
+open Lampe
+
+nr_def «A»<>() -> Field {
+    4294967297 : Field
+}
+
+nr_def «B»<>() -> u32 {
+    19 : u32
+}
+
+nr_def «foo»<@A : type_fp>() -> Field {
+    f@A
+}
+
+nr_def «foo2»<@B : type_u 32>() -> u32 {
+    u@B
+}
+
+nr_def «test»<>() -> Unit {
+    -- let a = (@foo<4294967297 : type_fp> as λ() → Field)();
+    -- let b = (@foo2<19 : type_u 32> as λ() → u32)();
+}
+

--- a/Lampe/Tests/FieldGenerics.lean
+++ b/Lampe/Tests/FieldGenerics.lean
@@ -6,20 +6,12 @@ nr_def «A»<>() -> Field {
     4294967297 : Field
 }
 
-nr_def «B»<>() -> u32 {
-    19 : u32
-}
-
 nr_def «foo»<@A : type_fp>() -> Field {
     f@A
 }
 
-nr_def «foo2»<@B : type_u 32>() -> u32 {
-    u@B
-}
-
-nr_def «test»<>() -> Unit {
-    -- let a = (@foo<4294967297 : type_fp> as λ() → Field)();
-    -- let b = (@foo2<19 : type_u 32> as λ() → u32)();
+nr_def «test»<>() -> Field {
+    let a = (@foo<4294967297 : type_fp> as λ() → Field)();
+    a
 }
 

--- a/Lampe/Tests/FieldGenerics.lean
+++ b/Lampe/Tests/FieldGenerics.lean
@@ -33,14 +33,7 @@ lemma foo_intro : STHoare p env ⟦⟧ (foo.call h![gen] h![]) fun output => out
 lemma test_intro : STHoare p env ⟦⟧ (test.call h![] h![]) fun output => output = (4294967297 : Fp p) := by
     enter_decl
     steps [A_intro, foo_intro]
-
-    apply STHoare.letIn_intro
-    enter_decl
-    steps
-
-    apply STHoare.var_intro
-    intros
-    steps
     subst_vars
     rfl
+
 

--- a/Lampe/Tests/FieldGenerics.lean
+++ b/Lampe/Tests/FieldGenerics.lean
@@ -6,6 +6,7 @@ nr_def «A»<>() -> Field {
     4294967297 : Field
 }
 
+
 nr_def «foo»<@A : type_fp>() -> Field {
     f@A
 }
@@ -14,4 +15,32 @@ nr_def «test»<>() -> Field {
     let a = (@foo<4294967297 : type_fp> as λ() → Field)();
     a
 }
+
+def env := Lampe.Env.mk [«A», «foo», «test»] []
+
+lemma A_intro : STHoare p env ⟦⟧ (A.call h![] h![]) fun output => output = (4294967297 : Fp p) := by
+    enter_decl
+    steps
+    subst_vars
+    rfl
+
+lemma foo_intro : STHoare p env ⟦⟧ (foo.call h![gen] h![]) fun output => output = (gen : Fp p) := by
+    enter_decl
+    steps [A_intro]
+    subst_vars
+    rfl
+
+lemma test_intro : STHoare p env ⟦⟧ (test.call h![] h![]) fun output => output = (4294967297 : Fp p) := by
+    enter_decl
+    steps [A_intro, foo_intro]
+
+    apply STHoare.letIn_intro
+    enter_decl
+    steps
+
+    apply STHoare.var_intro
+    intros
+    steps
+    subst_vars
+    rfl
 

--- a/Lampe/Tests/Tests.lean
+++ b/Lampe/Tests/Tests.lean
@@ -438,7 +438,7 @@ nr_def fmtstr_test<>() -> Field {
   y
 }
 
-nr_def create_arr<@N : type_u 32>() -> [Field; N] {
+nr_def create_arr<@N : u32>() -> [Field; N] {
   [1 : Field ; N]
 }
 
@@ -448,9 +448,9 @@ example : STHoare p Γ ⟦⟧ (create_arr.fn.body _ h![3] |>.body h![])
   steps
   aesop
 
-nr_type_alias Array<T, @N : type_u 32> = [T; N]
+nr_type_alias Array<T, @N : u32> = [T; N]
 
-nr_def alias_test<>(x : @Array<Field, 3 : type_u 32>) -> Field {
+nr_def alias_test<>(x : @Array<Field, 3 : u32>) -> Field {
   x[1 : u32]
 }
 
@@ -460,7 +460,7 @@ example : STHoare p Γ ⟦⟧ (alias_test.fn.body _ h![] |>.body h![⟨[1, 2, 3]
   steps
   aesop
 
-nr_def const_test<@N : type_u 8>(x : Field) -> Field {
+nr_def const_test<@N : u8>(x : Field) -> Field {
   let mut res = x;
   for _? in 0 : u8 .. u@N {
     res = #fMul(res, 2 : Field) : Field;

--- a/Lampe/Tests/Tests.lean
+++ b/Lampe/Tests/Tests.lean
@@ -438,7 +438,7 @@ nr_def fmtstr_test<>() -> Field {
   y
 }
 
-nr_def create_arr<@N : 32>() -> [Field; N] {
+nr_def create_arr<@N : type_u 32>() -> [Field; N] {
   [1 : Field ; N]
 }
 
@@ -448,9 +448,9 @@ example : STHoare p Γ ⟦⟧ (create_arr.fn.body _ h![3] |>.body h![])
   steps
   aesop
 
-nr_type_alias Array<T, @N : 32> = [T; N]
+nr_type_alias Array<T, @N : type_u 32> = [T; N]
 
-nr_def alias_test<>(x : @Array<Field, 3 : 32>) -> Field {
+nr_def alias_test<>(x : @Array<Field, 3 : type_u 32>) -> Field {
   x[1 : u32]
 }
 
@@ -460,9 +460,9 @@ example : STHoare p Γ ⟦⟧ (alias_test.fn.body _ h![] |>.body h![⟨[1, 2, 3]
   steps
   aesop
 
-nr_def const_test<@N : 8>(x : Field) -> Field {
+nr_def const_test<@N : type_u 8>(x : Field) -> Field {
   let mut res = x;
-  for _? in 0 : u8 .. @N {
+  for _? in 0 : u8 .. u@N {
     res = #fMul(res, 2 : Field) : Field;
   };
   res;

--- a/src/lean/builtin.rs
+++ b/src/lean/builtin.rs
@@ -1,9 +1,9 @@
 use std::ops::Deref;
 
 use noirc_frontend::{
+    Type, TypeBinding,
     ast::BinaryOpKind,
     ast::{IntegerBitSize, Signedness, UnaryOp},
-    Type, TypeBinding,
 };
 
 pub type BuiltinName = String;

--- a/src/lean/context.rs
+++ b/src/lean/context.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use noirc_frontend::{hir::def_map::ModuleData, node_interner::NodeInterner, Type};
+use noirc_frontend::{Type, hir::def_map::ModuleData, node_interner::NodeInterner};
 
 pub struct EmitterCtx {
     // Maps an impl parameter type to a type variable name.

--- a/src/lean/pattern.rs
+++ b/src/lean/pattern.rs
@@ -1,10 +1,10 @@
 use noirc_frontend::{
+    Type,
     ast::Ident,
     hir_def::{expr::HirIdent, stmt::HirPattern},
-    Type,
 };
 
-use super::{context::EmitterCtx, LeanEmitter};
+use super::{LeanEmitter, context::EmitterCtx};
 
 #[derive(Clone, Debug)]
 enum PatType {

--- a/src/lean/syntax.rs
+++ b/src/lean/syntax.rs
@@ -52,7 +52,7 @@ pub(super) fn format_trait_impl(
 ) -> String {
     formatdoc! {
         "nr_trait_impl[{impl_id}] <{impl_generics}> {trait_name}<{trait_generics}> for {target} where {trait_constraints} {{
-                {methods} 
+                {methods}
             }}"
     }
 }
@@ -67,14 +67,11 @@ pub(super) fn format_free_function_def(
 ) -> (String, String) {
     let func_ident = normalize_ident(func_ident);
     let escaped_func_ident = escape_ident(&func_ident);
-    (
-        func_ident.clone(),
-        formatdoc! {
-            r"nr_def {escaped_func_ident}<{def_generics}>({params}) -> {ret_type} {{
+    (func_ident.clone(), formatdoc! {
+        r"nr_def {escaped_func_ident}<{def_generics}>({params}) -> {ret_type} {{
             {body}
             }}"
-        },
-    )
+    })
 }
 
 #[inline]
@@ -95,9 +92,13 @@ pub(super) fn format_trait_function_def(
 }
 
 #[inline]
-pub(super) fn format_generic_def(name: &str, u_size: Option<u8>) -> String {
-    if let Some(w) = u_size {
-        format!("@{name} : {w}")
+pub(super) fn format_generic_def(name: &str, is_num: bool, u_size: Option<u8>) -> String {
+    if is_num {
+        if let Some(w) = u_size {
+            format!("@{name} : type_u {w}")
+        } else {
+            format!("@{name} : type_fp")
+        }
     } else {
         format!("{name}")
     }
@@ -111,11 +112,7 @@ pub(super) fn format_alias(alias_name: &str, generics: &str, typ: &str) -> Strin
 pub(super) mod literal {
     #[inline]
     pub fn format_bool(v: bool) -> String {
-        if v {
-            format!("true")
-        } else {
-            format!("false")
-        }
+        if v { format!("true") } else { format!("false") }
     }
 
     #[inline]
@@ -198,8 +195,13 @@ pub(super) mod r#type {
     }
 
     #[inline]
-    pub fn format_const(ident: &str, size: &str) -> String {
-        format!("{ident} : {size}")
+    pub fn format_uint_const(ident: &str, size: &str) -> String {
+        format!("{ident} : type_u {size}")
+    }
+
+    #[inline]
+    pub fn format_field_const(ident: &str) -> String {
+        format!("{ident} : type_fp")
     }
 }
 
@@ -317,9 +319,15 @@ pub(super) mod expr {
     }
 
     #[inline]
-    pub fn format_const(ident: &str) -> String {
+    pub fn format_uint_const(ident: &str) -> String {
         let var = normalize_ident(ident);
-        format!("@{var}")
+        format!("u@{var}")
+    }
+
+    #[inline]
+    pub fn format_field_const(ident: &str) -> String {
+        let var = normalize_ident(ident);
+        format!("f@{var}")
     }
 
     #[inline]

--- a/src/lean/syntax.rs
+++ b/src/lean/syntax.rs
@@ -67,11 +67,14 @@ pub(super) fn format_free_function_def(
 ) -> (String, String) {
     let func_ident = normalize_ident(func_ident);
     let escaped_func_ident = escape_ident(&func_ident);
-    (func_ident.clone(), formatdoc! {
-        r"nr_def {escaped_func_ident}<{def_generics}>({params}) -> {ret_type} {{
+    (
+        func_ident.clone(),
+        formatdoc! {
+            r"nr_def {escaped_func_ident}<{def_generics}>({params}) -> {ret_type} {{
             {body}
             }}"
-    })
+        },
+    )
 }
 
 #[inline]
@@ -95,9 +98,9 @@ pub(super) fn format_trait_function_def(
 pub(super) fn format_generic_def(name: &str, is_num: bool, u_size: Option<u8>) -> String {
     if is_num {
         if let Some(w) = u_size {
-            format!("@{name} : type_u {w}")
+            format!("@{name} : u{w}")
         } else {
-            format!("@{name} : type_fp")
+            format!("@{name} : Field")
         }
     } else {
         format!("{name}")
@@ -112,7 +115,11 @@ pub(super) fn format_alias(alias_name: &str, generics: &str, typ: &str) -> Strin
 pub(super) mod literal {
     #[inline]
     pub fn format_bool(v: bool) -> String {
-        if v { format!("true") } else { format!("false") }
+        if v {
+            format!("true")
+        } else {
+            format!("false")
+        }
     }
 
     #[inline]
@@ -196,12 +203,12 @@ pub(super) mod r#type {
 
     #[inline]
     pub fn format_uint_const(ident: &str, size: &str) -> String {
-        format!("{ident} : type_u {size}")
+        format!("{ident} : u{size}")
     }
 
     #[inline]
     pub fn format_field_const(ident: &str) -> String {
-        format!("{ident} : type_fp")
+        format!("{ident} : Field")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,12 +360,11 @@ mod test {
         print_result(
             r#"
             global A: Field = 4294967297;
-            global U: u32 = 19;
+
             fn foo<let A: Field>() -> Field { A }
-            fn foo2<let B: u32>() -> u32 { B }
+
             fn main() {
                 let _ = foo::<A>();
-                let _ = foo2::<U>();
             }
             "#,
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,4 +354,20 @@ mod test {
         "#,
         )
     }
+
+    #[test]
+    fn field_generics() -> anyhow::Result<()> {
+        print_result(
+            r#"
+            global A: Field = 4294967297;
+            global U: u32 = 19;
+            fn foo<let A: Field>() -> Field { A }
+            fn foo2<let B: u32>() -> u32 { B }
+            fn main() {
+                let _ = foo::<A>();
+                let _ = foo2::<U>();
+            }
+            "#,
+        )
+    }
 }

--- a/src/noir/project.rs
+++ b/src/noir/project.rs
@@ -7,7 +7,7 @@ use std::{
 
 use fm::{FileId, FileManager};
 use nargo::parse_all;
-use noirc_driver::{check_crate, file_manager_with_stdlib, prepare_crate, CompileOptions};
+use noirc_driver::{CompileOptions, check_crate, file_manager_with_stdlib, prepare_crate};
 use noirc_frontend::hir::Context;
 
 use crate::{
@@ -16,7 +16,7 @@ use crate::{
         file::{Error as FileError, Result as FileResult},
     },
     lean::LeanEmitter,
-    noir::{source::Source, WithWarnings},
+    noir::{WithWarnings, source::Source},
 };
 
 /// A type for file identifiers that are known to the extraction process.
@@ -128,16 +128,12 @@ impl Project {
         let root_crate = prepare_crate(&mut context, &self.project_root.join(root_path).as_path());
 
         // Perform compilation to check the code within it.
-        let ((), warnings) = check_crate(
-            &mut context,
-            root_crate,
-            &CompileOptions {
-                deny_warnings: false,
-                disable_macros: false,
-                debug_comptime_in_file: None,
-                ..Default::default()
-            },
-        )
+        let ((), warnings) = check_crate(&mut context, root_crate, &CompileOptions {
+            deny_warnings: false,
+            disable_macros: false,
+            debug_comptime_in_file: None,
+            ..Default::default()
+        })
         .map_err(|diagnostics| CompileError::CheckFailure { diagnostics })?;
 
         Ok(WithWarnings::new(


### PR DESCRIPTION
This PR adds generic field elements.

Small notes associated with the PR:

* Notation for unsigned int generics was changed from just the bit-width `w` to `type_u w`
* Added notation for generic field elements as `type_fp`
* Numeric consts now have different notation depending on the type. `f@A` for `A : type_fp` and `u@B` for `B : type_u w`
* I also ran `cargo fmt` to normalize the rust formatting and prevent errant formatting diffs in future PRs (it may be worth adding this to CI in the future)

Small TODO: 
* The proof of the final lemma in `Lampe/Tests/FieldGenerics.lean` is a tad bit messy (`steps` was not able to finish the proof automatically), so it may be worth looking at why.