### PR TITLE
add some error handling to steps tactic

### DIFF
--- a/Lampe/Lampe/Semantics/Env.lean
+++ b/Lampe/Lampe/Semantics/Env.lean
@@ -16,6 +16,7 @@ structure Env where
 
   -- All trait implementations in scope, pairing the name with the implementation details.
   traits : List (Ident × TraitImpl)
+deriving Inhabited
 
 namespace Env
 

--- a/Lampe/Lampe/Tactic/Steps.lean
+++ b/Lampe/Lampe/Tactic/Steps.lean
@@ -199,7 +199,7 @@ structure AddLemma where
 def tryApplySyntaxes (goal : MVarId) (lemmas : List AddLemma): TacticM (List MVarId) := match lemmas with
 | [] => throwError "no lemmas left"
 | n::ns => do
-  trace[Lampe.STHoare.Helpers] "trying {← ppExpr n.expr} with generalizeEnv: {n.generalizeEnv}"
+  trace[Lampe.STHoare.Helpers] "trying {←ppExpr n.expr} with generalizeEnv: {n.generalizeEnv}"
   try
     let (subset, goal, others) ← if n.generalizeEnv
       then

--- a/Lampe/Lampe/Tp.lean
+++ b/Lampe/Lampe/Tp.lean
@@ -251,4 +251,23 @@ match tp with
 
 end
 
+/- In this section we provide unification hints to assist with the ergonomics of stating theorems -/
+section unificationHints
+
+/-- This is slightly dangerous, as it could conflict with the unification with `Tp.i n` -/
+unif_hint (p : Prime) (n : Nat) (tp : Tp) where
+  Tp.u n =?= tp
+  ⊢ Tp.denote p tp =?= BitVec n
+
+unif_hint (p : Prime) (tp : Tp) where
+  Tp.bool =?= tp
+  ⊢ Tp.denote p tp =?= Bool
+
+unif_hint (p q : Prime) (tp : Tp) where
+  p =?= q
+  Tp.field =?= tp
+  ⊢ Tp.denote p tp =?= Fin (q.val + 1)
+
+end unificationHints
+
 end Lampe

--- a/Lampe/Tests/Envs.lean
+++ b/Lampe/Tests/Envs.lean
@@ -56,36 +56,33 @@ example {p} {fieldArg : Fp p}:
     fun v => v = 2 * fieldArg := by
   simp only [both_trait_call]
   steps
-  step_as (⟦⟧) (fun v => v = 2 * u8Arg)
-  . try_all_traits [] compoundEnv
+  step_as (⟦⟧) (fun v => v = (2 * u8Arg : Tp.denote p (Tp.u 8)))
+  · try_all_traits [] compoundEnv
     steps
     casesm* ∃ _, _
     subst_vars
     bv_decide
 
   steps
-  step_as (⟦z = 2 * u8Arg⟧) (fun v => v = 2 * u8Arg)
-  . assumption
-  . enter_decl
+  step_as (⟦z = 2 * u8Arg⟧) (fun v => v = (2 * u8Arg : Tp.denote p (Tp.u 8)))
+  · assumption
+  · enter_decl
     steps
     subst_vars
     rfl
 
   steps
-  step_as (⟦z = 2 * u8Arg⟧) (fun v => v = 2 * fieldArg)
-  . assumption
-  . try_all_traits [] compoundEnv
+  step_as (⟦z = 2 * u8Arg⟧) (fun v => v = (2 * fieldArg : Tp.denote p Tp.field))
+  · assumption
+  · try_all_traits [] compoundEnv
     steps
     subst_vars
     ring
 
   steps
-  step_as (⟦w = 2 * fieldArg⟧) (fun v => v = 2 * fieldArg)
-  . assumption
-  . subst_vars
-    rfl
-  . enter_decl
+  step_as (⟦z = 2 * u8Arg⟧) (fun v => v = (2 * fieldArg : Tp.denote p Tp.field))
+  · assumption
+  · enter_decl
     steps
     subst_vars
     rfl
-

--- a/Lampe/Tests/Envs.lean
+++ b/Lampe/Tests/Envs.lean
@@ -80,9 +80,7 @@ example {p} {fieldArg : Fp p}:
     ring
 
   steps
