### PR TITLE
add `simp only` call to `enter_decl` and `enter_trait`

### DIFF
--- a/Examples/Merkle/lampe/Merkle-0.0.0/Spec.lean
+++ b/Examples/Merkle/lampe/Merkle-0.0.0/Spec.lean
@@ -289,7 +289,6 @@ set_option maxRecDepth 10000 in
 set_option maxHeartbeats 2000000 in
 theorem to_le_bytes_intro {input} : STHoare lp env ⟦⟧ (to_le_bytes.call h![] h![input]) fun v => v = Fp.toBytesLE 32 input := by
   enter_decl
-  simp only
   steps [to_le_bits_intro]
   enter_block_as =>
     ([bytes ↦ ⟨(Tp.u 8).array 32, List.Vector.replicate 32 0⟩])
@@ -364,7 +363,6 @@ set_option maxHeartbeats 2000000 in
 theorem from_le_bytes_intro {input} : STHoare lp env ⟦⟧ (from_le_bytes.call h![] h![input])
     fun output => output = Lampe.Fp.ofBytesLE input.toList := by
   enter_decl
-  simp only
   steps
 
   loop_inv nat fun i _ _ => [v ↦ ⟨.field, 256 ^ i⟩] ⋆ [result ↦ ⟨.field, Lampe.Fp.ofBytesLE $ input.toList.take i⟩]
@@ -594,7 +592,6 @@ theorem rc_intro : STHoare lp env (⟦⟧)
     (Expr.call [] (Tp.field.array 8) (FuncRef.decl "RC" [] HList.nil) h![])
       fun output => output = ⟨Ref.RC.toList, by rfl⟩ := by
   enter_decl
-  simp only [Extracted.RC]
   steps []
   subst_vars
   unfold Ref.RC
@@ -604,7 +601,6 @@ theorem square_intro : STHoare lp env (⟦⟧)
     (Expr.call [Tp.field] Tp.field (FuncRef.decl "square" [] HList.nil) h![input])
       fun output => output = Ref.square input := by
   enter_decl
-  simp only [Extracted.square]
   steps [sigma_intro]
   unfold Ref.square
   subst_vars
