### PR TITLE
Rust cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,12 @@ jobs:
           run: |
             export RUST_MIN_STACK=16777216;  # 16 MB
             cargo test --all
+        - name: Format (rustfmt)
+          working-directory: lampe
+          run: cargo fmt --check
+        - name: Lint (clippy)
+          working-directory: lampe
+          run: RUSTFLAGS="-Dwarnings" cargo clippy
     end-to-end:
       needs: [build-lake, build-cargo]
       runs-on: ubuntu-latest

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.85"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -13,7 +13,7 @@ use std::{fs, fs::OpenOptions, io::Write, panic, path::PathBuf, process::ExitCod
 
 use clap::{arg, Parser};
 use lampe::{
-    error::{emit, Error},
+    error::{emit, file, Error},
     noir::source::Source,
     noir_to_lean, Project, Result,
 };
@@ -69,11 +69,31 @@ fn main() -> ExitCode {
     }
 }
 
+/// A particular testing mode for the main function used to run through Noir frontend tests
+///
+/// # Errors
+///
+/// - [`Error`] If the source directory is not readable
 pub fn run_test_mode(args: &ProgramOptions) -> Result<ExitCode> {
-    let list = fs::read_dir(&args.root).unwrap();
+    let list = fs::read_dir(&args.root).map_err(|_| {
+        file::Error::Other(format!(
+            "Unable to read directory {:?}",
+            args.root.as_os_str()
+        ))
+    })?;
     for entry in list {
-        let entry = entry.unwrap();
-        if !entry.metadata().unwrap().is_dir() {
+        let entry =
+            entry.map_err(|err| file::Error::Other(format!("Unable to read entry: {err:?}")))?;
+        if !entry
+            .metadata()
+            .map_err(|_| {
+                file::Error::Other(format!(
+                    "Unable to read metadata of {:?}",
+                    entry.file_name()
+                ))
+            })?
+            .is_dir()
+        {
             continue;
         }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -11,13 +11,11 @@
 
 use std::{fs, fs::OpenOptions, io::Write, panic, path::PathBuf, process::ExitCode};
 
-use clap::{Parser, arg};
+use clap::{arg, Parser};
 use lampe::{
-    Project,
-    Result,
-    error::{Error, emit},
+    error::{emit, Error},
     noir::source::Source,
-    noir_to_lean,
+    noir_to_lean, Project, Result,
 };
 
 /// The default Noir project path for the CLI to extract from.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -11,11 +11,12 @@
 
 use std::{fs, fs::OpenOptions, io::Write, panic, path::PathBuf, process::ExitCode};
 
-use clap::{arg, Parser};
+use clap::{Parser, arg};
 use lampe::{
-    error::{emit, file, Error},
+    Project, Result,
+    error::{Error, emit, file},
     noir::source::Source,
-    noir_to_lean, Project, Result,
+    noir_to_lean,
 };
 
 /// The default Noir project path for the CLI to extract from.

--- a/src/error/emit.rs
+++ b/src/error/emit.rs
@@ -19,4 +19,7 @@ pub enum Error {
 
     #[error("Unsupported feature {_0}")]
     UnsupportedFeature(String),
+
+    #[error("Unexpected type: type of {_0} must be {_1}")]
+    UnexpectedType(String, String),
 }

--- a/src/lean/builtin.rs
+++ b/src/lean/builtin.rs
@@ -1,9 +1,9 @@
 use std::ops::Deref;
 
 use noirc_frontend::{
-    Type, TypeBinding,
     ast::BinaryOpKind,
     ast::{IntegerBitSize, Signedness, UnaryOp},
+    Type, TypeBinding,
 };
 
 pub type BuiltinName = String;

--- a/src/lean/builtin.rs
+++ b/src/lean/builtin.rs
@@ -1,7 +1,7 @@
 use noirc_frontend::{
+    Type, TypeBinding,
     ast::BinaryOpKind,
     ast::{IntegerBitSize, Signedness, UnaryOp},
-    Type, TypeBinding,
 };
 
 pub type BuiltinName = String;

--- a/src/lean/builtin.rs
+++ b/src/lean/builtin.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use noirc_frontend::{
     ast::BinaryOpKind,
     ast::{IntegerBitSize, Signedness, UnaryOp},
@@ -49,9 +47,9 @@ impl TryInto<BuiltinType> for Type {
             Type::Array(_, _) => Ok(BuiltinType::Array),
             Type::Slice(_) => Ok(BuiltinType::Slice),
             Type::String(_) => Ok(BuiltinType::String),
-            Type::TypeVariable(tv) => match tv.borrow().deref() {
+            Type::TypeVariable(tv) => match &*tv.borrow() {
                 TypeBinding::Bound(ty) => TryInto::<BuiltinType>::try_into(ty.clone()),
-                _ => Err(format!("unbound type variable `{tv:?}`")),
+                TypeBinding::Unbound(..) => Err(format!("unbound type variable `{tv:?}`")),
             },
             _ => Err(format!("unknown builtin type `{self:?}`")),
         }
@@ -59,41 +57,35 @@ impl TryInto<BuiltinType> for Type {
 }
 
 impl BuiltinType {
-    fn is_arithmetic(&self) -> bool {
-        match self {
-            BuiltinType::Field
-            | BuiltinType::Uint(_)
-            | BuiltinType::Int(_)
-            | BuiltinType::BigInt => true,
-            _ => false,
-        }
+    fn is_arithmetic(self) -> bool {
+        matches!(
+            self,
+            BuiltinType::Field | BuiltinType::Uint(_) | BuiltinType::Int(_) | BuiltinType::BigInt
+        )
     }
 
-    fn is_bitwise(&self) -> bool {
-        match self {
-            BuiltinType::Bool | BuiltinType::Uint(_) | BuiltinType::Int(_) => true,
-            _ => false,
-        }
+    fn is_bitwise(self) -> bool {
+        matches!(
+            self,
+            BuiltinType::Bool | BuiltinType::Uint(_) | BuiltinType::Int(_)
+        )
     }
 
-    fn is_collection(&self) -> bool {
-        match self {
-            BuiltinType::Array | BuiltinType::Slice => true,
-            _ => false,
-        }
+    fn is_collection(self) -> bool {
+        matches!(self, BuiltinType::Array | BuiltinType::Slice)
     }
 
-    fn name_prefix(&self) -> String {
+    fn name_prefix(self) -> String {
         match self {
-            BuiltinType::Field => format!("f"),
-            BuiltinType::Uint(_) => format!("u"),
-            BuiltinType::Int(_) => format!("i"),
-            BuiltinType::BigInt => format!("bigInt"),
-            BuiltinType::Bool => format!("b"),
-            BuiltinType::Unit => format!("unit"),
-            BuiltinType::Array => format!("array"),
-            BuiltinType::Slice => format!("slice"),
-            BuiltinType::String => format!("str"),
+            BuiltinType::Field => "f".to_string(),
+            BuiltinType::Uint(_) => "u".to_string(),
+            BuiltinType::Int(_) => "i".to_string(),
+            BuiltinType::BigInt => "bigInt".to_string(),
+            BuiltinType::Bool => "b".to_string(),
+            BuiltinType::Unit => "unit".to_string(),
+            BuiltinType::Array => "array".to_string(),
+            BuiltinType::Slice => "slice".to_string(),
+            BuiltinType::String => "str".to_string(),
         }
     }
 }
@@ -120,7 +112,7 @@ pub fn try_func_expr_into_builtin_name(func_expr: &str) -> Option<BuiltinName> {
 pub fn get_index_builtin_name(coll_type: BuiltinType) -> Option<BuiltinName> {
     if coll_type.is_collection() {
         let ty_name = coll_type.name_prefix();
-        Some(format!("{}Index", ty_name))
+        Some(format!("{ty_name}Index"))
     } else {
         None
     }
@@ -134,13 +126,13 @@ pub fn try_prefix_into_builtin_name(
     let rhs_ty_prefix = rhs_type.map(|ty| (ty, ty.name_prefix()));
     match (op, rhs_ty_prefix) {
         (UnaryOp::Minus, Some((rhs_type, prefix))) if rhs_type.is_arithmetic() => {
-            Some(format!("{}Neg", prefix))
+            Some(format!("{prefix}Neg"))
         }
         (UnaryOp::Not, Some((rhs_type, prefix))) if rhs_type.is_bitwise() => {
-            Some(format!("{}Not", prefix))
+            Some(format!("{prefix}Not"))
         }
-        (UnaryOp::MutableReference, _) => Some(format!("ref")),
-        (UnaryOp::Dereference { .. }, _) => Some(format!("readRef")),
+        (UnaryOp::MutableReference, _) => Some("ref".to_string()),
+        (UnaryOp::Dereference { .. }, _) => Some("readRef".to_string()),
         _ => None,
     }
 }
@@ -153,24 +145,24 @@ pub fn try_infix_into_builtin_name(
     let ty_name = lhs_type.name_prefix();
     match op {
         // Arithmetic
-        BinaryOpKind::Add if lhs_type.is_arithmetic() => Some(format!("{}Add", ty_name)),
-        BinaryOpKind::Subtract if lhs_type.is_arithmetic() => Some(format!("{}Sub", ty_name)),
-        BinaryOpKind::Divide if lhs_type.is_arithmetic() => Some(format!("{}Div", ty_name)),
-        BinaryOpKind::Multiply if lhs_type.is_arithmetic() => Some(format!("{}Mul", ty_name)),
-        BinaryOpKind::Modulo if lhs_type.is_arithmetic() => Some(format!("{}Rem", ty_name)),
+        BinaryOpKind::Add if lhs_type.is_arithmetic() => Some(format!("{ty_name}Add")),
+        BinaryOpKind::Subtract if lhs_type.is_arithmetic() => Some(format!("{ty_name}Sub")),
+        BinaryOpKind::Divide if lhs_type.is_arithmetic() => Some(format!("{ty_name}Div")),
+        BinaryOpKind::Multiply if lhs_type.is_arithmetic() => Some(format!("{ty_name}Mul")),
+        BinaryOpKind::Modulo if lhs_type.is_arithmetic() => Some(format!("{ty_name}Rem")),
         // Cmp
-        BinaryOpKind::Equal => Some(format!("{}Eq", ty_name)),
-        BinaryOpKind::NotEqual => Some(format!("{}Neq", ty_name)),
-        BinaryOpKind::Greater if lhs_type.is_arithmetic() => Some(format!("{}Gt", ty_name)),
-        BinaryOpKind::GreaterEqual if lhs_type.is_arithmetic() => Some(format!("{}Geq", ty_name)),
-        BinaryOpKind::Less if lhs_type.is_arithmetic() => Some(format!("{}Lt", ty_name)),
-        BinaryOpKind::LessEqual if lhs_type.is_arithmetic() => Some(format!("{}Leq", ty_name)),
+        BinaryOpKind::Equal => Some(format!("{ty_name}Eq")),
+        BinaryOpKind::NotEqual => Some(format!("{ty_name}Neq")),
+        BinaryOpKind::Greater if lhs_type.is_arithmetic() => Some(format!("{ty_name}Gt")),
+        BinaryOpKind::GreaterEqual if lhs_type.is_arithmetic() => Some(format!("{ty_name}Geq")),
+        BinaryOpKind::Less if lhs_type.is_arithmetic() => Some(format!("{ty_name}Lt")),
+        BinaryOpKind::LessEqual if lhs_type.is_arithmetic() => Some(format!("{ty_name}Leq")),
         // Bit
-        BinaryOpKind::And if lhs_type.is_bitwise() => Some(format!("{}And", ty_name)),
-        BinaryOpKind::Or if lhs_type.is_bitwise() => Some(format!("{}Or", ty_name)),
-        BinaryOpKind::Xor if lhs_type.is_bitwise() => Some(format!("{}Xor", ty_name)),
-        BinaryOpKind::ShiftLeft if lhs_type.is_bitwise() => Some(format!("{}Shl", ty_name)),
-        BinaryOpKind::ShiftRight if lhs_type.is_bitwise() => Some(format!("{}Shr", ty_name)),
+        BinaryOpKind::And if lhs_type.is_bitwise() => Some(format!("{ty_name}And")),
+        BinaryOpKind::Or if lhs_type.is_bitwise() => Some(format!("{ty_name}Or")),
+        BinaryOpKind::Xor if lhs_type.is_bitwise() => Some(format!("{ty_name}Xor")),
+        BinaryOpKind::ShiftLeft if lhs_type.is_bitwise() => Some(format!("{ty_name}Shl")),
+        BinaryOpKind::ShiftRight if lhs_type.is_bitwise() => Some(format!("{ty_name}Shr")),
         _ => None,
     }
 }

--- a/src/lean/context.rs
+++ b/src/lean/context.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use noirc_frontend::{hir::def_map::ModuleData, node_interner::NodeInterner, Type};
+use noirc_frontend::{Type, hir::def_map::ModuleData, node_interner::NodeInterner};
 
 pub struct EmitterCtx {
     // Maps an impl parameter type to a type variable name.

--- a/src/lean/context.rs
+++ b/src/lean/context.rs
@@ -11,14 +11,7 @@ pub struct EmitterCtx {
 
 /// Returns true if and only if `typ` is an `impl` type.
 pub(super) fn is_impl(typ: &Type) -> bool {
-    match typ {
-        Type::TypeVariable(_) | Type::TraitAsType(_, _, _) | Type::NamedGeneric(_, _)
-            if typ.to_string().starts_with("impl") =>
-        {
-            true
-        }
-        _ => false,
-    }
+    matches!(typ, Type::TypeVariable(_) | Type::TraitAsType(_,_,_) | Type::NamedGeneric(_, _) if typ.to_string().starts_with("impl"))
 }
 
 impl EmitterCtx {
@@ -27,7 +20,7 @@ impl EmitterCtx {
         let mut impl_param_overrides = HashMap::new();
         let mut impl_ret_overrides = HashMap::new();
         // Get the function definitions from the module.
-        let module_fns = module.value_definitions().flat_map(|value_def| match value_def {
+        let module_fns = module.value_definitions().filter_map(|value_def| match value_def {
             noirc_frontend::hir::def_map::ModuleDefId::FunctionId(func_id) => Some(func_id),
             _ => None,
         });
@@ -65,7 +58,7 @@ impl EmitterCtx {
     }
 
     pub fn get_impl_param<'a>(&'a self, typ: &Type) -> Option<&'a str> {
-        self.impl_param_overrides.get(typ).map(|s| s.as_str())
+        self.impl_param_overrides.get(typ).map(std::string::String::as_str)
     }
 
     pub fn get_impl_return<'a>(&'a self, typ: &Type) -> Option<&'a Type> {

--- a/src/lean/context.rs
+++ b/src/lean/context.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use noirc_frontend::{Type, hir::def_map::ModuleData, node_interner::NodeInterner};
+use noirc_frontend::{hir::def_map::ModuleData, node_interner::NodeInterner, Type};
 
 pub struct EmitterCtx {
     // Maps an impl parameter type to a type variable name.

--- a/src/lean/mod.rs
+++ b/src/lean/mod.rs
@@ -14,13 +14,12 @@ use context::EmitterCtx;
 use fm::FileId;
 use itertools::Itertools;
 use noirc_frontend::{
-    Kind, ResolvedGeneric, StructField, Type, TypeBinding, TypeBindings,
     ast::{IntegerBitSize, Signedness},
     graph::CrateId,
     hir::{
-        Context,
         def_map::{ModuleData, ModuleDefId, ModuleId},
         type_check::generics::TraitGenerics,
+        Context,
     },
     hir_def::{
         expr::{HirArrayLiteral, HirExpression, HirIdent, HirLiteral},
@@ -31,14 +30,15 @@ use noirc_frontend::{
     node_interner::{
         DefinitionKind, ExprId, FuncId, GlobalId, StmtId, StructId, TraitId, TypeAliasId,
     },
+    Kind, ResolvedGeneric, StructField, Type, TypeBinding, TypeBindings,
 };
 
+use crate::error::emit::Error::UnsupportedFeature;
 use crate::{
     error::emit::{Error, Result},
     lean::{indent::Indenter, syntax::expr::format_builtin_call},
     noir::project::KnownFiles,
 };
-use crate::error::emit::Error::UnsupportedFeature;
 
 #[derive(PartialEq, Eq, Clone, Hash)]
 pub enum EmitOutput {
@@ -257,7 +257,7 @@ impl LeanEmitter {
                 ModuleDefId::TypeId(id) => EmitOutput::Struct(self.emit_struct_def(ind, id, &ctx)?),
                 ModuleDefId::TypeAliasId(id) => EmitOutput::Alias(self.emit_alias(id, &ctx)?),
                 ModuleDefId::ModuleId(_) => {
-                   return Err(UnsupportedFeature("modules".to_string()));
+                    return Err(UnsupportedFeature("modules".to_string()));
                 }
                 // Skip the trait definitions.
                 ModuleDefId::TraitId(_) => continue,
@@ -871,8 +871,10 @@ impl LeanEmitter {
                 Box::new(self.substitute_bindings(env, bindings)),
                 *unconstrained,
             ),
-            Type::TraitAsType(id, name, generics) => {
-                Type::TraitAsType(id.clone(), name.clone(), TraitGenerics {
+            Type::TraitAsType(id, name, generics) => Type::TraitAsType(
+                id.clone(),
+                name.clone(),
+                TraitGenerics {
                     ordered: generics
                         .ordered
                         .iter()
@@ -886,8 +888,8 @@ impl LeanEmitter {
                             typ: self.substitute_bindings(&t.typ, bindings),
                         })
                         .collect(),
-                })
-            }
+                },
+            ),
             Type::MutableReference(t) => {
                 Type::MutableReference(Box::new(self.substitute_bindings(t, bindings)))
             }

--- a/src/lean/mod.rs
+++ b/src/lean/mod.rs
@@ -5,10 +5,7 @@ pub mod indent;
 mod pattern;
 mod syntax;
 
-use std::{
-    collections::{HashMap, HashSet},
-    ops::Deref,
-};
+use std::collections::{HashMap, HashSet};
 
 use context::EmitterCtx;
 use fm::FileId;
@@ -33,7 +30,7 @@ use noirc_frontend::{
     Kind, ResolvedGeneric, StructField, Type, TypeBinding, TypeBindings,
 };
 
-use crate::error::emit::Error::UnsupportedFeature;
+use crate::error::{self, emit::Error::UnsupportedFeature};
 use crate::{
     error::emit::{Error, Result},
     lean::{indent::Indenter, syntax::expr::format_builtin_call},
@@ -50,6 +47,7 @@ pub enum EmitOutput {
 }
 
 impl EmitOutput {
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         match self {
             EmitOutput::Struct(s)
@@ -71,14 +69,14 @@ impl EmitOutput {
     }
 }
 
-impl ToString for EmitOutput {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for EmitOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             EmitOutput::Struct(s)
             | EmitOutput::Function(s)
             | EmitOutput::Global(s)
             | EmitOutput::TraitImpl(s)
-            | EmitOutput::Alias(s) => s.to_string(),
+            | EmitOutput::Alias(s) => write!(f, "{s}"),
         }
     }
 }
@@ -107,6 +105,128 @@ pub struct LeanEmitter {
 
     /// The identifier for the root crate in the Noir compilation context.
     root_crate: CrateId,
+}
+
+/// Collects the named generics from a type recursively.
+#[must_use]
+pub fn collect_named_generics(typ: &Type) -> Vec<String> {
+    match typ {
+        Type::Array(inner_type, _)
+        | Type::Slice(inner_type)
+        | Type::MutableReference(inner_type) => collect_named_generics(inner_type),
+        Type::Tuple(elems) => elems.iter().flat_map(collect_named_generics).collect_vec(),
+        Type::Struct(_, generics)
+        | Type::TraitAsType(
+            _,
+            _,
+            TraitGenerics {
+                ordered: generics, ..
+            },
+        ) => generics.iter().flat_map(collect_named_generics).collect_vec(),
+        Type::Bool
+        | Type::Integer(..)
+        | Type::String(..)
+        | Type::FmtString(..)
+        | Type::Unit
+        | Type::FieldElement => Vec::new(),
+        Type::NamedGeneric(..) => Vec::from([format!("{typ}")]),
+        _ => unimplemented!("cannot collect named generics from {typ} (yet)"),
+    }
+}
+
+#[must_use]
+fn emit_numeric_type_const(typ: &Type) -> String {
+    match typ {
+        Type::TypeVariable(tv) => match &*tv.borrow() {
+            TypeBinding::Bound(b) => {
+                let b = b.follow_bindings();
+                emit_numeric_type_const(&b)
+            }
+            TypeBinding::Unbound(..) => format!("{typ}"),
+        },
+        Type::Constant(num, Kind::Numeric(_)) => format!("{num}"),
+
+        _ => format!("{typ}"),
+    }
+}
+///
+/// Given a type `T` and a `TypeBindings` map `m`, returns a new type where
+/// the type variables in `T` have been recursively substituted with the
+/// values in `m`.
+#[must_use]
+fn substitute_bindings(typ: &Type, bindings: &TypeBindings) -> Type {
+    match typ {
+        Type::TypeVariable(tv) | Type::NamedGeneric(tv, _) => bindings
+            .get(&tv.id())
+            .map(|(_, _, t)| t)
+            .cloned()
+            .unwrap_or(typ.clone()),
+        Type::Array(n, e) => Type::Array(
+            Box::new(substitute_bindings(n.as_ref(), bindings)),
+            Box::new(substitute_bindings(e.as_ref(), bindings)),
+        ),
+        Type::Slice(e) => Type::Slice(Box::new(substitute_bindings(e.as_ref(), bindings))),
+        Type::String(n) => Type::String(Box::new(substitute_bindings(n, bindings))),
+        Type::FmtString(n, vec) => Type::FmtString(
+            Box::new(substitute_bindings(n, bindings)),
+            Box::new(substitute_bindings(vec, bindings)),
+        ),
+        Type::Tuple(vec) => {
+            Type::Tuple(vec.iter().map(|t| substitute_bindings(t, bindings)).collect())
+        }
+        Type::Struct(def, generics) => Type::Struct(
+            def.clone(),
+            generics.iter().map(|t| substitute_bindings(t, bindings)).collect(),
+        ),
+        Type::Alias(def, generics) => Type::Alias(
+            def.clone(),
+            generics.iter().map(|t| substitute_bindings(t, bindings)).collect(),
+        ),
+        Type::Function(params, ret, env, unconstrained) => Type::Function(
+            params.iter().map(|t| substitute_bindings(t, bindings)).collect(),
+            Box::new(substitute_bindings(ret, bindings)),
+            Box::new(substitute_bindings(env, bindings)),
+            *unconstrained,
+        ),
+        Type::TraitAsType(id, name, generics) => Type::TraitAsType(
+            *id,
+            name.clone(),
+            TraitGenerics {
+                ordered: generics
+                    .ordered
+                    .iter()
+                    .map(|t| substitute_bindings(t, bindings))
+                    .collect(),
+                named: generics
+                    .named
+                    .iter()
+                    .map(|t| NamedType {
+                        name: t.name.clone(),
+                        typ: substitute_bindings(&t.typ, bindings),
+                    })
+                    .collect(),
+            },
+        ),
+        Type::MutableReference(t) => {
+            Type::MutableReference(Box::new(substitute_bindings(t, bindings)))
+        }
+        Type::Forall(tvs, t) => {
+            Type::Forall(tvs.clone(), Box::new(substitute_bindings(t, bindings)))
+        }
+        _ => typ.clone(),
+    }
+}
+///
+/// If `typ` is an alias, unfolds it until it is no longer an alias.
+#[must_use]
+fn unfold_alias(typ: Type) -> Type {
+    match typ {
+        Type::Alias(alias, generics) => {
+            let unfolded_typ = alias.borrow().get_type(&generics);
+            unfold_alias(unfolded_typ)
+        }
+        typ => typ,
+    }
 }
 
 impl LeanEmitter {
@@ -242,7 +362,7 @@ impl LeanEmitter {
                     }
                     let (def_name, def) = self.emit_free_function_def(ind, id, &ctx)?;
                     // [TODO] fix
-                    if def_name.starts_with("_") {
+                    if def_name.starts_with('_') {
                         continue;
                     }
                     func_refs.insert(format!("«{def_name}»"));
@@ -329,7 +449,7 @@ impl LeanEmitter {
                 format!("{typ_str} : {trait_str}")
             })
             .join(", ");
-        let trait_generic_vals = &trait_impl
+        let trait_generic_values = &trait_impl
             .trait_generics
             .iter()
             .map(|g| self.emit_fully_qualified_type(g, ctx))
@@ -341,10 +461,7 @@ impl LeanEmitter {
             .trait_generics
             .iter()
             // Only named generics need to be included in the `<>`.
-            .filter(|g| match g {
-                Type::NamedGeneric(..) => true,
-                _ => false,
-            })
+            .filter(|g| matches!(g, Type::NamedGeneric(..)))
             .map(|g| self.emit_fully_qualified_type(g, ctx))
             .collect_vec();
 
@@ -352,14 +469,14 @@ impl LeanEmitter {
         // Extend with the generics for the trait.
         impl_generic_decls.extend(trait_generic_vars.iter().cloned());
         // Extend with the generics for the implementor.
-        impl_generic_decls.extend(self.collect_named_generics(&trait_impl.typ));
+        impl_generic_decls.extend(collect_named_generics(&trait_impl.typ));
         let impl_generic_decls_str = impl_generic_decls.join(", ");
 
         // Emit the implemented functions.
         ind.indent();
         let mut method_strings = Vec::<String>::default();
-        for func_id in trait_impl.methods.iter() {
-            let method_string = self.emit_trait_function_def(ind, func_id.clone(), ctx)?;
+        for func_id in &trait_impl.methods {
+            let method_string = self.emit_trait_function_def(ind, *func_id, ctx)?;
             method_strings.push(method_string);
         }
         ind.dedent()?;
@@ -369,43 +486,11 @@ impl LeanEmitter {
             impl_id,
             &impl_generic_decls_str,
             &full_name,
-            &trait_generic_vals,
+            trait_generic_values,
             &target,
             &methods,
             &where_clause_str,
         ))
-    }
-
-    /// Collects the named generics from a type recursively.
-    pub fn collect_named_generics(&self, typ: &Type) -> Vec<String> {
-        match typ {
-            Type::Array(inner_type, _)
-            | Type::Slice(inner_type)
-            | Type::MutableReference(inner_type) => self.collect_named_generics(&inner_type),
-            Type::Tuple(elems) => elems
-                .iter()
-                .flat_map(|typ| self.collect_named_generics(typ))
-                .collect_vec(),
-            Type::Struct(_, generics)
-            | Type::TraitAsType(
-                _,
-                _,
-                TraitGenerics {
-                    ordered: generics, ..
-                },
-            ) => generics
-                .iter()
-                .flat_map(|g| self.collect_named_generics(g))
-                .collect_vec(),
-            Type::Bool
-            | Type::Integer(..)
-            | Type::String(..)
-            | Type::FmtString(..)
-            | Type::Unit
-            | Type::FieldElement => Vec::new(),
-            Type::NamedGeneric(..) => Vec::from([format!("{typ}")]),
-            _ => unimplemented!("cannot collect named generics from {typ} (yet)"),
-        }
     }
 
     /// Emits the Lean code corresponding to a type alias in Noir.
@@ -460,7 +545,7 @@ impl LeanEmitter {
                 ind.dedent()?;
 
                 Ok(syntax::format_free_function_def(
-                    &ident, &"", &"", &expr_type, &body,
+                    &ident, "", "", &expr_type, &body,
                 ))
             }
             _ => Err(Error::GlobalStatementNotLet),
@@ -473,7 +558,6 @@ impl LeanEmitter {
         let (is_num, u_size) = match g.kind() {
             Kind::Numeric(num_tp) => match num_tp.as_ref() {
                 Type::Integer(_, bit_size) => (true, Some(bit_size.bit_size())),
-                Type::FieldElement => (true, None),
                 _ => (true, None),
             },
             _ => (false, None),
@@ -511,7 +595,7 @@ impl LeanEmitter {
                 let typ = &field.typ;
                 ind.run(format!(
                     "{name} : {typ}",
-                    typ = self.emit_fully_qualified_type(&typ, ctx)
+                    typ = self.emit_fully_qualified_type(typ, ctx)
                 ))
             })
             .collect_vec();
@@ -556,8 +640,8 @@ impl LeanEmitter {
         let impl_generics = func_meta
             .parameters
             .iter()
-            .flat_map(|(_, ty, _)| ctx.get_impl_param(ty))
-            .map(|var| var.to_string());
+            .filter_map(|(_, ty, _)| ctx.get_impl_param(ty))
+            .map(std::string::ToString::to_string);
         let generics_string = func_meta
             .all_generics
             .iter()
@@ -572,7 +656,7 @@ impl LeanEmitter {
         // Generate the function body ready for insertion
         ind.indent();
         let body = if is_unconstrained {
-            ind.run(format_builtin_call("fresh".to_string(), "", &ret_type))
+            ind.run(format_builtin_call(&"fresh".into(), "", &ret_type))
         } else {
             self.emit_expr(
                 ind,
@@ -627,8 +711,8 @@ impl LeanEmitter {
         let impl_generics = func_meta
             .parameters
             .iter()
-            .flat_map(|(_, ty, _)| ctx.get_impl_param(ty))
-            .map(|var| var.to_string());
+            .filter_map(|(_, ty, _)| ctx.get_impl_param(ty))
+            .map(std::string::ToString::to_string);
         let generics_string = func_meta
             .direct_generics
             .iter()
@@ -654,21 +738,6 @@ impl LeanEmitter {
             &ret_type,
             &body,
         ))
-    }
-
-    fn emit_numeric_type_const(&self, typ: &Type, ctx: &EmitterCtx) -> String {
-        match typ {
-            Type::TypeVariable(tv) => match tv.borrow().deref() {
-                TypeBinding::Bound(b) => {
-                    let b = b.follow_bindings();
-                    self.emit_numeric_type_const(&b, ctx)
-                }
-                TypeBinding::Unbound(..) => format!("{typ}"),
-            },
-            Type::Constant(num, Kind::Numeric(_)) => format!("{num}"),
-
-            _ => format!("{typ}"),
-        }
     }
 
     /// Emits a fully-qualified type name for types where this is relevant.
@@ -700,7 +769,7 @@ impl LeanEmitter {
             Type::Unit => syntax::r#type::format_unit(),
             Type::Array(size, elem_type) => {
                 let elem_type = self.emit_fully_qualified_type(elem_type, ctx);
-                let size = self.emit_numeric_type_const(size.as_ref(), ctx);
+                let size = emit_numeric_type_const(size.as_ref());
                 syntax::r#type::format_array(&elem_type, &size)
             }
             Type::Slice(elem_type) => {
@@ -758,7 +827,7 @@ impl LeanEmitter {
                 Type::FieldElement => syntax::r#type::format_field_const(&num.to_string()),
                 _ => unimplemented!("unsupported numeric type {num_typ}"),
             },
-            Type::TypeVariable(tv) => match tv.borrow().deref() {
+            Type::TypeVariable(tv) => match &*tv.borrow() {
                 TypeBinding::Bound(b) => {
                     let b = b.follow_bindings();
                     self.emit_fully_qualified_type(&b, ctx)
@@ -828,78 +897,6 @@ impl LeanEmitter {
         }
     }
 
-    /// Given a type `T` and a `TypeBindings` map `m`, returns a new type where
-    /// the type variables in `T` have been recursively substituted with the
-    /// values in `m`.
-    pub fn substitute_bindings(&self, typ: &Type, bindings: &TypeBindings) -> Type {
-        match typ {
-            Type::TypeVariable(tv) | Type::NamedGeneric(tv, _) => bindings
-                .get(&tv.id())
-                .map(|(_, _, t)| t)
-                .cloned()
-                .unwrap_or(typ.clone()),
-            Type::Array(n, e) => Type::Array(
-                Box::new(self.substitute_bindings(n.as_ref(), bindings)),
-                Box::new(self.substitute_bindings(e.as_ref(), bindings)),
-            ),
-            Type::Slice(e) => Type::Slice(Box::new(self.substitute_bindings(e.as_ref(), bindings))),
-            Type::String(n) => Type::String(Box::new(self.substitute_bindings(n, bindings))),
-            Type::FmtString(n, vec) => Type::FmtString(
-                Box::new(self.substitute_bindings(n, bindings)),
-                Box::new(self.substitute_bindings(vec, bindings)),
-            ),
-            Type::Tuple(vec) => {
-                Type::Tuple(vec.iter().map(|t| self.substitute_bindings(t, bindings)).collect())
-            }
-            Type::Struct(def, generics) => Type::Struct(
-                def.clone(),
-                generics
-                    .iter()
-                    .map(|t| self.substitute_bindings(t, bindings))
-                    .collect(),
-            ),
-            Type::Alias(def, generics) => Type::Alias(
-                def.clone(),
-                generics
-                    .iter()
-                    .map(|t| self.substitute_bindings(t, bindings))
-                    .collect(),
-            ),
-            Type::Function(params, ret, env, unconstrained) => Type::Function(
-                params.iter().map(|t| self.substitute_bindings(t, bindings)).collect(),
-                Box::new(self.substitute_bindings(ret, bindings)),
-                Box::new(self.substitute_bindings(env, bindings)),
-                *unconstrained,
-            ),
-            Type::TraitAsType(id, name, generics) => Type::TraitAsType(
-                id.clone(),
-                name.clone(),
-                TraitGenerics {
-                    ordered: generics
-                        .ordered
-                        .iter()
-                        .map(|t| self.substitute_bindings(t, bindings))
-                        .collect(),
-                    named: generics
-                        .named
-                        .iter()
-                        .map(|t| NamedType {
-                            name: t.name.clone(),
-                            typ: self.substitute_bindings(&t.typ, bindings),
-                        })
-                        .collect(),
-                },
-            ),
-            Type::MutableReference(t) => {
-                Type::MutableReference(Box::new(self.substitute_bindings(t, bindings)))
-            }
-            Type::Forall(tvs, t) => {
-                Type::Forall(tvs.clone(), Box::new(self.substitute_bindings(t, bindings)))
-            }
-            _ => typ.clone(),
-        }
-    }
-
     /// Emits the Lean source code corresponding to a Noir expression.
     ///
     /// # Errors
@@ -931,11 +928,11 @@ impl LeanEmitter {
             HirExpression::Prefix(prefix) => {
                 let rhs = self.emit_expr(ind, prefix.rhs, ctx)?;
                 let rhs_ty = self.id_bound_type(prefix.rhs);
-                let rhs_builtin_ty = self.unfold_alias(rhs_ty.clone()).try_into().ok();
+                let rhs_builtin_ty = unfold_alias(rhs_ty.clone()).try_into().ok();
                 if let Some(builtin_name) =
                     builtin::try_prefix_into_builtin_name(prefix.operator, rhs_builtin_ty)
                 {
-                    syntax::expr::format_builtin_call(builtin_name, &rhs, &out_ty_str)
+                    syntax::expr::format_builtin_call(&builtin_name, &rhs, &out_ty_str)
                 } else {
                     // Convert to a trait call if this prefix call doesn't correspond to a builtin
                     // call.
@@ -946,7 +943,7 @@ impl LeanEmitter {
                         .get_prefix_operator_trait_method(&prefix.operator)
                         .expect("no trait corresponds to {prefix.operator:?}");
                     let func_name = self.context.def_interner.definition_name(
-                        self.context.def_interner.trait_method_id(trait_method_id.clone()),
+                        self.context.def_interner.trait_method_id(trait_method_id),
                     );
                     let corresp_trait =
                         self.context.def_interner.get_trait(trait_method_id.trait_id);
@@ -978,8 +975,8 @@ impl LeanEmitter {
                 let lhs_ty = self.id_bound_type(infix.lhs);
                 let rhs_ty = self.id_bound_type(infix.rhs);
                 if let Some(builtin_name) = match (
-                    self.unfold_alias(lhs_ty.clone()).try_into(),
-                    self.unfold_alias(rhs_ty.clone()).try_into(),
+                    unfold_alias(lhs_ty.clone()).try_into(),
+                    unfold_alias(rhs_ty.clone()).try_into(),
                 ) {
                     (Ok(lhs_ty), Ok(rhs_ty)) => {
                         builtin::try_infix_into_builtin_name(infix.operator.kind, lhs_ty, rhs_ty)
@@ -987,7 +984,7 @@ impl LeanEmitter {
                     _ => None,
                 } {
                     syntax::expr::format_builtin_call(
-                        builtin_name,
+                        &builtin_name,
                         &[lhs, rhs].join(", "),
                         &out_ty_str,
                     )
@@ -1002,7 +999,7 @@ impl LeanEmitter {
                         .def_interner
                         .get_operator_trait_method(infix.operator.kind);
                     let func_name = self.context.def_interner.definition_name(
-                        self.context.def_interner.trait_method_id(trait_method_id.clone()),
+                        self.context.def_interner.trait_method_id(trait_method_id),
                     );
                     let trait_name = self
                         .context
@@ -1046,7 +1043,7 @@ impl LeanEmitter {
 
                 if let Some(builtin_name) = builtin::try_func_expr_into_builtin_name(&func_expr_str)
                 {
-                    syntax::expr::format_builtin_call(builtin_name, &args_str, &out_ty_str)
+                    syntax::expr::format_builtin_call(&builtin_name, &args_str, &out_ty_str)
                 } else {
                     let fn_typ_str =
                         self.emit_fully_qualified_type(&self.id_bound_type(call.func), ctx);
@@ -1060,7 +1057,7 @@ impl LeanEmitter {
 
                 match &ident_def.kind {
                     DefinitionKind::Function(func_id) => {
-                        let func_meta = self.context.def_interner.function_meta(&func_id);
+                        let func_meta = self.context.def_interner.function_meta(func_id);
                         // Find the `impl` generic values.
                         // These are later appended to the emitted generics.
                         let impl_generics = bindings
@@ -1091,7 +1088,7 @@ impl LeanEmitter {
                                 let self_type = func_meta
                                     .self_type
                                     .as_ref()
-                                    .map(|t| self.substitute_bindings(t, bindings))
+                                    .map(|t| substitute_bindings(t, bindings))
                                     .expect(
                                         "the function associated with a trait function identifier \
                                          must have a self type",
@@ -1101,13 +1098,13 @@ impl LeanEmitter {
                                 let trait_generics = trait_impl
                                     .trait_generics
                                     .iter()
-                                    .map(|g| self.substitute_bindings(g, &bindings))
+                                    .map(|g| substitute_bindings(g, bindings))
                                     .map(|t| self.emit_fully_qualified_type(&t, ctx))
                                     .join(", ");
                                 let ident_generics = generics
                                     .unwrap_or_default()
                                     .iter()
-                                    .map(|g| self.substitute_bindings(g, &bindings))
+                                    .map(|g| substitute_bindings(g, bindings))
                                     .map(|t| self.emit_fully_qualified_type(&t, ctx))
                                     .chain(impl_generics)
                                     .join(", ");
@@ -1128,20 +1125,20 @@ impl LeanEmitter {
                                     .generics
                                     .iter()
                                     .map(|rg| Type::TypeVariable(rg.type_var.clone()))
-                                    .map(|g| self.substitute_bindings(&g, &bindings))
+                                    .map(|g| substitute_bindings(&g, bindings))
                                     .map(|t| self.emit_fully_qualified_type(&t, ctx))
                                     .join(", ");
                                 let ident_generics = generics
                                     .unwrap_or_default()
                                     .iter()
-                                    .map(|g| self.substitute_bindings(g, &bindings))
+                                    .map(|g| substitute_bindings(g, bindings))
                                     .map(|t| self.emit_fully_qualified_type(&t, ctx))
                                     .chain(impl_generics)
                                     .join(", ");
                                 let self_type = func_meta
                                     .self_type
                                     .as_ref()
-                                    .map(|t| self.substitute_bindings(t, bindings))
+                                    .map(|t| substitute_bindings(t, bindings))
                                     .map(|t| self.emit_fully_qualified_type(&t, ctx))
                                     .expect("self type must be present");
                                 syntax::expr::format_trait_func_ident(
@@ -1156,7 +1153,7 @@ impl LeanEmitter {
                                 let fn_name = match &func_meta.self_type {
                                     Some(self_type) => {
                                         let self_type_str =
-                                            self.emit_fully_qualified_type(&self_type, ctx);
+                                            self.emit_fully_qualified_type(self_type, ctx);
                                         format!("{self_type_str}::{name}")
                                     }
                                     _ => name.to_string(),
@@ -1174,7 +1171,7 @@ impl LeanEmitter {
                                 let ident_generics = func_meta
                                     .all_generics
                                     .iter()
-                                    .flat_map(|t| bindings.get(&t.type_var.id()))
+                                    .filter_map(|t| bindings.get(&t.type_var.id()))
                                     .map(|(_, _, ty)| self.emit_fully_qualified_type(ty, ctx))
                                     .chain(impl_generics)
                                     .join(", ");
@@ -1226,9 +1223,9 @@ impl LeanEmitter {
             HirExpression::Index(index) => {
                 let coll_type = self.id_bound_type(index.collection);
                 let coll_builtin_type: builtin::BuiltinType =
-                    self.unfold_alias(coll_type.clone()).try_into().unwrap();
+                    unfold_alias(coll_type.clone()).try_into().unwrap();
                 let index_builtin_name = builtin::get_index_builtin_name(coll_builtin_type)
-                    .expect(&format!("cannot index {:?}", coll_builtin_type));
+                    .unwrap_or_else(|| panic!("cannot index {coll_builtin_type:?}"));
 
                 let collection_expr_str = self.emit_expr(ind, index.collection, ctx)?;
                 let index_expr_str = self.emit_expr(ind, index.index, ctx)?;
@@ -1237,9 +1234,9 @@ impl LeanEmitter {
                 let index_expr_str = self.emit_cast_to_u32(&index_expr_str, ctx);
                 let args_str = format!("{collection_expr_str}, {index_expr_str}");
 
-                syntax::expr::format_builtin_call(index_builtin_name, &args_str, &out_ty_str)
+                syntax::expr::format_builtin_call(&index_builtin_name, &args_str, &out_ty_str)
             }
-            HirExpression::Literal(lit) => self.emit_literal(ind, lit, expr, ctx)?,
+            HirExpression::Literal(lit) => self.emit_literal(ind, &lit, expr, ctx)?,
             HirExpression::Constructor(constructor) => {
                 let struct_def = constructor.r#type;
                 let struct_def = struct_def.borrow();
@@ -1256,10 +1253,10 @@ impl LeanEmitter {
                 // correspond to the order in the original definition.
                 let fields_strings: Vec<String> = fields
                     .iter()
-                    .sorted_by_key(|(i, _)| field_orders.get(i).cloned().unwrap_or_default())
+                    .sorted_by_key(|(i, _)| field_orders.get(i).copied().unwrap_or_default())
                     .map(|(_, expr)| {
                         let expr_str = self.emit_expr(ind, *expr, ctx)?;
-                        Ok(format!("{expr_str}"))
+                        Ok(expr_str.to_string())
                     })
                     .try_collect()?;
                 let fields_str = fields_strings.join(", ");
@@ -1279,7 +1276,7 @@ impl LeanEmitter {
                 let lhs_expr_ty = self.id_bound_type(member.lhs);
                 let target_expr_str = self.emit_expr(ind, member.lhs, ctx)?;
                 let member_iden = member.rhs;
-                match self.unfold_alias(lhs_expr_ty.clone()) {
+                match unfold_alias(lhs_expr_ty.clone()) {
                     Type::Struct(..) => {
                         let struct_ty_str = self.emit_fully_qualified_type(&lhs_expr_ty, ctx);
                         syntax::expr::format_member_access(
@@ -1300,7 +1297,7 @@ impl LeanEmitter {
                 let target_type = self.emit_fully_qualified_type(&cast.r#type, ctx);
 
                 syntax::expr::format_builtin_call(
-                    builtin::CAST_BUILTIN_NAME.into(),
+                    &builtin::CAST_BUILTIN_NAME.into(),
                     &source,
                     &target_type,
                 )
@@ -1314,11 +1311,7 @@ impl LeanEmitter {
                     None
                 };
 
-                syntax::expr::format_ite(
-                    &if_cond,
-                    &then_exec,
-                    else_exec.as_ref().map(|s| s.as_str()),
-                )
+                syntax::expr::format_ite(&if_cond, &then_exec, else_exec.as_deref())
             }
             HirExpression::Tuple(tuple) => {
                 let item_exprs: Vec<String> = tuple
@@ -1422,17 +1415,6 @@ impl LeanEmitter {
         }
     }
 
-    /// If `typ` is an alias, unfolds it until it is no longer an alias.
-    fn unfold_alias(&self, typ: Type) -> Type {
-        match typ {
-            Type::Alias(alias, generics) => {
-                let unfolded_typ = alias.borrow().get_type(&generics);
-                self.unfold_alias(unfolded_typ)
-            }
-            typ => typ,
-        }
-    }
-
     /// Emits the Lean source code corresponding to a Noir statement.
     ///
     /// # Errors
@@ -1469,7 +1451,7 @@ impl LeanEmitter {
                 let constraint_expr = self.emit_expr(ind, constraint.0, ctx)?;
 
                 syntax::expr::format_builtin_call(
-                    builtin::ASSERT_BUILTIN_NAME.into(),
+                    &builtin::ASSERT_BUILTIN_NAME.into(),
                     &constraint_expr,
                     &self.emit_fully_qualified_type(&Type::Unit, ctx),
                 )
@@ -1498,7 +1480,7 @@ impl LeanEmitter {
         // Append a semicolon to the statement if it doesn't already end with one.
         // We emit some statements already with a semicolon, so we don't want to add
         // another. [TODO] maybe fix this for consistency
-        if result.ends_with(";") {
+        if result.ends_with(';') {
             Ok(result)
         } else {
             Ok(format!("{result};"))
@@ -1520,7 +1502,7 @@ impl LeanEmitter {
         let result = match l_val {
             HirLValue::Ident(ident, _) => {
                 let ident_str = self.context.def_interner.definition_name(ident.id);
-                syntax::expr::format_var_ident(ident_str)
+                Ok(syntax::expr::format_var_ident(ident_str))
             }
             HirLValue::MemberAccess {
                 object, field_name, ..
@@ -1535,18 +1517,22 @@ impl LeanEmitter {
                     } => typ,
                 };
                 match lhs_ty {
-                    Type::Tuple(..) => {
-                        syntax::lval::format_tuple_access(&lhs_lval_str, &field_name.to_string())
-                    }
+                    Type::Tuple(..) => Ok(syntax::lval::format_tuple_access(
+                        &lhs_lval_str,
+                        &field_name.to_string(),
+                    )),
                     Type::Struct(..) => {
                         let struct_ty_str = self.emit_fully_qualified_type(lhs_ty, ctx);
-                        syntax::lval::format_member_access(
+                        Ok(syntax::lval::format_member_access(
                             &struct_ty_str,
                             &lhs_lval_str,
                             &field_name.to_string(),
-                        )
+                        ))
                     }
-                    _ => panic!("invalid member access lvalue: lhs is not a struct or a tuple"),
+                    _ => Err(error::emit::Error::UnexpectedType(
+                        lhs_lval_str,
+                        "tuple or struct".to_string(),
+                    )),
                 }
             }
             HirLValue::Index { array, index, .. } => {
@@ -1563,18 +1549,25 @@ impl LeanEmitter {
                     } => typ,
                 };
                 match lhs_ty {
-                    Type::Array(..) => syntax::lval::format_array_access(&lhs_lval_str, &idx_expr),
-                    Type::Slice(..) => syntax::lval::format_slice_access(&lhs_lval_str, &idx_expr),
-                    _ => panic!("invalid index access lvalue: lhs is not an array or a slice"),
+                    Type::Array(..) => {
+                        Ok(syntax::lval::format_array_access(&lhs_lval_str, &idx_expr))
+                    }
+                    Type::Slice(..) => {
+                        Ok(syntax::lval::format_slice_access(&lhs_lval_str, &idx_expr))
+                    }
+                    _ => Err(error::emit::Error::UnexpectedType(
+                        lhs_lval_str,
+                        "array or slice".to_string(),
+                    )),
                 }
             }
             HirLValue::Dereference { lvalue, .. } => {
                 let lhs_lval = self.emit_l_value(ind, lvalue.as_ref(), ctx)?;
-                syntax::lval::format_deref_access(&lhs_lval)
+                Ok(syntax::lval::format_deref_access(&lhs_lval))
             }
         };
 
-        Ok(result)
+        result
     }
 
     /// Emits the Lean source code corresponding to a Noir literal.
@@ -1585,20 +1578,20 @@ impl LeanEmitter {
     pub fn emit_literal(
         &self,
         ind: &mut Indenter,
-        literal: HirLiteral,
+        literal: &HirLiteral,
         expr: ExprId,
         ctx: &EmitterCtx,
     ) -> Result<String> {
         let result = match &literal {
             HirLiteral::Array(array) | HirLiteral::Slice(array) => match array {
                 HirArrayLiteral::Standard(elems) => {
-                    let elems = elems
+                    let elems: Vec<String> = elems
                         .iter()
                         .map(|elem| self.emit_expr(ind, *elem, ctx))
                         .try_collect()?;
                     match literal {
-                        HirLiteral::Array(..) => syntax::literal::format_array(elems),
-                        HirLiteral::Slice(..) => syntax::literal::format_slice(elems),
+                        HirLiteral::Array(..) => syntax::literal::format_array(&elems),
+                        HirLiteral::Slice(..) => syntax::literal::format_slice(&elems),
                         _ => unreachable!(),
                     }
                 }
@@ -1631,9 +1624,9 @@ impl LeanEmitter {
             HirLiteral::FmtStr(str_parts, vars, _) => {
                 let output_str = str_parts.iter().fold(String::new(), |mut acc, part| {
                     match part {
-                        noirc_frontend::token::FmtStrFragment::String(s) => acc.push_str(&s),
+                        noirc_frontend::token::FmtStrFragment::String(s) => acc.push_str(s),
                         noirc_frontend::token::FmtStrFragment::Interpolation(inner, _) => {
-                            acc.push_str(&format!("{{{inner}}}"))
+                            acc.push_str(&format!("{{{inner}}}"));
                         }
                     }
                     acc
@@ -1643,14 +1636,14 @@ impl LeanEmitter {
                     vars.iter()
                         .try_fold(String::new(), |mut acc, &var_id| -> Result<String> {
                             let var_name = self.emit_expr(ind, var_id, ctx)?;
-                            acc.push_str(&format!("{}", &var_name,));
+                            acc.push_str(&var_name.to_string());
                             acc.push_str(", ");
                             Ok(acc)
                         })?;
 
                 let output_vars = output_vars.trim_end_matches(", ");
 
-                format!("#format(\"{}\", {})", output_str, output_vars)
+                format!("#format(\"{output_str}\", {output_vars})")
             }
             HirLiteral::Unit => syntax::literal::format_unit(),
         };
@@ -1683,7 +1676,7 @@ impl LeanEmitter {
 
     fn emit_cast_to_u32(&self, expr: &str, ctx: &EmitterCtx) -> String {
         syntax::expr::format_builtin_call(
-            builtin::CAST_BUILTIN_NAME.into(),
+            &builtin::CAST_BUILTIN_NAME.into(),
             expr,
             &self.emit_fully_qualified_type(
                 &Type::Integer(Signedness::Unsigned, IntegerBitSize::ThirtyTwo),

--- a/src/lean/mod.rs
+++ b/src/lean/mod.rs
@@ -11,12 +11,13 @@ use context::EmitterCtx;
 use fm::FileId;
 use itertools::Itertools;
 use noirc_frontend::{
+    Kind, ResolvedGeneric, StructField, Type, TypeBinding, TypeBindings,
     ast::{IntegerBitSize, Signedness},
     graph::CrateId,
     hir::{
+        Context,
         def_map::{ModuleData, ModuleDefId, ModuleId},
         type_check::generics::TraitGenerics,
-        Context,
     },
     hir_def::{
         expr::{HirArrayLiteral, HirExpression, HirIdent, HirLiteral},
@@ -27,7 +28,6 @@ use noirc_frontend::{
     node_interner::{
         DefinitionKind, ExprId, FuncId, GlobalId, StmtId, StructId, TraitId, TypeAliasId,
     },
-    Kind, ResolvedGeneric, StructField, Type, TypeBinding, TypeBindings,
 };
 
 use crate::error::{self, emit::Error::UnsupportedFeature};

--- a/src/lean/pattern.rs
+++ b/src/lean/pattern.rs
@@ -1,10 +1,10 @@
 use noirc_frontend::{
-    Type,
     ast::Ident,
     hir_def::{expr::HirIdent, stmt::HirPattern},
+    Type,
 };
 
-use super::{LeanEmitter, context::EmitterCtx};
+use super::{context::EmitterCtx, LeanEmitter};
 
 #[derive(Clone, Debug)]
 enum PatType {

--- a/src/lean/pattern.rs
+++ b/src/lean/pattern.rs
@@ -14,19 +14,10 @@ enum PatType {
 
 /// The context of a pattern which contains all the necessary information to convert a nested `HirPattern::Identifier` pattern into a let (mut) binding.
 /// This means, it contains the stack of tuple and struct patterns that the identifier is nested in, and whether the identifier is mutable.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 struct PatCtx {
     stack: Vec<PatType>,
     is_mut: bool,
-}
-
-impl Default for PatCtx {
-    fn default() -> Self {
-        Self {
-            stack: Vec::new(),
-            is_mut: false,
-        }
-    }
 }
 
 impl PatCtx {
@@ -70,7 +61,7 @@ fn parse_pattern(pat: &HirPattern, ctx: &mut PatCtx) -> Vec<PatRes> {
         }
         HirPattern::Struct(struct_type, sub_pats, ..) => {
             let mut res = Vec::new();
-            for (ident, pat) in sub_pats.iter() {
+            for (ident, pat) in sub_pats {
                 ctx.push(PatType::Struct {
                     struct_type: struct_type.clone(),
                     field: ident.clone(),
@@ -126,7 +117,7 @@ pub(super) fn format_pattern(
             for pat_type in ctx.stack {
                 match pat_type {
                     PatType::Tuple(i) => {
-                        rhs = super::syntax::expr::format_tuple_access(&rhs, &format!("{}", i));
+                        rhs = super::syntax::expr::format_tuple_access(&rhs, &format!("{i}"));
                     }
                     PatType::Struct { struct_type, field } => {
                         let struct_name =

--- a/src/lean/pattern.rs
+++ b/src/lean/pattern.rs
@@ -1,10 +1,10 @@
 use noirc_frontend::{
+    Type,
     ast::Ident,
     hir_def::{expr::HirIdent, stmt::HirPattern},
-    Type,
 };
 
-use super::{context::EmitterCtx, LeanEmitter};
+use super::{LeanEmitter, context::EmitterCtx};
 
 #[derive(Clone, Debug)]
 enum PatType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ mod test {
     #[test]
     fn patterns() -> anyhow::Result<()> {
         print_result(
-            r#"
+            r"
             struct Option2<T> {
                 _is_some: bool,
                 _value: T,
@@ -259,14 +259,14 @@ mod test {
                     x
                 };
             }
-        "#,
+        ",
         )
     }
 
     #[test]
     fn const_generics() -> anyhow::Result<()> {
         print_result(
-            r#"
+            r"
             fn nat_generic_test<let N: u32>() -> [Field; N] {
                 for i in 0..N {
                     i;
@@ -281,14 +281,14 @@ mod test {
                 }
                 res
             }
-        "#,
+        ",
         )
     }
 
     #[test]
     fn trait_generics() -> anyhow::Result<()> {
         print_result(
-            r#"
+            r"
             trait BinaryHasher<F> {
                 fn hash(a: F, b: F) -> F;
             }
@@ -308,14 +308,14 @@ mod test {
                 }
                 curr_h
             }
-        "#,
+        ",
         )
     }
 
     #[test]
     fn globals() -> anyhow::Result<()> {
         print_result(
-            r#"
+            r"
             global FOOS: [Field; 2] = [FOO, FOO + 1];
 
             global FOO: Field  = 42;
@@ -323,26 +323,26 @@ mod test {
             fn main() -> pub Field {
                 FOOS[1]
             }
-        "#,
+        ",
         )
     }
 
     #[test]
     fn unconstrained() -> anyhow::Result<()> {
         print_result(
-            r#"
+            r"
             unconstrained fn fun() -> Field{
                 let x = 5;
                 x
             }
-        "#,
+        ",
         )
     }
 
     #[test]
     fn arrays() -> anyhow::Result<()> {
         print_result(
-            r#"
+            r"
             pub fn mtree_recover<let N : u32>(idx: [bool; N], p: [Field; N], item: Field) -> Field
             {
                 item
@@ -351,14 +351,14 @@ mod test {
             fn main(root: pub Field, proof : pub [Field; 32], idx : pub [bool; 32], item : pub Field) {
                 assert(root == mtree_recover(idx, proof, item));
             }
-        "#,
+        ",
         )
     }
 
     #[test]
     fn field_generics() -> anyhow::Result<()> {
         print_result(
-            r#"
+            r"
             global A: Field = 4294967297;
 
             fn foo<let A: Field>() -> Field { A }
@@ -366,7 +366,7 @@ mod test {
             fn main() {
                 let _ = foo::<A>();
             }
-            "#,
+            ",
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@
 #![allow(clippy::module_name_repetitions)]
 // These occur in our Noir dependencies and cannot be avoided.
 #![allow(clippy::multiple_crate_versions)]
+// This only occurs for keys of type `Type`. It may be worth checking if this is actually an issue
+// we should worry about
+#![allow(clippy::mutable_key_type)]
 
 pub mod error;
 pub mod lean;

--- a/src/noir/project.rs
+++ b/src/noir/project.rs
@@ -7,7 +7,7 @@ use std::{
 
 use fm::{FileId, FileManager};
 use nargo::parse_all;
-use noirc_driver::{check_crate, file_manager_with_stdlib, prepare_crate, CompileOptions};
+use noirc_driver::{CompileOptions, check_crate, file_manager_with_stdlib, prepare_crate};
 use noirc_frontend::hir::Context;
 
 use crate::{
@@ -16,7 +16,7 @@ use crate::{
         file::{Error as FileError, Result as FileResult},
     },
     lean::LeanEmitter,
-    noir::{source::Source, WithWarnings},
+    noir::{WithWarnings, source::Source},
 };
 
 /// A type for file identifiers that are known to the extraction process.

--- a/src/noir/project.rs
+++ b/src/noir/project.rs
@@ -7,7 +7,7 @@ use std::{
 
 use fm::{FileId, FileManager};
 use nargo::parse_all;
-use noirc_driver::{CompileOptions, check_crate, file_manager_with_stdlib, prepare_crate};
+use noirc_driver::{check_crate, file_manager_with_stdlib, prepare_crate, CompileOptions};
 use noirc_frontend::hir::Context;
 
 use crate::{
@@ -16,7 +16,7 @@ use crate::{
         file::{Error as FileError, Result as FileResult},
     },
     lean::LeanEmitter,
-    noir::{WithWarnings, source::Source},
+    noir::{source::Source, WithWarnings},
 };
 
 /// A type for file identifiers that are known to the extraction process.
@@ -128,12 +128,16 @@ impl Project {
         let root_crate = prepare_crate(&mut context, &self.project_root.join(root_path).as_path());
 
         // Perform compilation to check the code within it.
-        let ((), warnings) = check_crate(&mut context, root_crate, &CompileOptions {
-            deny_warnings: false,
-            disable_macros: false,
-            debug_comptime_in_file: None,
-            ..Default::default()
-        })
+        let ((), warnings) = check_crate(
+            &mut context,
+            root_crate,
+            &CompileOptions {
+                deny_warnings: false,
+                disable_macros: false,
+                debug_comptime_in_file: None,
+                ..Default::default()
+            },
+        )
         .map_err(|diagnostics| CompileError::CheckFailure { diagnostics })?;
 
         Ok(WithWarnings::new(

--- a/src/noir/project.rs
+++ b/src/noir/project.rs
@@ -125,7 +125,7 @@ impl Project {
         // Then we build our compilation context
         let mut context = Context::new(manager, parsed_files);
         context.activate_lsp_mode();
-        let root_crate = prepare_crate(&mut context, &self.project_root.join(root_path).as_path());
+        let root_crate = prepare_crate(&mut context, self.project_root.join(root_path).as_path());
 
         // Perform compilation to check the code within it.
         let ((), warnings) = check_crate(


### PR DESCRIPTION
This PR adds `cargo fmt` and `cargo clippy` checks to CI, and fixes all of the raised issues.

It also fixes the rust toolchain.