### PR TITLE
Fix Typos in Comments and Documentation

### DIFF
--- a/Lampe/Lampe/Data/Meta.lean
+++ b/Lampe/Lampe/Data/Meta.lean
@@ -3,7 +3,7 @@ import Lean
 open Lean PrettyPrinter Delaborator
 
 /-- Disable a delaborator unless an option is set to true. Used in Lampe to disable pretty printers
-until they are stabalized. -/
+until they are stabilized. -/
 def whenDelabOptionSet (name : Name) (f : DelabM α) : DelabM α := do
   if (← getOptions).getBool name true then f else failure
 

--- a/src/lean/mod.rs
+++ b/src/lean/mod.rs
@@ -588,7 +588,7 @@ impl<'file_manager, 'parsed_files> LeanEmitter<'file_manager, 'parsed_files> {
         }
     }
 
-    /// Emits the Lean source code corresponding to a resolved generics occuring
+    /// Emits the Lean source code corresponding to a resolved generics occurring
     /// at generic declarations.
     #[allow(clippy::unused_self)]
     pub fn emit_resolved_generic(&self, g: &ResolvedGeneric, _ctx: &EmitterCtx) -> String {


### PR DESCRIPTION


Description:  
This pull request corrects minor spelling mistakes in the codebase. Specifically, it changes "stabalized" to "stabilized" in a Lean comment and "occuring" to "occurring" in a Rust documentation comment. These changes improve the clarity and professionalism of the code documentation. No functional code has been altered.
