### PR TITLE
Depend on upstream Noir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,8 @@ version = 4
 
 [[package]]
 name = "acir"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acir_field",
  "base64 0.21.7",
@@ -28,8 +28,8 @@ dependencies = [
 
 [[package]]
 name = "acir_field"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -42,8 +42,8 @@ dependencies = [
 
 [[package]]
 name = "acvm"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -57,8 +57,8 @@ dependencies = [
 
 [[package]]
 name = "acvm_blackbox_solver"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acir",
  "blake2",
@@ -244,7 +244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -257,7 +257,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -308,7 +308,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -341,7 +341,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -467,8 +467,8 @@ dependencies = [
 
 [[package]]
 name = "bn254_blackbox_solver"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -492,8 +492,8 @@ dependencies = [
 
 [[package]]
 name = "brillig"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acir_field",
  "serde",
@@ -501,8 +501,8 @@ dependencies = [
 
 [[package]]
 name = "brillig_vm"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
@@ -542,9 +542,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
@@ -607,7 +607,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -783,7 +783,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -794,7 +794,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -869,8 +869,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecdsa"
@@ -895,7 +901,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -941,7 +947,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1010,8 +1016,8 @@ dependencies = [
 
 [[package]]
 name = "fm"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "codespan-reporting",
  "iter-extended",
@@ -1390,8 +1396,8 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "iter-extended"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 
 [[package]]
 name = "itertools"
@@ -1528,9 +1534,9 @@ checksum = "82903360c009b816f5ab72a9b68158c27c301ee2c3f20655b55c5e589e7d3bb7"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
 name = "libredox"
@@ -1562,9 +1568,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miniz_oxide"
@@ -1583,8 +1589,8 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nargo"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acvm",
  "fm",
@@ -1607,8 +1613,8 @@ dependencies = [
 
 [[package]]
 name = "nargo_toml"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "dirs",
  "fm",
@@ -1626,8 +1632,8 @@ dependencies = [
 
 [[package]]
 name = "noir_greybox_fuzzer"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acvm",
  "build-data",
@@ -1646,8 +1652,8 @@ dependencies = [
 
 [[package]]
 name = "noir_protobuf"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "color-eyre",
  "prost",
@@ -1655,8 +1661,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_abi"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acvm",
  "iter-extended",
@@ -1671,13 +1677,13 @@ dependencies = [
 
 [[package]]
 name = "noirc_arena"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 
 [[package]]
 name = "noirc_artifacts"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acvm",
  "codespan-reporting",
@@ -1691,8 +1697,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_driver"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acvm",
  "build-data",
@@ -1711,8 +1717,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_errors"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acvm",
  "base64 0.21.7",
@@ -1729,8 +1735,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_evaluator"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acvm",
  "bn254_blackbox_solver",
@@ -1758,8 +1764,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_frontend"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acvm",
  "bn254_blackbox_solver",
@@ -1788,8 +1794,8 @@ dependencies = [
 
 [[package]]
 name = "noirc_printable_type"
-version = "1.0.0-beta.6"
-source = "git+https://github.com/reilabs/noir?branch=lampe-upstream#13639b2a6b2c3496983d1d6824779d2fdc223264"
+version = "1.0.0-beta.7"
+source = "git+https://github.com/noir-lang/noir?rev=5071093f9b51e111a49a5f78d827774ef8e80c74#5071093f9b51e111a49a5f78d827774ef8e80c74"
 dependencies = [
  "acvm",
  "iter-extended",
@@ -1849,7 +1855,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1949,7 +1955,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2000,12 +2006,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2079,7 +2085,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.102",
+ "syn 2.0.103",
  "tempfile",
 ]
 
@@ -2093,7 +2099,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2126,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -2254,6 +2260,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,7 +2374,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.102",
+ "syn 2.0.103",
  "walkdir",
 ]
 
@@ -2389,9 +2415,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "log",
  "once_cell",
@@ -2497,6 +2523,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2542,7 +2580,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2568,15 +2606,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.9.0",
+ "schemars",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2586,14 +2625,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2748,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2765,7 +2804,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2816,7 +2855,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2827,17 +2866,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -2998,7 +3036,7 @@ checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3186,7 +3224,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -3208,7 +3246,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3292,7 +3330,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3303,14 +3341,14 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -3465,7 +3503,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
  "synstructure",
 ]
 
@@ -3486,7 +3524,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3506,7 +3544,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
  "synstructure",
 ]
 
@@ -3527,7 +3565,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3560,7 +3598,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.103",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,20 @@ repository = "https://github.com/reilabs/lampe"
 license = "MIT"
 
 [dependencies]
-fm = { git = "https://github.com/reilabs/noir", branch = "lampe-upstream" }
-nargo = { git = "https://github.com/reilabs/noir", branch = "lampe-upstream" }
-nargo_toml = { git = "https://github.com/reilabs/noir", branch = "lampe-upstream" }
-noirc_driver = { git = "https://github.com/reilabs/noir", branch = "lampe-upstream" }
-noirc_errors = { git = "https://github.com/reilabs/noir", branch = "lampe-upstream" }
-noirc_frontend = { git = "https://github.com/reilabs/noir", branch = "lampe-upstream" }
+fm = { git = "https://github.com/noir-lang/noir", rev = "5071093f9b51e111a49a5f78d827774ef8e80c74" }
+nargo = { git = "https://github.com/noir-lang/noir", rev = "5071093f9b51e111a49a5f78d827774ef8e80c74" }
+nargo_toml = { git = "https://github.com/noir-lang/noir", rev = "5071093f9b51e111a49a5f78d827774ef8e80c74" }
+noirc_driver = { git = "https://github.com/noir-lang/noir", rev = "5071093f9b51e111a49a5f78d827774ef8e80c74" }
+noirc_errors = { git = "https://github.com/noir-lang/noir", rev = "5071093f9b51e111a49a5f78d827774ef8e80c74" }
+noirc_frontend = { git = "https://github.com/noir-lang/noir", rev = "5071093f9b51e111a49a5f78d827774ef8e80c74" }
+
+# Left behind to enable easier local development when needed
+# fm = { path = "../noir/compiler/fm" }
+# nargo = { path = "../noir/tooling/nargo" }
+# nargo_toml = { path = "../noir/tooling/nargo_toml" }
+# noirc_driver = { path = "../noir/compiler/noirc_driver" }
+# noirc_errors = { path = "../noir/compiler/noirc_errors" }
+# noirc_frontend = { path = "../noir/compiler/noirc_frontend" }
 
 clap = { version = "4.5.17", features = ["unstable-v5"] }
 derivative = "2.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,25 +84,6 @@ authors = [""]
     }
 
     #[test]
-    fn test_unbound() {
-        let type_source = r"
-struct Bad<T> {
-    x: Field,
-}
-
-fn mkBad<T>() -> Bad<T> {
-    Bad { x: 3 }
-}
-
-fn main() -> pub Field {
-    let f = mkBad();
-    f.x
-}
-";
-        assert!(test_extractor_on(type_source).is_ok());
-    }
-
-    #[test]
     fn test_order() {
         let type_source = r"
 struct FooStruct2 {


### PR DESCRIPTION
Our changes have been merged upstream, and so this PR bumps our dependency on the noir repository to be on a pinned commit of the upstream Noir development.

Closes #121 