### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/ci-noir.yaml
+++ b/.github/workflows/ci-noir.yaml
@@ -10,7 +10,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
           - name: Checkout Noir repo
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
             with:
               repository: noir-lang/noir
               ref: 5071093f9b51e111a49a5f78d827774ef8e80c74
@@ -30,7 +30,7 @@ jobs:
             working-directory: noir/test_programs
             run: ./rebuild.sh
           - name: Checkout Lampe repo
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
             with:
               path: lampe
           - name: Install xonsh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install xonsh
         run: |
           export DEBIAN_FRONTEND=noninteractive
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (sparse)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             Lampe
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: lampe
       - name: Set up Rust
@@ -76,7 +76,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Install rust
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: lampe
       - name: Set up Rust
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: lampe
       - name: Set up Rust
@@ -140,7 +140,7 @@ jobs:
       LAMPE_TEST_CURRENT_COMMIT_SHA: ${{ github.head_ref }}
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: lampe
       - name: Install xonsh


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0