### PR TITLE
fix: `Tp.denote` delaborator

### DIFF
--- a/Lampe/Lampe/Data/Meta.lean
+++ b/Lampe/Lampe/Data/Meta.lean
@@ -3,7 +3,7 @@ import Lean
 open Lean PrettyPrinter Delaborator
 
 /-- Disable a delaborator unless an option is set to true. Used in Lampe to disable pretty printers
-until they are stabalized. -/
+until they are stabilized. -/
 def whenDelabOptionSet (name : Name) (f : DelabM α) : DelabM α := do
   if (← getOptions).getBool name then f else failure
 

--- a/Lampe/Lampe/Tp.lean
+++ b/Lampe/Lampe/Tp.lean
@@ -5,6 +5,7 @@ import Lampe.Data.HList
 import Lampe.Data.Strings
 import Lampe.Data.Meta
 
+-- Note: This option needs to be defined outside of any namespace for it to register correctly
 register_option Lampe.pp.Tp : Bool := {
   defValue := true
   descr := "Pretty print applications of `Tp.denote`"
@@ -158,6 +159,7 @@ open Meta (mkAppM)
 
 abbrev whenDelabTp : DelabM α → DelabM α := whenDelabOptionSet `Lampe.pp.Tp
 
+/-- convert `[A, B, C, ...]` to the product `A.denote × B.denote × C.denote × ... -/
 def delabDenoteArgsAux (p : Expr) (tps : List Expr) : MetaM Expr := do
   let rec loop (acc : Expr) : List Expr → MetaM Expr
   | [] => return acc
@@ -167,6 +169,8 @@ def delabDenoteArgsAux (p : Expr) (tps : List Expr) : MetaM Expr := do
   let base ← mkAppM `Unit #[]
   loop base tps
 
+/-- Delaborate `Tp.denote` to its defeq concrete Lean type. This improves the readability of goal
+states involving `Tp.denote` -/
 @[app_delab Lampe.Tp.denote]
 def delabTpDenote : Delab := whenDelabTp getExpr >>= fun expr => whenFullyApplied expr do
   let_expr Tp.denote p tpExpr := expr | failure


### PR DESCRIPTION
Fix the delaborator for `Tp.denote` to avoid any infinite recursion that was observed after #120 and #126. I do not foresee any issues from this change, and it appears it fixes any of the delab issues in #125 