@@ -616,7 +612,6 @@ theorem permute_intro : STHoare lp env ⟦⟧ (Expr.call [Tp.field.array 2] (Tp.
   cases i using List.Vector.casesOn with | cons _ i =>
   cases i using List.Vector.casesOn with | cons _ i =>
   cases i using List.Vector.casesOn
-  simp only [Extracted.permute]
   steps [bar_intro, square_intro, rc_intro]
   casesm* ∃_,_
   simp [Builtin.indexTpl, Nat.mod_eq_of_lt, lp] at *
@@ -636,11 +631,9 @@ lemma SkyscraperHash_correct: STHoare lp env ⟦⟧ (Expr.call [Tp.field, Tp.fie
 
 lemma weird_assert_eq_intro : STHoare lp env ⟦⟧ (weird_assert_eq.call h![] h![a, b]) (fun _ => a = b) := by
   enter_decl
-  simp only
   steps
   enter_block_as (⟦⟧) (fun _ => ⟦⟧)
   · enter_decl
-    simp only
     steps
   steps
   simp_all
@@ -651,7 +644,6 @@ theorem main_correct [Fact (CollisionResistant Ref.State.compress)] {tree : Merk
         (main.call h![] h![tree.root, proof, item, index])
         (fun _ => item ∈ tree) := by
   enter_decl
-  simp only
   steps [recover_intro (H:= «struct#Skyscraper».tp h![]) (N:=32) (hHash := SkyscraperHash_correct), weird_assert_eq_intro]
   use index.reverse
   subst_vars

--- a/Examples/MerkleFromScratch/user_files/Spec.lean
+++ b/Examples/MerkleFromScratch/user_files/Spec.lean
@@ -7,22 +7,17 @@ import ProvenZk
 
 import Mathlib.Data.Vector.Snoc
 
-open Lampe
-open «Merkle-1.0.0»
-open «Merkle-1.0.0».Ref
-open «Merkle-1.0.0».Extracted
+open Lampe «Merkle-1.0.0» «Merkle-1.0.0».Extracted «Merkle-1.0.0».Field
 
 namespace «Merkle-1.0.0»
 namespace Spec
 
-def lp : Lampe.Prime := ⟨Field.p, Field.pPrime⟩
+def lp : Lampe.Prime := ⟨p, pPrime⟩
 
 def _root_.List.Vector.pad {α n} (v : List.Vector α n) (d : Nat) (pad : α) : List.Vector α d := match d, n with
 | 0, _ => List.Vector.nil
 | d+1, 0 => pad ::ᵥ List.Vector.pad v d pad
 | d+1, _+1 => v.head ::ᵥ List.Vector.pad v.tail d pad
-
-def env := «Merkle-1.0.0».Extracted.Main.env
 
 @[simp]
 theorem List.Vector.toList_pad {v : List.Vector α n} {pad} : (v.pad d pad).toList = v.toList.takeD d pad := by
@@ -164,7 +159,7 @@ theorem rotate_left_intro : STHoare lp env ⟦N < 254⟧
 theorem sbox_intro : STHoare lp env ⟦⟧ (sbox.call h![] h![input])
     fun output => output = Ref.sbox input := by
   enter_decl
-  simp only [«Merkle-1.0.0».Extracted.sbox]
+  simp only [Extracted.sbox]
   steps [rotate_left_intro]
   · subst_vars; rfl
   all_goals decide
@@ -228,7 +223,7 @@ theorem to_le_bits_intro {input} : STHoare lp env ⟦⟧ (to_le_bits.call h![] h
     · have : input.val / 115792089237316195423570985008687907853269984665640564039457584007913129639936 = 0 := by
         cases input
         conv => lhs; arg 1; whnf
-        simp [Nat.div_eq_zero_iff, *, lp, Field.p] at *
+        simp [Nat.div_eq_zero_iff, *, lp, p] at *
         linarith
       congr 1
       simp [Int.cast, IntCast.intCast]
@@ -295,7 +290,6 @@ set_option maxRecDepth 10000 in
 set_option maxHeartbeats 2000000 in
 theorem to_le_bytes_intro {input} : STHoare lp env ⟦⟧ (to_le_bytes.call h![] h![input]) fun v => v = Fp.toBytesLE 32 input := by
   enter_decl
-  simp only
   steps [to_le_bits_intro]
   enter_block_as =>
     ([bytes ↦ ⟨(Tp.u 8).array 32, List.Vector.replicate 32 0⟩])
@@ -370,7 +364,6 @@ set_option maxHeartbeats 2000000 in
 theorem from_le_bytes_intro {input} : STHoare lp env ⟦⟧ (from_le_bytes.call h![] h![input])
     fun output => output = Lampe.Fp.ofBytesLE input.toList := by
   enter_decl
-  simp only
   steps
 
   loop_inv nat fun i _ _ => [v ↦ ⟨.field, 256 ^ i⟩] ⋆ [result ↦ ⟨.field, Lampe.Fp.ofBytesLE $ input.toList.take i⟩]
@@ -447,7 +440,7 @@ set_option maxHeartbeats 3000000000000
 theorem bar_intro : STHoare lp env ⟦⟧ (bar.call h![] h![input])
     fun output => output = Ref.bar input := by
   enter_decl
-  simp only [«Merkle-1.0.0».Extracted.bar]
+  simp only [Extracted.bar]
   steps [to_le_bytes_intro]
 
   enter_block_as
@@ -588,41 +581,38 @@ theorem bar_intro : STHoare lp env ⟦⟧ (bar.call h![] h![input])
     rfl
 
 theorem sigma_intro : STHoare lp env (⟦⟧)
-    («Merkle-1.0.0».Extracted.SIGMA.call h![] h![])
-      fun output => output = «Merkle-1.0.0».Ref.SIGMA := by
+    (Extracted.SIGMA.call h![] h![])
+      fun output => output = Ref.SIGMA := by
   enter_decl
-  simp only [«Merkle-1.0.0».Extracted.SIGMA]
+  simp only [Extracted.SIGMA]
   steps []
-  unfold «Merkle-1.0.0».Ref.SIGMA
+  unfold Ref.SIGMA
   assumption
 
 theorem rc_intro : STHoare lp env (⟦⟧)
     (Expr.call [] (Tp.field.array 8) (FuncRef.decl "RC" [] HList.nil) h![])
-      fun output => output = ⟨«Merkle-1.0.0».Ref.RC.toList, by rfl⟩ := by
+      fun output => output = ⟨Ref.RC.toList, by rfl⟩ := by
   enter_decl
-  simp only [«Merkle-1.0.0».Extracted.RC]
   steps []
   subst_vars
-  unfold «Merkle-1.0.0».Ref.RC
+  unfold Ref.RC
   rfl
 
 theorem square_intro : STHoare lp env (⟦⟧)
     (Expr.call [Tp.field] Tp.field (FuncRef.decl "square" [] HList.nil) h![input])
-      fun output => output = «Merkle-1.0.0».Ref.square input := by
+      fun output => output = Ref.square input := by
   enter_decl
-  simp only [«Merkle-1.0.0».Extracted.square]
   steps [sigma_intro]
-  unfold «Merkle-1.0.0».Ref.square
+  unfold Ref.square
   subst_vars
   rfl
 
 theorem permute_intro : STHoare lp env ⟦⟧ (Expr.call [Tp.field.array 2] (Tp.field.array 2) (FuncRef.decl "permute" [] HList.nil) h![i])
-    fun output => output = («Merkle-1.0.0».Ref.State.permute ⟨i[0], i[1]⟩).1 ::ᵥ («Merkle-1.0.0».Ref.State.permute ⟨i[0], i[1]⟩).2 ::ᵥ List.Vector.nil := by
+    fun output => output = (Ref.State.permute ⟨i[0], i[1]⟩).1 ::ᵥ (Ref.State.permute ⟨i[0], i[1]⟩).2 ::ᵥ List.Vector.nil := by
   enter_decl
   cases i using List.Vector.casesOn with | cons _ i =>
   cases i using List.Vector.casesOn with | cons _ i =>
   cases i using List.Vector.casesOn
-  simp only [«Merkle-1.0.0».Extracted.permute]
   steps [bar_intro, square_intro, rc_intro]
   casesm* ∃_,_
   simp [Builtin.indexTpl, Nat.mod_eq_of_lt, lp] at *
@@ -633,7 +623,7 @@ instance {α H n} : Membership α (MerkleTree α H n) where
   mem t e := ∃p, e = MerkleTree.itemAt t p
 
 lemma SkyscraperHash_correct: STHoare lp env ⟦⟧ (Expr.call [Tp.field, Tp.field] Tp.field
-          (FuncRef.trait (some $ «struct#Skyscraper».tp h![]) "BinaryHasher" [Kind.type] (HList.cons Tp.field HList.nil) "hash" [] HList.nil) h![a,b]) (fun v => v = «Merkle-1.0.0».Ref.State.compress ⟨[a, b], rfl⟩) := by
+          (FuncRef.trait (some $ «struct#Skyscraper».tp h![]) "BinaryHasher" [Kind.type] (HList.cons Tp.field HList.nil) "hash" [] HList.nil) h![a,b]) (fun v => v = Ref.State.compress ⟨[a, b], rfl⟩) := by
   enter_trait [] env
   steps [permute_intro]
   casesm*∃_,_
@@ -642,14 +632,10 @@ lemma SkyscraperHash_correct: STHoare lp env ⟦⟧ (Expr.call [Tp.field, Tp.fie
 
 lemma weird_assert_eq_intro : STHoare lp env ⟦⟧ (weird_assert_eq.call h![] h![a, b]) (fun _ => a = b) := by
   enter_decl
-  simp only
   steps
   enter_block_as (⟦⟧) (fun _ => ⟦⟧)
   · enter_decl
-    simp only
     steps
   steps
   simp_all
 
-end Spec
-end «Merkle-1.0.0»

--- a/Examples/MerkleFromScratch/user_files/append_to_Merkle.lean
+++ b/Examples/MerkleFromScratch/user_files/append_to_Merkle.lean
@@ -1,17 +1,15 @@
-
 open «Merkle-1.0.0».Ref
 open «Merkle-1.0.0».Spec
 open «Merkle-1.0.0».Extracted
 
 def env := «Merkle-1.0.0».Extracted.Main.env
 
-theorem main_correct [Fact (CollisionResistant «Merkle-1.0.0».Ref.State.compress)] {tree : MerkleTree (Fp lp) «Merkle-1.0.0».Ref.State.compress 32}:
-    STHoare lp env
+theorem main_correct [Fact (CollisionResistant Ref.State.compress)] {tree : MerkleTree (Fp Spec.lp) Ref.State.compress 32}:
+    STHoare Spec.lp env
         ⟦⟧
         (main.call h![] h![tree.root, proof, item, index])
         (fun _ => item ∈ tree) := by
   enter_decl
-  simp only
   steps [recover_intro (H:= «struct#Skyscraper».tp h![]) (N:=32) (hHash := SkyscraperHash_correct), weird_assert_eq_intro]
   use index.reverse
   subst_vars

--- a/Lampe/Lampe/Tactic/Steps.lean
+++ b/Lampe/Lampe/Tactic/Steps.lean
@@ -348,7 +348,8 @@ theorem callDecl_direct_intro {p} {Γ : Env} {func} {args} {Q H}
     rfl
 
 syntax "enter_decl" : tactic
-macro_rules | `(tactic|enter_decl) => `(tactic|apply callDecl_direct_intro (by rfl) (by rfl) (by rfl) (by rfl))
+macro_rules | `(tactic|enter_decl) => `(tactic|
+  apply callDecl_direct_intro (by rfl) (by rfl) (by rfl) (by rfl); simp only)
 
 theorem callTrait_direct_intro {impls : List $ Lampe.Ident × Function}
     (h_trait : TraitResolution Γ ⟨⟨traitName, traitKinds, traitGenerics⟩, selfTp⟩ impls)
@@ -371,7 +372,9 @@ theorem callTrait_direct_intro {impls : List $ Lampe.Ident × Function}
   · assumption
 
 syntax "enter_trait" "[" term,* "]" term  : tactic
-macro_rules | `(tactic|enter_trait [$generics,*] $envSyn) => `(tactic|apply callTrait_direct_intro (by try_impls_all [$generics,*] $envSyn) (by rfl) (by rfl) (by rfl) (by rfl))
+macro_rules | `(tactic|enter_trait [$generics,*] $envSyn) => `(tactic|
+  apply callTrait_direct_intro (by try_impls_all [$generics,*] $envSyn)
+                               (by rfl) (by rfl) (by rfl) (by rfl); simp only)
 
 theorem bindVar {v : α} { P : α → Prop } (hp: ∀v, P v) : P v := by
   apply hp v

--- a/Lampe/Tests/FieldGenerics.lean
+++ b/Lampe/Tests/FieldGenerics.lean
@@ -35,5 +35,3 @@ lemma test_intro : STHoare p env ⟦⟧ (test.call h![] h![]) fun output => outp
     steps [A_intro, foo_intro]
     subst_vars
     rfl
-
-

--- a/Lampe/Tests/Negatives.lean
+++ b/Lampe/Tests/Negatives.lean
@@ -19,7 +19,6 @@ example : STHoare p env ⟦⟧ (zero?.fn.body _ h![] |>.body h![])
 
   enter_block_as (⟦⟧) (fun v => v = -1)
   · enter_decl
-    simp only [NEGONE]
     steps
     simp_all
 


### PR DESCRIPTION
This PR factors out the `simp only` change to `enter_decl` and `enter_trait` from #99 to keep that PR entirely focused on the delaborator/syntax.

All the fixes in `Examples/*` and `Lampe/Tests/*` are due to the two `simp only` calls added in `Lampe/Tactic/Steps.lean`