-  step_as (⟦z = 2 * u8Arg⟧) (fun v => v = (2 * fieldArg : Tp.denote p Tp.field))
-  · assumption
-  · enter_decl
-    steps
-    subst_vars
-    rfl
+  enter_decl
+  steps
+  subst_vars
+  rfl

--- a/Lampe/Tests/Envs.lean
+++ b/Lampe/Tests/Envs.lean
@@ -56,7 +56,7 @@ example {p} {fieldArg : Fp p}:
     fun v => v = 2 * fieldArg := by
   simp only [both_trait_call]
   steps
-  step_as (⟦⟧) (fun v => v = (2 * u8Arg : Tp.denote p (Tp.u 8)))
+  step_as (⟦⟧) (fun v => v = (2 * u8Arg : U 8))
   · try_all_traits [] compoundEnv
     steps
     casesm* ∃ _, _
@@ -64,7 +64,7 @@ example {p} {fieldArg : Fp p}:
     bv_decide
 
   steps
-  step_as (⟦z = 2 * u8Arg⟧) (fun v => v = (2 * u8Arg : Tp.denote p (Tp.u 8)))
+  step_as (⟦z = 2 * u8Arg⟧) (fun v => v = (2 * u8Arg : U 8))
   · assumption
   · enter_decl
     steps
@@ -72,7 +72,7 @@ example {p} {fieldArg : Fp p}:
     rfl
 
   steps
-  step_as (⟦z = 2 * u8Arg⟧) (fun v => v = (2 * fieldArg : Tp.denote p Tp.field))
+  step_as (⟦z = 2 * u8Arg⟧) (fun v => v = (2 * fieldArg : Fp p))
   · assumption
   · try_all_traits [] compoundEnv
     steps

--- a/Lampe/Tests/Errors.lean
+++ b/Lampe/Tests/Errors.lean
@@ -1,0 +1,67 @@
+import Lampe
+
+open Lampe
+
+-- TODO: I'm using this file for testing, delete before I merging
+
+nr_def fib<@N : u32>() -> Field {
+    let mut a = 0 : Field;
+    let mut b = 1 : Field;
+    for _? in 0 : u32 .. u@N {
+            let temp = a;
+        a = b;
+        b = #fAdd(temp, b) : Field;
+        skip;
+    };
+    a;
+}
+
+def env := Lampe.Env.mk [fib] []
+
+open Lampe
+
+variable {p : Prime}
+
+def Ref.fib : Nat → Nat
+| 0 => 0
+| 1 => 1
+| n + 2 => fib (n + 1) + fib n
+
+def Spec.fib (p) (N : U 32) : Fp p :=
+  Ref.fib N.toNat
+
+@[simp]
+lemma fib_induction (i : U 32) (hhi : i < (2 ^ 32 : Nat) - 2)
+    : Spec.fib p (i + 2) = Spec.fib _ (i + 1) + Spec.fib _ i := by
+  simp only [Spec.fib, fib]
+  repeat rw [BitVec.toNat_add]
+  simp
+  have h2 : i.toNat + 2 < 4294967296 := by
+    have : i.toNat < 2 ^32 - 2 := by change i < (2 ^ 32 : Nat) - 2; assumption
+    omega
+  have h1 : i.toNat + 1 < 4294967296 := by omega
+  rw [Nat.mod_eq_of_lt h2, Nat.mod_eq_of_lt h1]
+  simp [Ref.fib]
+
+open Spec in
+theorem fib_spec {N : U 32} (h : N < (2 ^ 32 : Nat) - 2) :
+    STHoare p env ⟦⟧ (fib.call h![N] h![])
+      fun output => output = fib p N := by
+  enter_decl
+  steps
+  loop_inv fun i _ _ => ([a ↦ ⟨Tp.field, fib p i⟩] ⋆ [b ↦ ⟨Tp.field, fib p (i + 1)⟩])
+  · change 0 ≤ N; bv_decide
+  · intros i _ _
+    steps
+    · intros
+      congr
+      simp_all
+    · congr
+      simp_all
+      rw [add_comm]
+      calc fib p (i + 1) + fib p i = fib p (i + 2) := by rw [fib_induction (p := p) i (by bv_decide)]
+        _ = fib p (i + (1 + 1)) := by rfl
+        _ = fib p (i + 1 + 1) := by rw [BitVec.add_assoc]
+  · steps
+    subst_vars
+    rfl

