### PR TITLE
Fix the integer -> field element conversions

### DIFF
--- a/Lampe/Lampe/Hoare/Builtins.lean
+++ b/Lampe/Lampe/Hoare/Builtins.lean
@@ -296,6 +296,14 @@ theorem iFromField_intro : STHoarePureBuiltin p Γ Builtin.iFromField (by tauto)
   apply pureBuiltin_intro_consequence <;> try tauto
   tauto
 
+theorem uAsField_intro {p Γ s f} : STHoarePureBuiltin p Γ Builtin.uAsField (by tauto) h![f] (a := s) := by
+  apply pureBuiltin_intro_consequence <;> try tauto
+  tauto
+
+theorem iAsField_intro {p Γ s f} : STHoarePureBuiltin p Γ Builtin.iAsField (by tauto) h![f] (a := s) := by
+  apply pureBuiltin_intro_consequence <;> try tauto
+  tauto
+
 -- Slice
 
 theorem sliceLen_intro : STHoarePureBuiltin p Γ Builtin.sliceLen (by tauto) h![s] := by

--- a/Lampe/Lampe/Tactic/Steps.lean
+++ b/Lampe/Lampe/Tactic/Steps.lean
@@ -107,6 +107,17 @@ def getClosingTerm (val : Expr) : TacticM (Option (TSyntax `term × Bool)) := wi
         | ``Lampe.Builtin.sliceIndex => return some (←``(sliceIndex_intro), false)
         | ``Lampe.Builtin.ref => return some (←``(ref_intro), false)
 
+        | ``Lampe.Builtin.fApplyRangeConstraint => return some (←``(fApplyRangeConstraint_intro), false)
+        | ``Lampe.Builtin.fModBeBits => return some (←``(genericTotalPureBuiltin_intro Builtin.fModBeBits), true)
+        | ``Lampe.Builtin.fModBeBytes => return some (←``(genericTotalPureBuiltin_intro Builtin.fModBeBytes), true)
+        | ``Lampe.Builtin.fModLeBits => return some (←``(genericTotalPureBuiltin_intro Builtin.fModLeBits), true)
+        | ``Lampe.Builtin.fModLeBytes => return some (←``(genericTotalPureBuiltin_intro Builtin.fModLeBytes), true)
+        | ``Lampe.Builtin.fModNumBits => return some (←``(fModNumBits_intro), false)
+        | ``Lampe.Builtin.iAsField => return some (←``(genericTotalPureBuiltin_intro Builtin.iAsField), true)
+        | ``Lampe.Builtin.iFromField => return some (←``(genericTotalPureBuiltin_intro Builtin.iFromField), true)
+        | ``Lampe.Builtin.uAsField => return some (←``(genericTotalPureBuiltin_intro Builtin.uAsField), true)
+        | ``Lampe.Builtin.uFromField => return some (←``(genericTotalPureBuiltin_intro Builtin.uFromField), true)
+
         | _ => return none
       | _ => return none
     | ``Lampe.Expr.ref => return some (←``(ref_intro), false)


### PR DESCRIPTION
Previously these conversions (`uAsField` and `iAsField`) used `sorry` as we had not clarified the expected semantics of these conversions with Aztec. We now have clarity on how these should behave, and have implemented the correct conversion behavior in our builtins. The exact semantics of these conversions are documented in the doc blocks.

This commit adds the intro theorems for `uAsField` and `iAsField`, and also removes an incidental example that should not have been in the codebase.

Closes #44 