### PR TITLE
Delaborate `Tp.denote`

### DIFF
--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -16,6 +16,7 @@ import Lampe.Builtin.Struct
 import Lampe.Data.Field
 import Lampe.Data.HList
 import Lampe.Data.Integers
+import Lampe.Data.Meta
 import Lampe.Data.Strings
 import Lampe.Delab
 import Lampe.Hoare.Builtins

--- a/Lampe/Lampe/Data/Meta.lean
+++ b/Lampe/Lampe/Data/Meta.lean
@@ -2,6 +2,9 @@ import Lean
 
 open Lean PrettyPrinter Delaborator
 
+def whenDelabOptionSet (name : Name) (f : DelabM α) : DelabM α := do
+  if (← getOptions).getBool name true then f else failure
+
 def whenFullyApplied (expr : Expr) (f : DelabM α) : DelabM α := do
   let numArgs := expr.getAppNumArgs
   let fType ← Meta.inferType expr.getAppFn

--- a/Lampe/Lampe/Data/Meta.lean
+++ b/Lampe/Lampe/Data/Meta.lean
@@ -2,9 +2,13 @@ import Lean
 
 open Lean PrettyPrinter Delaborator
 
+/-- Disable a delaborator unless an option is set to true. Used in Lampe to disable pretty printers
+until they are stabalized. -/
 def whenDelabOptionSet (name : Name) (f : DelabM α) : DelabM α := do
   if (← getOptions).getBool name true then f else failure
 
+/-- Apply a delaborator only on a fully applied function application. This prevents the delaborator
+from firing on partial applications which could lead to annoying visibility issues for the user. -/
 def whenFullyApplied (expr : Expr) (f : DelabM α) : DelabM α := do
   let numArgs := expr.getAppNumArgs
   let fType ← Meta.inferType expr.getAppFn

--- a/Lampe/Lampe/Data/Meta.lean
+++ b/Lampe/Lampe/Data/Meta.lean
@@ -1,0 +1,11 @@
+import Lean
+
+open Lean PrettyPrinter Delaborator
+
+def whenFullyApplied (expr : Expr) (f : DelabM α) : DelabM α := do
+  let numArgs := expr.getAppNumArgs
+  let fType ← Meta.inferType expr.getAppFn
+  let arity := fType.getNumHeadForalls
+  let arity2 := fType.getNumHeadLambdas
+  if numArgs == arity + arity2 then f else failure
+

--- a/Lampe/Lampe/Delab.lean
+++ b/Lampe/Lampe/Delab.lean
@@ -11,8 +11,7 @@ register_option Lampe.pp.Expr : Bool := {
   descr := "Pretty print Lampe.Expr using the Lampe syntax"
 }
 
-def whenDelabExprOption (f : DelabM α) : DelabM α := do
-  if (← getOptions).getBool `Lampe.pp.Expr true then f else failure
+abbrev whenDelabExprOption : DelabM α → DelabM α := whenDelabOptionSet `Lampe.pp.Expr
 
 syntax "⸨" nr_expr "⸩" : term
 
@@ -485,8 +484,7 @@ register_option Lampe.pp.STHoare : Bool := {
   descr := "Pretty print Lampe.STHoare using the Lampe syntax"
 }
 
-def whenDelabSTHoareOption (f : DelabM α) : DelabM α := do
-  if (← getOptions).getBool `Lampe.pp.STHoare true then f else failure
+abbrev whenDelabSTHoareOption : DelabM α → DelabM α := whenDelabOptionSet `Lampe.pp.STHoare
 
 @[app_delab Lampe.STHoare]
 def delabSTHoare : Delab := whenDelabSTHoareOption getExpr >>= fun expr =>

--- a/Lampe/Lampe/Delab.lean
+++ b/Lampe/Lampe/Delab.lean
@@ -1,4 +1,5 @@
 import Lean
+import Lampe.Data.Meta
 import Lampe.Syntax
 import Lampe.Hoare.SepTotal
 import Lampe.Tactic.Steps