--- a/Lampe/Tests/Errors.lean
+++ b/Lampe/Tests/Errors.lean
@@ -65,3 +65,16 @@ theorem fib_spec {N : U 32} (h : N < (2 ^ 32 : Nat) - 2) :
   · steps
     subst_vars
     rfl
+
+-- TODO: Make this error way better
+
+nr_def hello<>() -> str<5> {
+  "hello"
+}
+
+theorem t1 {lp}: STHoare lp env (⟦⟧)
+    (hello.call h![] h![])
+      fun output => (String.mk output.toList) = hello2 := by
+      -- fun output => output = (hello2, by rfl) := by
+  enter_decl
+

--- a/Lampe/Tests/Errors.lean
+++ b/Lampe/Tests/Errors.lean
@@ -31,7 +31,7 @@ Additional diagnostic information may be available using the `set_option diagnos
 theorem enter_block_error : STHoare p helloEnv ⟦⟧ (hello.call h![] h![])
     fun output => (String.mk output.toList) = "hello" := by
   enter_decl
-  enter_block_as (⟦⟧) (fun (v : Tp.denote p (Tp.str 5)) => (String.mk v.toList) = 5)
+  step_as (⟦⟧) (fun (v : Tp.denote p (Tp.str 5)) => (String.mk v.toList) = 5)
   sorry
 
 /- testing steps error messaging -/

--- a/Lampe/Tests/Errors.lean
+++ b/Lampe/Tests/Errors.lean
@@ -66,15 +66,35 @@ theorem fib_spec {N : U 32} (h : N < (2 ^ 32 : Nat) - 2) :
     subst_vars
     rfl
 
--- TODO: Make this error way better
-
 nr_def hello<>() -> str<5> {
   "hello"
 }
 
+-- TODO: Make this error way better
+/--
+error: tactic 'rfl' failed, the left-hand side
+  List.find?
+    (fun x ↦
+      match x with
+      | { name := n, «fn» := «fn» } => decide (n = hello.name))
+    env.functions
+is not definitionally equal to the right-hand side
+  some { name := hello.name, «fn» := ?m.8313 }
+lp : Lampe.Prime
+⊢ List.find?
+      (fun x ↦
+        match x with
+        | { name := n, «fn» := «fn» } => decide (n = hello.name))
+      env.functions =
+    some { name := hello.name, «fn» := ?m.8313 }
+---
+error: unsolved goals
+lp : Lampe.Prime
+⊢ STHoare lp env ⟦True⟧ ((hello.fn.body (Tp.denote lp) h![]).body h![]) fun output ↦
+    ⟦{ data := List.Vector.toList output } = "hello"⟧
+-/
+#guard_msgs in
 theorem t1 {lp}: STHoare lp env (⟦⟧)
     (hello.call h![] h![])
-      fun output => (String.mk output.toList) = hello2 := by
-      -- fun output => output = (hello2, by rfl) := by
+      fun output => (String.mk output.toList) = "hello" := by
   enter_decl
-

--- a/Lampe/Tests/Errors.lean
+++ b/Lampe/Tests/Errors.lean
@@ -2,7 +2,7 @@ import Lampe
 
 open Lampe
 
-nr_def hello<>() -> str<5> {
+noir_def hello<>() -> String<5 : u32> := {
   "hello"
 }
 
@@ -44,11 +44,11 @@ theorem steps_error : STHoare p helloEnv ⟦⟧ (hello.call h![] h![])
   steps [bad_lemma]
   sorry
 
-nr_def loop_fn<>() -> Field {
-  let mut t = (1 : Field);
+noir_def loop_fn<>() -> Field := {
+  let mut (t : Field) = 1 : Field;
 
-  for _i in (0 : u32)..(5 : u32) {
-    t = #fMul(t, 2 : Field) : Field;
+  for _i in (0 : u32)..(5 : u32) do {
+    t = (#_fMul returning Field)(t, 2 : Field);
   } ;
   t
 }

--- a/Lampe/Tests/Negatives.lean
+++ b/Lampe/Tests/Negatives.lean
@@ -17,7 +17,7 @@ example : STHoare p env ⟦⟧ (zero_by_another_name.fn.body _ h![] |>.body h![]
   simp only [zero_by_another_name]
   steps
 
-  step_as (⟦⟧) (fun v => v = (-1 : Tp.denote p Tp.field))
+  step_as (⟦⟧) (fun v => v = (-1 : Fp p))
   · enter_decl
     steps
     simp_all

--- a/Lampe/Tests/Negatives.lean
+++ b/Lampe/Tests/Negatives.lean
@@ -17,11 +17,10 @@ example : STHoare p env ⟦⟧ (zero_by_another_name.fn.body _ h![] |>.body h![]
   simp only [zero_by_another_name]
   steps
 
-  step_as (⟦⟧) (fun v => v = -1)
+  step_as (⟦⟧) (fun v => v = (-1 : Tp.denote p Tp.field))
   · enter_decl
     steps
     simp_all
 
   steps
   simp_all
-

--- a/Lampe/Tests/Syntax.lean
+++ b/Lampe/Tests/Syntax.lean
@@ -285,7 +285,7 @@ example : STHoare p ⟨[add_two_fields], []⟩ ⟦⟧
     fun (v : Tp.denote p .field) => v = 3 := by
   simp only [call_decl]
   steps
-  step_as (⟦⟧) (fun v => v = 3)
+  step_as (⟦⟧) (fun (v : Fp p) => v = 3)
   . assumption
   · enter_decl
     simp only [add_two_fields]
@@ -488,12 +488,12 @@ example : STHoare p ⟨[return_ten, call_function], []⟩ ⟦⟧ (simple_hof.fn.
   apply pluck_final_pure_destructively
   rintro rfl
 
-  step_as (⟦⟧) (fun v => v = 10)
+  step_as (⟦⟧) (fun (v : Fp p) => v = 10)
   . assumption
   . enter_decl
     simp only [call_function]
 
-    step_as (⟦⟧) (fun v => v = 10)
+    step_as (⟦⟧) (fun (v : Fp p) => v = 10)
     . assumption
     . enter_decl
       steps

--- a/testing/Merkle/lampe/Merkle-0.0.0/Spec.lean
+++ b/testing/Merkle/lampe/Merkle-0.0.0/Spec.lean
@@ -214,7 +214,7 @@ theorem to_le_bits_intro {input} : STHoare lp env ⟦⟧ («utils::bits::to_le_b
       ([val ↦ ⟨.field, input⟩] ⋆ [bits ↦ v])
       (fun _ => [val ↦ ⟨.field, 0⟩] ⋆ [bits ↦ ⟨(Tp.u 1).array 256, Fp.toBitsLE 256 input⟩])
 
-    loop_inv nat fun i _ _ => [val ↦ ⟨.field, ↑(input.val / 2^i)⟩] ⋆ [bits ↦ ⟨(Tp.u 1).array 256, Fp.toBitsLE i input |>.pad 256 0⟩]
+    loop_inv nat fun i _ _ => [val ↦ ⟨.field, (↑(input.val / 2^i) : Fp lp)⟩] ⋆ [bits ↦ ⟨(Tp.u 1).array 256, Fp.toBitsLE i input |>.pad 256 0⟩]
     · decide
     · simp [Int.cast, IntCast.intCast, Fp.cast_self]
     · have : input.val / 115792089237316195423570985008687907853269984665640564039457584007913129639936 = 0 := by
@@ -234,7 +234,7 @@ theorem to_le_bits_intro {input} : STHoare lp env ⟦⟧ («utils::bits::to_le_b
         rfl
       step_as v =>
         ([val ↦ ⟨.field, v⟩])
-        (fun _ => [val ↦ ⟨.field, ↑(v.val / 2)⟩])
+        (fun _ => [val ↦ ⟨.field, (↑(v.val / 2) : Fp lp)⟩])
       · simp only [pow_succ]
         congr 2
         rw [ZMod.val_natCast, Nat.mod_eq_of_lt]
@@ -360,7 +360,7 @@ theorem from_le_bytes_intro {input} : STHoare lp env ⟦⟧ («utils::bytes::fro
   enter_decl
   steps
 
-  loop_inv nat fun i _ _ => [v ↦ ⟨.field, 256 ^ i⟩] ⋆ [result ↦ ⟨.field, Lampe.Fp.ofBytesLE $ input.toList.take i⟩]
+  loop_inv nat fun i _ _ => [v ↦ ⟨.field, (256 ^ i : Fp lp)⟩] ⋆ [result ↦ ⟨.field, Lampe.Fp.ofBytesLE $ input.toList.take i⟩]
   · decide
   · intro i _ hhi
     steps
@@ -574,6 +574,7 @@ theorem bar_intro : STHoare lp env ⟦⟧ («bar::bar».call h![] h![input])
     · subst_vars
       steps
   steps [as_array_intro, from_le_bytes_intro]
+
   rotate_left
   · subst_vars; rfl
   · subst_vars; rfl

--- a/testing/MerkleFromScratch/user_files/Spec.lean
+++ b/testing/MerkleFromScratch/user_files/Spec.lean
@@ -215,7 +215,7 @@ theorem to_le_bits_intro {input} : STHoare lp env ⟦⟧ («utils::bits::to_le_b
       ([val ↦ ⟨.field, input⟩] ⋆ [bits ↦ v])
       (fun _ => [val ↦ ⟨.field, 0⟩] ⋆ [bits ↦ ⟨(Tp.u 1).array 256, Fp.toBitsLE 256 input⟩])
 
-    loop_inv nat fun i _ _ => [val ↦ ⟨.field, ↑(input.val / 2^i)⟩] ⋆ [bits ↦ ⟨(Tp.u 1).array 256, Fp.toBitsLE i input |>.pad 256 0⟩]
+    loop_inv nat fun i _ _ => [val ↦ ⟨.field, (↑(input.val / 2^i) : Fp lp)⟩] ⋆ [bits ↦ ⟨(Tp.u 1).array 256, Fp.toBitsLE i input |>.pad 256 0⟩]
     · decide
     · simp [Int.cast, IntCast.intCast, Fp.cast_self]
     · have : input.val / 115792089237316195423570985008687907853269984665640564039457584007913129639936 = 0 := by
@@ -235,7 +235,7 @@ theorem to_le_bits_intro {input} : STHoare lp env ⟦⟧ («utils::bits::to_le_b
         rfl
       step_as v =>
         ([val ↦ ⟨.field, v⟩])
-        (fun _ => [val ↦ ⟨.field, ↑(v.val / 2)⟩])
+        (fun _ => [val ↦ ⟨.field, (↑(v.val / 2) : Fp lp)⟩])
       · simp only [pow_succ]
         congr 2
         rw [ZMod.val_natCast, Nat.mod_eq_of_lt]
@@ -361,7 +361,7 @@ theorem from_le_bytes_intro {input} : STHoare lp env ⟦⟧ («utils::bytes::fro
   enter_decl
   steps
 
-  loop_inv nat fun i _ _ => [v ↦ ⟨.field, 256 ^ i⟩] ⋆ [result ↦ ⟨.field, Lampe.Fp.ofBytesLE $ input.toList.take i⟩]
+  loop_inv nat fun i _ _ => [v ↦ ⟨.field, (256 ^ i : Fp lp)⟩] ⋆ [result ↦ ⟨.field, Lampe.Fp.ofBytesLE $ input.toList.take i⟩]
   · decide
   · intro i _ hhi
     steps


### PR DESCRIPTION
This PR improves the error handling for some of our tactics, addressing #92.

* `steps` flags unkonwn supplied lemmas instead of failing silently
* `enter_block_as` and `loop_inv` flag incorrectly formatted/nonsense pre and post conditions instead of failing silently
* `enter_decl` gives a more insightful error when the declaration is not in the environment 

It also adds configuration options to `steps` with the syntax
`steps <limit> [<lemmas>] +config1 +config2 -not_config3 ...`
So far only `+strict` is detected, but it leaves open the option for more fine-grained steps behavior

TODOs:
- [x] Improve `enter_decl` error handling
- [x] Figure out the issue with type unification in pre and post conditions
- [x] Figure out if we can get rid of the `term` field in `AddLemma`