@@ -12,13 +13,6 @@ register_option Lampe.pp.Expr : Bool := {
 
 def whenDelabExprOption (f : DelabM α) : DelabM α := do
   if (← getOptions).getBool `Lampe.pp.Expr true then f else failure
-
-def whenFullyApplied (expr : Expr) (f : DelabM α) : DelabM α := do
-  let numArgs := expr.getAppNumArgs
-  let fType ← Meta.inferType expr.getAppFn
-  let arity := fType.getNumHeadForalls
-  let arity2 := fType.getNumHeadLambdas
-  if numArgs == arity + arity2 then f else failure
 
 syntax "⸨" nr_expr "⸩" : term
 

--- a/Lampe/Lampe/Tp.lean
+++ b/Lampe/Lampe/Tp.lean
@@ -1,7 +1,9 @@
+import Lean
 import Lampe.Data.Integers
 import Lampe.Data.Field
 import Lampe.Data.HList
 import Lampe.Data.Strings
+import Lampe.Data.Meta
 
 namespace Lampe
 
@@ -143,6 +145,20 @@ def Tp.denote : Tp → Type
 | .fn argTps outTp => FuncRef argTps outTp
 
 end
+
+section Delab
+
+open Lean PrettyPrinter Delaborator SubExpr
+
+@[app_delab Lampe.Tp.denote]
+def delabTpDenote : Delab := getExpr >>= fun expr => whenFullyApplied expr do
+  let reducedExpr ← Meta.reduceAll expr
+  if reducedExpr.isAppOf `Lampe.Tp.denote then
+    failure
+  else
+    return ←delab reducedExpr
+
+end Delab
 
 @[reducible]
 def HList.toTuple (hList : HList (Tp.denote p) tps) (name : Option String) : Tp.denote p <| .tuple name tps := match hList with

--- a/Lampe/Lampe/Tp.lean
+++ b/Lampe/Lampe/Tp.lean
@@ -157,6 +157,8 @@ register_option pp.Tp : Bool := {
 
 abbrev whenDelabTp : DelabM α → DelabM α := whenDelabOptionSet `Lampe.pp.Tp
 
+/-- Delaborate `Tp.denote` to its defeq concrete Lean type. This improves the readability of goal
+states involving `Tp.denote` -/
 @[app_delab Lampe.Tp.denote]
 def delabTpDenote : Delab := whenDelabTp getExpr >>= fun expr => whenFullyApplied expr do
   let reducedExpr := (← Meta.unfold expr `Lampe.Tp.denote).expr

--- a/Lampe/Lampe/Tp.lean
+++ b/Lampe/Lampe/Tp.lean
@@ -150,8 +150,15 @@ section Delab
 
 open Lean PrettyPrinter Delaborator SubExpr
 
+register_option pp.Tp : Bool := {
+  defValue := true
+  descr := "Pretty print applications of `Tp.denote`"
+}
+
+abbrev whenDelabTp : DelabM α → DelabM α := whenDelabOptionSet `Lampe.pp.Tp
+
 @[app_delab Lampe.Tp.denote]
-def delabTpDenote : Delab := getExpr >>= fun expr => whenFullyApplied expr do
+def delabTpDenote : Delab := whenDelabTp getExpr >>= fun expr => whenFullyApplied expr do
   let reducedExpr := (← Meta.unfold expr `Lampe.Tp.denote).expr
   if reducedExpr.isAppOf `Lampe.Tp.denote then
     failure

--- a/Lampe/Lampe/Tp.lean
+++ b/Lampe/Lampe/Tp.lean
@@ -152,11 +152,11 @@ open Lean PrettyPrinter Delaborator SubExpr
 
 @[app_delab Lampe.Tp.denote]
 def delabTpDenote : Delab := getExpr >>= fun expr => whenFullyApplied expr do
-  let reducedExpr ← Meta.reduceAll expr
+  let reducedExpr := (← Meta.unfold expr `Lampe.Tp.denote).expr
   if reducedExpr.isAppOf `Lampe.Tp.denote then
     failure
   else
-    return ←delab reducedExpr
+    return ← delab reducedExpr
 
 end Delab
 


### PR DESCRIPTION
This PR adds a delaborator for `Tp.denote`. This is part of a long effort to make the proof states
the user will encounter less "scary".
