### PR TITLE
Fix handling of impl-block generics

### DIFF
--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Aes128.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Aes128.lean
@@ -8,11 +8,11 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def aes128::aes128_encrypt<N: u32>(input: Array<u8, N: u32>, iv: Array<u8, 16: u32>, key: Array<u8, 16: u32>) -> Array<u8, ((N + 16) - (N % 16)): u32> := {
+noir_def std::aes128::aes128_encrypt<N: u32>(input: Array<u8, N: u32>, iv: Array<u8, 16: u32>, key: Array<u8, 16: u32>) -> Array<u8, ((N + 16) - (N % 16)): u32> := {
   (#_aes128_encrypt returning Array<u8, ((N + 16) - (N % 16)): u32>)(input, iv, key)
 }
 
 
 def Aes128.env : Env := Env.mk
-  [«aes128::aes128_encrypt»]
+  [«std::aes128::aes128_encrypt»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Append.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Append.lean
@@ -14,7 +14,7 @@ noir_trait_impl[impl_315]<T: Type> std::append::Append<> for Slice<T> where [] :
   };
   
   noir_def append<>(self: Slice<T>, other: Slice<T>) -> Slice<T> := {
-    (std::slice::append<> as λ(Slice<T>, Slice<T>) -> Slice<T>)(self, other)
+    (std::slice::append<T> as λ(Slice<T>, Slice<T>) -> Slice<T>)(self, other)
   };
 }
 

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Array/CheckShuffle.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Array/CheckShuffle.lean
@@ -8,15 +8,15 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def array::check_shuffle::__get_shuffle_indices<T: Type, N: u32>(lhs: Array<T, N: u32>, rhs: Array<T, N: u32>) -> Array<u32, N: u32> := {
+noir_def std::array::check_shuffle::__get_shuffle_indices<T: Type, N: u32>(lhs: Array<T, N: u32>, rhs: Array<T, N: u32>) -> Array<u32, N: u32> := {
   (#_fresh returning Array<u32, N: u32>)()
 }
 
-noir_def array::check_shuffle::__get_index<N: u32>(indices: Array<u32, N: u32>, idx: u32) -> u32 := {
+noir_def std::array::check_shuffle::__get_index<N: u32>(indices: Array<u32, N: u32>, idx: u32) -> u32 := {
   (#_fresh returning u32)()
 }
 
-noir_def array::check_shuffle::check_shuffle<T: Type, N: u32>(lhs: Array<T, N: u32>, rhs: Array<T, N: u32>) -> Unit := {
+noir_def std::array::check_shuffle::check_shuffle<T: Type, N: u32>(lhs: Array<T, N: u32>, rhs: Array<T, N: u32>) -> Unit := {
   let (shuffle_indices: Array<u32, N: u32>) = (array::check_shuffle::__get_shuffle_indices<T, N: u32> as λ(Array<T, N: u32>, Array<T, N: u32>) -> Array<u32, N: u32>)(lhs, rhs);
   for i in (0: u32) .. uConst!(N: u32) do {
     let (idx: u32) = (array::check_shuffle::__get_index<N: u32> as λ(Array<u32, N: u32>, u32) -> u32)(shuffle_indices, i);
@@ -39,35 +39,35 @@ noir_trait_impl[impl_23]<> std::cmp::Eq<> for std::array::check_shuffle::test::C
   };
 }
 
-noir_def array::check_shuffle::test::test_shuffle<>() -> Unit := {
+noir_def std::array::check_shuffle::test::test_shuffle<>() -> Unit := {
   let (lhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
   let (rhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((2: Field), (0: Field), (3: Field), (1: Field), (4: Field));
   (array::check_shuffle::check_shuffle<Field, 5: u32> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> Unit)(lhs, rhs);
   #_skip
 }
 
-noir_def array::check_shuffle::test::test_shuffle_identity<>() -> Unit := {
+noir_def std::array::check_shuffle::test::test_shuffle_identity<>() -> Unit := {
   let (lhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
   let (rhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
   (array::check_shuffle::check_shuffle<Field, 5: u32> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> Unit)(lhs, rhs);
   #_skip
 }
 
-noir_def array::check_shuffle::test::test_shuffle_fail<>() -> Unit := {
+noir_def std::array::check_shuffle::test::test_shuffle_fail<>() -> Unit := {
   let (lhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
   let (rhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (5: Field));
   (array::check_shuffle::check_shuffle<Field, 5: u32> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> Unit)(lhs, rhs);
   #_skip
 }
 
-noir_def array::check_shuffle::test::test_shuffle_duplicates<>() -> Unit := {
+noir_def std::array::check_shuffle::test::test_shuffle_duplicates<>() -> Unit := {
   let (lhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
   let (rhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (3: Field));
   (array::check_shuffle::check_shuffle<Field, 5: u32> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> Unit)(lhs, rhs);
   #_skip
 }
 
-noir_def array::check_shuffle::test::test_shuffle_compound_struct<>() -> Unit := {
+noir_def std::array::check_shuffle::test::test_shuffle_compound_struct<>() -> Unit := {
   let (lhs: Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>) = (#_mkArray returning Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>)((#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (0: Field), (12345: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (-100: Field), (54321: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_true, (5: Field), (18446744073709551615: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_true, (9814: Field), (17221745184140693811: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (341: Field), (0: u64)));
   let (rhs: Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>) = (#_mkArray returning Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>)((#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (341: Field), (0: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (0: Field), (12345: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (-100: Field), (54321: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_true, (9814: Field), (17221745184140693811: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_true, (5: Field), (18446744073709551615: u64)));
   (array::check_shuffle::check_shuffle<std::array::check_shuffle::test::CompoundStruct<>, 5: u32> as λ(Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>, Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>) -> Unit)(lhs, rhs);
@@ -76,5 +76,5 @@ noir_def array::check_shuffle::test::test_shuffle_compound_struct<>() -> Unit :=
 
 
 def Array.CheckShuffle.env : Env := Env.mk
-  [«array::check_shuffle::__get_shuffle_indices», «array::check_shuffle::__get_index», «array::check_shuffle::check_shuffle», «array::check_shuffle::test::test_shuffle», «array::check_shuffle::test::test_shuffle_identity», «array::check_shuffle::test::test_shuffle_fail», «array::check_shuffle::test::test_shuffle_duplicates», «array::check_shuffle::test::test_shuffle_compound_struct»]
+  [«std::array::check_shuffle::__get_shuffle_indices», «std::array::check_shuffle::__get_index», «std::array::check_shuffle::check_shuffle», «std::array::check_shuffle::test::test_shuffle», «std::array::check_shuffle::test::test_shuffle_identity», «std::array::check_shuffle::test::test_shuffle_fail», «std::array::check_shuffle::test::test_shuffle_duplicates», «std::array::check_shuffle::test::test_shuffle_compound_struct»]
   [impl_23]

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Array/Mod.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Array/Mod.lean
@@ -10,12 +10,12 @@ namespace Extracted
 
 noir_trait_impl[impl_24]<N: u32> std::convert::From<String<N: u32> > for Array<u8, N: u32> where [] := {
   noir_def from<>(s: String<N: u32>) -> Array<u8, N: u32> := {
-    (std::string::as_bytes<> as λ(String<N: u32>) -> Array<u8, N: u32>)(s)
+    (std::string::as_bytes<N: u32> as λ(String<N: u32>) -> Array<u8, N: u32>)(s)
   };
 }
 
-noir_def array::test::map_empty<>() -> Unit := {
-  (#_assert returning Unit)(((Array<Field, 0: u32> as Eq<>)::eq<> as λ(Array<Field, 0: u32>, Array<Field, 0: u32>) -> bool)((std::array::map<Field, Unit> as λ(Array<Field, 0: u32>, λ(Field) -> Field) -> Array<Field, 0: u32>)((#_mkArray returning Array<Field, 0: u32>)(), (fn((x: Field)): Field := (#_fAdd returning Field)(x, (1: Field)))), (#_mkArray returning Array<Field, 0: u32>)()));
+noir_def std::array::test::map_empty<>() -> Unit := {
+  (#_assert returning Unit)(((Array<Field, 0: u32> as Eq<>)::eq<> as λ(Array<Field, 0: u32>, Array<Field, 0: u32>) -> bool)((std::array::map<Field, 0: u32, Unit> as λ(Array<Field, 0: u32>, λ(Field) -> Field) -> Array<Field, 0: u32>)((#_mkArray returning Array<Field, 0: u32>)(), (fn((x: Field)): Field := (#_fAdd returning Field)(x, (1: Field)))), (#_mkArray returning Array<Field, 0: u32>)()));
   #_skip
 }
 
@@ -23,86 +23,86 @@ noir_global_def arr_with_100_values: Array<u32, 100: u32> = (#_mkArray returning
 
 noir_global_def expected_with_100_values: Array<u32, 100: u32> = (#_mkArray returning Array<u32, 100: u32>)((0: u32), (0: u32), (2: u32), (3: u32), (5: u32), (6: u32), (8: u32), (12: u32), (13: u32), (13: u32), (15: u32), (19: u32), (19: u32), (19: u32), (21: u32), (21: u32), (26: u32), (26: u32), (27: u32), (28: u32), (28: u32), (28: u32), (29: u32), (30: u32), (32: u32), (32: u32), (35: u32), (37: u32), (38: u32), (41: u32), (42: u32), (42: u32), (42: u32), (43: u32), (44: u32), (44: u32), (45: u32), (47: u32), (48: u32), (48: u32), (50: u32), (50: u32), (53: u32), (54: u32), (54: u32), (58: u32), (61: u32), (62: u32), (62: u32), (63: u32), (64: u32), (66: u32), (66: u32), (68: u32), (69: u32), (70: u32), (70: u32), (71: u32), (71: u32), (72: u32), (72: u32), (73: u32), (74: u32), (80: u32), (80: u32), (81: u32), (81: u32), (82: u32), (84: u32), (84: u32), (86: u32), (86: u32), (87: u32), (89: u32), (89: u32), (89: u32), (93: u32), (95: u32), (96: u32), (98: u32), (100: u32), (104: u32), (105: u32), (106: u32), (107: u32), (108: u32), (109: u32), (114: u32), (114: u32), (116: u32), (118: u32), (119: u32), (120: u32), (121: u32), (123: u32), (123: u32), (123: u32), (125: u32), (126: u32), (127: u32));
 
-noir_def array::test::sort_u32<>(a: u32, b: u32) -> bool := {
+noir_def std::array::test::sort_u32<>(a: u32, b: u32) -> bool := {
   (#_uLeq returning bool)(a, b)
 }
 
-noir_def array::test::test_sort<>() -> Unit := {
+noir_def std::array::test::test_sort<>() -> Unit := {
   let mut (arr: Array<u32, 7: u32>) = (#_mkArray returning Array<u32, 7: u32>)((3: u32), (6: u32), (8: u32), (10: u32), (1: u32), (2: u32), (1: u32));
-  let (sorted: Array<u32, 7: u32>) = (std::array::sort<> as λ(Array<u32, 7: u32>) -> Array<u32, 7: u32>)(arr);
+  let (sorted: Array<u32, 7: u32>) = (std::array::sort<u32, 7: u32> as λ(Array<u32, 7: u32>) -> Array<u32, 7: u32>)(arr);
   let (expected: Array<u32, 7: u32>) = (#_mkArray returning Array<u32, 7: u32>)((1: u32), (1: u32), (2: u32), (3: u32), (6: u32), (8: u32), (10: u32));
   (#_assert returning Unit)(((Array<u32, 7: u32> as Eq<>)::eq<> as λ(Array<u32, 7: u32>, Array<u32, 7: u32>) -> bool)(sorted, expected));
   #_skip
 }
 
-noir_def array::test::test_sort_100_values<>() -> Unit := {
+noir_def std::array::test::test_sort_100_values<>() -> Unit := {
   let mut (arr: Array<u32, 100: u32>) = (#_mkArray returning Array<u32, 100: u32>)((42: u32), (123: u32), (87: u32), (93: u32), (48: u32), (80: u32), (50: u32), (5: u32), (104: u32), (84: u32), (70: u32), (47: u32), (119: u32), (66: u32), (71: u32), (121: u32), (3: u32), (29: u32), (42: u32), (118: u32), (2: u32), (54: u32), (89: u32), (44: u32), (81: u32), (0: u32), (26: u32), (106: u32), (68: u32), (96: u32), (84: u32), (48: u32), (95: u32), (54: u32), (45: u32), (32: u32), (89: u32), (100: u32), (109: u32), (19: u32), (37: u32), (41: u32), (19: u32), (98: u32), (53: u32), (114: u32), (107: u32), (66: u32), (6: u32), (74: u32), (13: u32), (19: u32), (105: u32), (64: u32), (123: u32), (28: u32), (44: u32), (50: u32), (89: u32), (58: u32), (123: u32), (126: u32), (21: u32), (43: u32), (86: u32), (35: u32), (21: u32), (62: u32), (82: u32), (0: u32), (108: u32), (120: u32), (72: u32), (72: u32), (62: u32), (80: u32), (12: u32), (71: u32), (70: u32), (86: u32), (116: u32), (73: u32), (38: u32), (15: u32), (127: u32), (81: u32), (30: u32), (8: u32), (125: u32), (28: u32), (26: u32), (69: u32), (114: u32), (63: u32), (27: u32), (28: u32), (61: u32), (42: u32), (13: u32), (32: u32));
-  let (sorted: Array<u32, 100: u32>) = (std::array::sort<> as λ(Array<u32, 100: u32>) -> Array<u32, 100: u32>)(arr);
+  let (sorted: Array<u32, 100: u32>) = (std::array::sort<u32, 100: u32> as λ(Array<u32, 100: u32>) -> Array<u32, 100: u32>)(arr);
   let (expected: Array<u32, 100: u32>) = (#_mkArray returning Array<u32, 100: u32>)((0: u32), (0: u32), (2: u32), (3: u32), (5: u32), (6: u32), (8: u32), (12: u32), (13: u32), (13: u32), (15: u32), (19: u32), (19: u32), (19: u32), (21: u32), (21: u32), (26: u32), (26: u32), (27: u32), (28: u32), (28: u32), (28: u32), (29: u32), (30: u32), (32: u32), (32: u32), (35: u32), (37: u32), (38: u32), (41: u32), (42: u32), (42: u32), (42: u32), (43: u32), (44: u32), (44: u32), (45: u32), (47: u32), (48: u32), (48: u32), (50: u32), (50: u32), (53: u32), (54: u32), (54: u32), (58: u32), (61: u32), (62: u32), (62: u32), (63: u32), (64: u32), (66: u32), (66: u32), (68: u32), (69: u32), (70: u32), (70: u32), (71: u32), (71: u32), (72: u32), (72: u32), (73: u32), (74: u32), (80: u32), (80: u32), (81: u32), (81: u32), (82: u32), (84: u32), (84: u32), (86: u32), (86: u32), (87: u32), (89: u32), (89: u32), (89: u32), (93: u32), (95: u32), (96: u32), (98: u32), (100: u32), (104: u32), (105: u32), (106: u32), (107: u32), (108: u32), (109: u32), (114: u32), (114: u32), (116: u32), (118: u32), (119: u32), (120: u32), (121: u32), (123: u32), (123: u32), (123: u32), (125: u32), (126: u32), (127: u32));
   (#_assert returning Unit)(((Array<u32, 100: u32> as Eq<>)::eq<> as λ(Array<u32, 100: u32>, Array<u32, 100: u32>) -> bool)(sorted, expected));
   #_skip
 }
 
-noir_def array::test::test_sort_100_values_comptime<>() -> Unit := {
-  let (sorted: Array<u32, 100: u32>) = (std::array::sort<> as λ(Array<u32, 100: u32>) -> Array<u32, 100: u32>)((arr_with_100_values<> as λ() -> Array<u32, 100: u32>)());
+noir_def std::array::test::test_sort_100_values_comptime<>() -> Unit := {
+  let (sorted: Array<u32, 100: u32>) = (std::array::sort<u32, 100: u32> as λ(Array<u32, 100: u32>) -> Array<u32, 100: u32>)((arr_with_100_values<> as λ() -> Array<u32, 100: u32>)());
   (#_assert returning Unit)(((Array<u32, 100: u32> as Eq<>)::eq<> as λ(Array<u32, 100: u32>, Array<u32, 100: u32>) -> bool)(sorted, (expected_with_100_values<> as λ() -> Array<u32, 100: u32>)()));
   #_skip
 }
 
-noir_def array::test::test_sort_via<>() -> Unit := {
+noir_def std::array::test::test_sort_via<>() -> Unit := {
   let mut (arr: Array<u32, 7: u32>) = (#_mkArray returning Array<u32, 7: u32>)((3: u32), (6: u32), (8: u32), (10: u32), (1: u32), (2: u32), (1: u32));
-  let (sorted: Array<u32, 7: u32>) = (std::array::sort_via<Unit> as λ(Array<u32, 7: u32>, λ(u32, u32) -> bool) -> Array<u32, 7: u32>)(arr, (array::test::sort_u32<> as λ(u32, u32) -> bool));
+  let (sorted: Array<u32, 7: u32>) = (std::array::sort_via<u32, 7: u32, Unit> as λ(Array<u32, 7: u32>, λ(u32, u32) -> bool) -> Array<u32, 7: u32>)(arr, (array::test::sort_u32<> as λ(u32, u32) -> bool));
   let (expected: Array<u32, 7: u32>) = (#_mkArray returning Array<u32, 7: u32>)((1: u32), (1: u32), (2: u32), (3: u32), (6: u32), (8: u32), (10: u32));
   (#_assert returning Unit)(((Array<u32, 7: u32> as Eq<>)::eq<> as λ(Array<u32, 7: u32>, Array<u32, 7: u32>) -> bool)(sorted, expected));
   #_skip
 }
 
-noir_def array::test::test_sort_via_100_values<>() -> Unit := {
+noir_def std::array::test::test_sort_via_100_values<>() -> Unit := {
   let mut (arr: Array<u32, 100: u32>) = (#_mkArray returning Array<u32, 100: u32>)((42: u32), (123: u32), (87: u32), (93: u32), (48: u32), (80: u32), (50: u32), (5: u32), (104: u32), (84: u32), (70: u32), (47: u32), (119: u32), (66: u32), (71: u32), (121: u32), (3: u32), (29: u32), (42: u32), (118: u32), (2: u32), (54: u32), (89: u32), (44: u32), (81: u32), (0: u32), (26: u32), (106: u32), (68: u32), (96: u32), (84: u32), (48: u32), (95: u32), (54: u32), (45: u32), (32: u32), (89: u32), (100: u32), (109: u32), (19: u32), (37: u32), (41: u32), (19: u32), (98: u32), (53: u32), (114: u32), (107: u32), (66: u32), (6: u32), (74: u32), (13: u32), (19: u32), (105: u32), (64: u32), (123: u32), (28: u32), (44: u32), (50: u32), (89: u32), (58: u32), (123: u32), (126: u32), (21: u32), (43: u32), (86: u32), (35: u32), (21: u32), (62: u32), (82: u32), (0: u32), (108: u32), (120: u32), (72: u32), (72: u32), (62: u32), (80: u32), (12: u32), (71: u32), (70: u32), (86: u32), (116: u32), (73: u32), (38: u32), (15: u32), (127: u32), (81: u32), (30: u32), (8: u32), (125: u32), (28: u32), (26: u32), (69: u32), (114: u32), (63: u32), (27: u32), (28: u32), (61: u32), (42: u32), (13: u32), (32: u32));
-  let (sorted: Array<u32, 100: u32>) = (std::array::sort_via<Unit> as λ(Array<u32, 100: u32>, λ(u32, u32) -> bool) -> Array<u32, 100: u32>)(arr, (array::test::sort_u32<> as λ(u32, u32) -> bool));
+  let (sorted: Array<u32, 100: u32>) = (std::array::sort_via<u32, 100: u32, Unit> as λ(Array<u32, 100: u32>, λ(u32, u32) -> bool) -> Array<u32, 100: u32>)(arr, (array::test::sort_u32<> as λ(u32, u32) -> bool));
   let (expected: Array<u32, 100: u32>) = (#_mkArray returning Array<u32, 100: u32>)((0: u32), (0: u32), (2: u32), (3: u32), (5: u32), (6: u32), (8: u32), (12: u32), (13: u32), (13: u32), (15: u32), (19: u32), (19: u32), (19: u32), (21: u32), (21: u32), (26: u32), (26: u32), (27: u32), (28: u32), (28: u32), (28: u32), (29: u32), (30: u32), (32: u32), (32: u32), (35: u32), (37: u32), (38: u32), (41: u32), (42: u32), (42: u32), (42: u32), (43: u32), (44: u32), (44: u32), (45: u32), (47: u32), (48: u32), (48: u32), (50: u32), (50: u32), (53: u32), (54: u32), (54: u32), (58: u32), (61: u32), (62: u32), (62: u32), (63: u32), (64: u32), (66: u32), (66: u32), (68: u32), (69: u32), (70: u32), (70: u32), (71: u32), (71: u32), (72: u32), (72: u32), (73: u32), (74: u32), (80: u32), (80: u32), (81: u32), (81: u32), (82: u32), (84: u32), (84: u32), (86: u32), (86: u32), (87: u32), (89: u32), (89: u32), (89: u32), (93: u32), (95: u32), (96: u32), (98: u32), (100: u32), (104: u32), (105: u32), (106: u32), (107: u32), (108: u32), (109: u32), (114: u32), (114: u32), (116: u32), (118: u32), (119: u32), (120: u32), (121: u32), (123: u32), (123: u32), (123: u32), (125: u32), (126: u32), (127: u32));
   (#_assert returning Unit)(((Array<u32, 100: u32> as Eq<>)::eq<> as λ(Array<u32, 100: u32>, Array<u32, 100: u32>) -> bool)(sorted, expected));
   #_skip
 }
 
-noir_def array::test::mapi_empty<>() -> Unit := {
-  (#_assert returning Unit)(((Array<u32, 0: u32> as Eq<>)::eq<> as λ(Array<u32, 0: u32>, Array<u32, 0: u32>) -> bool)((std::array::mapi<u32, Unit> as λ(Array<u32, 0: u32>, λ(u32, u32) -> u32) -> Array<u32, 0: u32>)((#_mkArray returning Array<u32, 0: u32>)(), (fn((i: u32), (x: u32)): u32 := (#_uAdd returning u32)((#_uMul returning u32)(i, x), (1: u32)))), (#_mkArray returning Array<u32, 0: u32>)()));
+noir_def std::array::test::mapi_empty<>() -> Unit := {
+  (#_assert returning Unit)(((Array<u32, 0: u32> as Eq<>)::eq<> as λ(Array<u32, 0: u32>, Array<u32, 0: u32>) -> bool)((std::array::mapi<u32, 0: u32, Unit> as λ(Array<u32, 0: u32>, λ(u32, u32) -> u32) -> Array<u32, 0: u32>)((#_mkArray returning Array<u32, 0: u32>)(), (fn((i: u32), (x: u32)): u32 := (#_uAdd returning u32)((#_uMul returning u32)(i, x), (1: u32)))), (#_mkArray returning Array<u32, 0: u32>)()));
   #_skip
 }
 
-noir_def array::test::for_each_empty<>() -> Unit := {
+noir_def std::array::test::for_each_empty<>() -> Unit := {
   let (empty_array: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
-  (std::array::for_each<Unit> as λ(Array<Field, 0: u32>, λ(Field) -> Unit) -> Unit)(empty_array, (fn((_x: Field)): Unit := (#_assert returning Unit)(#_false)));
+  (std::array::for_each<Field, 0: u32, Unit> as λ(Array<Field, 0: u32>, λ(Field) -> Unit) -> Unit)(empty_array, (fn((_x: Field)): Unit := (#_assert returning Unit)(#_false)));
   #_skip
 }
 
-noir_def array::test::for_eachi_empty<>() -> Unit := {
+noir_def std::array::test::for_eachi_empty<>() -> Unit := {
   let (empty_array: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
-  (std::array::for_eachi<Unit> as λ(Array<Field, 0: u32>, λ(u32, Field) -> Unit) -> Unit)(empty_array, (fn((_i: u32), (_x: Field)): Unit := (#_assert returning Unit)(#_false)));
+  (std::array::for_eachi<Field, 0: u32, Unit> as λ(Array<Field, 0: u32>, λ(u32, Field) -> Unit) -> Unit)(empty_array, (fn((_i: u32), (_x: Field)): Unit := (#_assert returning Unit)(#_false)));
   #_skip
 }
 
-noir_def array::test::map_example<>() -> Unit := {
+noir_def std::array::test::map_example<>() -> Unit := {
   let (a: Array<Field, 3: u32>) = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
-  let (b: Array<Field, 3: u32>) = (std::array::map<Field, Unit> as λ(Array<Field, 3: u32>, λ(Field) -> Field) -> Array<Field, 3: u32>)(a, (fn((a: Field)): Field := (#_fMul returning Field)(a, (2: Field))));
+  let (b: Array<Field, 3: u32>) = (std::array::map<Field, 3: u32, Unit> as λ(Array<Field, 3: u32>, λ(Field) -> Field) -> Array<Field, 3: u32>)(a, (fn((a: Field)): Field := (#_fMul returning Field)(a, (2: Field))));
   (#_assert returning Unit)(((Array<Field, 3: u32> as Eq<>)::eq<> as λ(Array<Field, 3: u32>, Array<Field, 3: u32>) -> bool)(b, (#_mkArray returning Array<Field, 3: u32>)((2: Field), (4: Field), (6: Field))));
   #_skip
 }
 
-noir_def array::test::mapi_example<>() -> Unit := {
+noir_def std::array::test::mapi_example<>() -> Unit := {
   let (a: Array<u32, 3: u32>) = (#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32));
-  let (b: Array<u32, 3: u32>) = (std::array::mapi<u32, Unit> as λ(Array<u32, 3: u32>, λ(u32, u32) -> u32) -> Array<u32, 3: u32>)(a, (fn((i: u32), (a: u32)): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(a, (2: u32)))));
+  let (b: Array<u32, 3: u32>) = (std::array::mapi<u32, 3: u32, Unit> as λ(Array<u32, 3: u32>, λ(u32, u32) -> u32) -> Array<u32, 3: u32>)(a, (fn((i: u32), (a: u32)): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(a, (2: u32)))));
   (#_assert returning Unit)(((Array<u32, 3: u32> as Eq<>)::eq<> as λ(Array<u32, 3: u32>, Array<u32, 3: u32>) -> bool)(b, (#_mkArray returning Array<u32, 3: u32>)((2: u32), (5: u32), (8: u32))));
   #_skip
 }
 
-noir_def array::test::for_each_example<>() -> Unit := {
+noir_def std::array::test::for_each_example<>() -> Unit := {
   let (a: Array<Field, 3: u32>) = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
   let mut (b: Array<Field, 3: u32>) = (#_mkArray returning Array<Field, 3: u32>)((0: Field), (0: Field), (0: Field));
   let (b_ref: & Array<Field, 3: u32>) = (#_ref returning & Array<Field, 3: u32>)(b);
   let mut (i: u32) = (0: u32);
   let (i_ref: & u32) = (#_ref returning & u32)(i);
-  (std::array::for_each<Tuple<& u32, & Array<Field, 3: u32> > > as λ(Array<Field, 3: u32>, λ(Field) -> Unit) -> Unit)(a, (fn((x: Field)): Unit := {
+  (std::array::for_each<Field, 3: u32, Tuple<& u32, & Array<Field, 3: u32> > > as λ(Array<Field, 3: u32>, λ(Field) -> Unit) -> Unit)(a, (fn((x: Field)): Unit := {
     {
       let (i_2925: Unit) = (#_readRef returning u32)(i_ref);
       ((*b_ref: Array<Field, 3: u32>)[i_2925]: Field) = (#_fMul returning Field)(x, (2: Field));
@@ -116,11 +116,11 @@ noir_def array::test::for_each_example<>() -> Unit := {
   #_skip
 }
 
-noir_def array::test::for_eachi_example<>() -> Unit := {
+noir_def std::array::test::for_eachi_example<>() -> Unit := {
   let (a: Array<u32, 3: u32>) = (#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32));
   let mut (b: Array<u32, 3: u32>) = (#_mkArray returning Array<u32, 3: u32>)((0: u32), (0: u32), (0: u32));
   let (b_ref: & Array<u32, 3: u32>) = (#_ref returning & Array<u32, 3: u32>)(b);
-  (std::array::for_eachi<Tuple<& Array<u32, 3: u32> > > as λ(Array<u32, 3: u32>, λ(u32, u32) -> Unit) -> Unit)(a, (fn((i: u32), (a: u32)): Unit := {
+  (std::array::for_eachi<u32, 3: u32, Tuple<& Array<u32, 3: u32> > > as λ(Array<u32, 3: u32>, λ(u32, u32) -> Unit) -> Unit)(a, (fn((i: u32), (a: u32)): Unit := {
     ((*b_ref: Array<u32, 3: u32>)[i]: u32) = (#_uAdd returning u32)(i, (#_uMul returning u32)(a, (2: u32)));
     #_skip
   }));
@@ -128,39 +128,39 @@ noir_def array::test::for_eachi_example<>() -> Unit := {
   #_skip
 }
 
-noir_def array::test::concat<>() -> Unit := {
+noir_def std::array::test::concat<>() -> Unit := {
   let (arr1: Array<Field, 4: u32>) = (#_mkArray returning Array<Field, 4: u32>)((1: Field), (2: Field), (3: Field), (4: Field));
   let (arr2: Array<Field, 6: u32>) = (#_mkArray returning Array<Field, 6: u32>)((6: Field), (7: Field), (8: Field), (9: Field), (10: Field), (11: Field));
-  let (concatenated_arr: Array<Field, (4 + 6): u32>) = (std::array::concat<6: u32> as λ(Array<Field, 4: u32>, Array<Field, 6: u32>) -> Array<Field, (4 + 6): u32>)(arr1, arr2);
+  let (concatenated_arr: Array<Field, (4 + 6): u32>) = (std::array::concat<Field, 4: u32, 6: u32> as λ(Array<Field, 4: u32>, Array<Field, 6: u32>) -> Array<Field, (4 + 6): u32>)(arr1, arr2);
   (#_assert returning Unit)(((Array<Field, (4 + 6): u32> as Eq<>)::eq<> as λ(Array<Field, (4 + 6): u32>, Array<Field, 10: u32>) -> bool)(concatenated_arr, (#_mkArray returning Array<Field, 10: u32>)((1: Field), (2: Field), (3: Field), (4: Field), (6: Field), (7: Field), (8: Field), (9: Field), (10: Field), (11: Field))));
   #_skip
 }
 
-noir_def array::test::concat_zero_length_with_something<>() -> Unit := {
+noir_def std::array::test::concat_zero_length_with_something<>() -> Unit := {
   let (arr1: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
   let (arr2: Array<Field, 1: u32>) = (#_mkArray returning Array<Field, 1: u32>)((1: Field));
-  let (concatenated_arr: Array<Field, (0 + 1): u32>) = (std::array::concat<1: u32> as λ(Array<Field, 0: u32>, Array<Field, 1: u32>) -> Array<Field, (0 + 1): u32>)(arr1, arr2);
+  let (concatenated_arr: Array<Field, (0 + 1): u32>) = (std::array::concat<Field, 0: u32, 1: u32> as λ(Array<Field, 0: u32>, Array<Field, 1: u32>) -> Array<Field, (0 + 1): u32>)(arr1, arr2);
   (#_assert returning Unit)(((Array<Field, (0 + 1): u32> as Eq<>)::eq<> as λ(Array<Field, (0 + 1): u32>, Array<Field, 1: u32>) -> bool)(concatenated_arr, (#_mkArray returning Array<Field, 1: u32>)((1: Field))));
   #_skip
 }
 
-noir_def array::test::concat_something_with_zero_length<>() -> Unit := {
+noir_def std::array::test::concat_something_with_zero_length<>() -> Unit := {
   let (arr1: Array<Field, 1: u32>) = (#_mkArray returning Array<Field, 1: u32>)((1: Field));
   let (arr2: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
-  let (concatenated_arr: Array<Field, (1 + 0): u32>) = (std::array::concat<0: u32> as λ(Array<Field, 1: u32>, Array<Field, 0: u32>) -> Array<Field, (1 + 0): u32>)(arr1, arr2);
+  let (concatenated_arr: Array<Field, (1 + 0): u32>) = (std::array::concat<Field, 1: u32, 0: u32> as λ(Array<Field, 1: u32>, Array<Field, 0: u32>) -> Array<Field, (1 + 0): u32>)(arr1, arr2);
   (#_assert returning Unit)(((Array<Field, (1 + 0): u32> as Eq<>)::eq<> as λ(Array<Field, (1 + 0): u32>, Array<Field, 1: u32>) -> bool)(concatenated_arr, (#_mkArray returning Array<Field, 1: u32>)((1: Field))));
   #_skip
 }
 
-noir_def array::test::concat_zero_lengths<>() -> Unit := {
+noir_def std::array::test::concat_zero_lengths<>() -> Unit := {
   let (arr1: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
   let (arr2: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
-  let (concatenated_arr: Array<Field, (0 + 0): u32>) = (std::array::concat<0: u32> as λ(Array<Field, 0: u32>, Array<Field, 0: u32>) -> Array<Field, (0 + 0): u32>)(arr1, arr2);
+  let (concatenated_arr: Array<Field, (0 + 0): u32>) = (std::array::concat<Field, 0: u32> as λ(Array<Field, 0: u32>, Array<Field, 0: u32>) -> Array<Field, (0 + 0): u32>)(arr1, arr2);
   (#_assert returning Unit)(((Array<Field, (0 + 0): u32> as Eq<>)::eq<> as λ(Array<Field, (0 + 0): u32>, Array<Field, 0: u32>) -> bool)(concatenated_arr, (#_mkArray returning Array<Field, 0: u32>)()));
   #_skip
 }
 
 
 def Array.Mod.env : Env := Env.mk
-  [«array::test::map_empty», arr_with_100_values, expected_with_100_values, «array::test::sort_u32», «array::test::test_sort», «array::test::test_sort_100_values», «array::test::test_sort_100_values_comptime», «array::test::test_sort_via», «array::test::test_sort_via_100_values», «array::test::mapi_empty», «array::test::for_each_empty», «array::test::for_eachi_empty», «array::test::map_example», «array::test::mapi_example», «array::test::for_each_example», «array::test::for_eachi_example», «array::test::concat», «array::test::concat_zero_length_with_something», «array::test::concat_something_with_zero_length», «array::test::concat_zero_lengths»]
+  [«std::array::test::map_empty», arr_with_100_values, expected_with_100_values, «std::array::test::sort_u32», «std::array::test::test_sort», «std::array::test::test_sort_100_values», «std::array::test::test_sort_100_values_comptime», «std::array::test::test_sort_via», «std::array::test::test_sort_via_100_values», «std::array::test::mapi_empty», «std::array::test::for_each_empty», «std::array::test::for_eachi_empty», «std::array::test::map_example», «std::array::test::mapi_example», «std::array::test::for_each_example», «std::array::test::for_eachi_example», «std::array::test::concat», «std::array::test::concat_zero_length_with_something», «std::array::test::concat_something_with_zero_length», «std::array::test::concat_zero_lengths»]
   [impl_24]

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Array/Quicksort.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Array/Quicksort.lean
@@ -8,19 +8,19 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def array::quicksort::partition<T: Type, N: u32, Env: Type>(arr: & Array<T, N: u32>, low: u32, high: u32, sortfn: λ(T, T) -> bool) -> u32 := {
+noir_def std::array::quicksort::partition<T: Type, N: u32, Env: Type>(arr: & Array<T, N: u32>, low: u32, high: u32, sortfn: λ(T, T) -> bool) -> u32 := {
   (#_fresh returning u32)()
 }
 
-noir_def array::quicksort::quicksort_loop<T: Type, N: u32, Env: Type>(arr: & Array<T, N: u32>, low: u32, high: u32, sortfn: λ(T, T) -> bool) -> Unit := {
+noir_def std::array::quicksort::quicksort_loop<T: Type, N: u32, Env: Type>(arr: & Array<T, N: u32>, low: u32, high: u32, sortfn: λ(T, T) -> bool) -> Unit := {
   (#_fresh returning Unit)()
 }
 
-noir_def array::quicksort::quicksort<T: Type, N: u32, Env: Type>(arr: Array<T, N: u32>, sortfn: λ(T, T) -> bool) -> Array<T, N: u32> := {
+noir_def std::array::quicksort::quicksort<T: Type, N: u32, Env: Type>(arr: Array<T, N: u32>, sortfn: λ(T, T) -> bool) -> Array<T, N: u32> := {
   (#_fresh returning Array<T, N: u32>)()
 }
 
 
 def Array.Quicksort.env : Env := Env.mk
-  [«array::quicksort::partition», «array::quicksort::quicksort_loop», «array::quicksort::quicksort»]
+  [«std::array::quicksort::partition», «std::array::quicksort::quicksort_loop», «std::array::quicksort::quicksort»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Cmp.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Cmp.lean
@@ -113,8 +113,8 @@ noir_trait_impl[impl_92]<T: Type> std::cmp::Eq<> for Slice<T> where [T: std::cmp
 
 noir_trait_impl[impl_93]<N: u32> std::cmp::Eq<> for String<N: u32> where [] := {
   noir_def eq<>(self: String<N: u32>, other: String<N: u32>) -> bool := {
-    let (self_bytes: Array<u8, N: u32>) = (std::string::as_bytes<> as λ(String<N: u32>) -> Array<u8, N: u32>)(self);
-    let (other_bytes: Array<u8, N: u32>) = (std::string::as_bytes<> as λ(String<N: u32>) -> Array<u8, N: u32>)(other);
+    let (self_bytes: Array<u8, N: u32>) = (std::string::as_bytes<N: u32> as λ(String<N: u32>) -> Array<u8, N: u32>)(self);
+    let (other_bytes: Array<u8, N: u32>) = (std::string::as_bytes<N: u32> as λ(String<N: u32>) -> Array<u8, N: u32>)(other);
     ((Array<u8, N: u32> as Eq<>)::eq<> as λ(Array<u8, N: u32>, Array<u8, N: u32>) -> bool)(self_bytes, other_bytes)
   };
 }
@@ -385,7 +385,7 @@ noir_trait_impl[impl_115]<A: Type, B: Type, C: Type, D: Type, E: Type> std::cmp:
   };
 }
 
-noir_def cmp::max<T: Type>(v1: T, v2: T) -> T := {
+noir_def std::cmp::max<T: Type>(v1: T, v2: T) -> T := {
   if ((T as Ord<>)::cmp<> as λ(T, T) -> bool)(v1, v2) then {
     v1
   } else {
@@ -393,7 +393,7 @@ noir_def cmp::max<T: Type>(v1: T, v2: T) -> T := {
   }
 }
 
-noir_def cmp::min<T: Type>(v1: T, v2: T) -> T := {
+noir_def std::cmp::min<T: Type>(v1: T, v2: T) -> T := {
   if ((T as Ord<>)::cmp<> as λ(T, T) -> bool)(v1, v2) then {
     v2
   } else {
@@ -401,7 +401,7 @@ noir_def cmp::min<T: Type>(v1: T, v2: T) -> T := {
   }
 }
 
-noir_def cmp::cmp_tests::sanity_check_min<>() -> Unit := {
+noir_def std::cmp::cmp_tests::sanity_check_min<>() -> Unit := {
   (#_assert returning Unit)((#_uEq returning bool)((cmp::min<u64> as λ(u64, u64) -> u64)((0: u64), (1: u64)), (0: u64)));
   (#_assert returning Unit)((#_uEq returning bool)((cmp::min<u64> as λ(u64, u64) -> u64)((0: u64), (0: u64)), (0: u64)));
   (#_assert returning Unit)((#_uEq returning bool)((cmp::min<u64> as λ(u64, u64) -> u64)((1: u64), (1: u64)), (1: u64)));
@@ -409,7 +409,7 @@ noir_def cmp::cmp_tests::sanity_check_min<>() -> Unit := {
   #_skip
 }
 
-noir_def cmp::cmp_tests::sanity_check_max<>() -> Unit := {
+noir_def std::cmp::cmp_tests::sanity_check_max<>() -> Unit := {
   (#_assert returning Unit)((#_uEq returning bool)((cmp::max<u64> as λ(u64, u64) -> u64)((0: u64), (1: u64)), (1: u64)));
   (#_assert returning Unit)((#_uEq returning bool)((cmp::max<u64> as λ(u64, u64) -> u64)((0: u64), (0: u64)), (0: u64)));
   (#_assert returning Unit)((#_uEq returning bool)((cmp::max<u64> as λ(u64, u64) -> u64)((1: u64), (1: u64)), (1: u64)));
@@ -417,7 +417,7 @@ noir_def cmp::cmp_tests::sanity_check_max<>() -> Unit := {
   #_skip
 }
 
-noir_def cmp::cmp_tests::correctly_handles_unequal_length_slices<>() -> Unit := {
+noir_def std::cmp::cmp_tests::correctly_handles_unequal_length_slices<>() -> Unit := {
   let (slice_1: Slice<Field>) = (#_mkSlice returning Slice<Field>)((0: Field), (1: Field), (2: Field), (3: Field));
   let (slice_2: Slice<Field>) = (#_mkSlice returning Slice<Field>)((0: Field), (1: Field), (2: Field));
   (#_assert returning Unit)((#_bNot returning bool)(((Slice<Field> as std::cmp::Eq<>)::eq<> as λ(Slice<Field>, Slice<Field>) -> bool)(slice_1, slice_2)));
@@ -426,5 +426,5 @@ noir_def cmp::cmp_tests::correctly_handles_unequal_length_slices<>() -> Unit := 
 
 
 def Cmp.env : Env := Env.mk
-  [«std::cmp::Ordering::less», «std::cmp::Ordering::equal», «std::cmp::Ordering::greater», «cmp::max», «cmp::min», «cmp::cmp_tests::sanity_check_min», «cmp::cmp_tests::sanity_check_max», «cmp::cmp_tests::correctly_handles_unequal_length_slices»]
+  [«std::cmp::Ordering::less», «std::cmp::Ordering::equal», «std::cmp::Ordering::greater», «std::cmp::max», «std::cmp::min», «std::cmp::cmp_tests::sanity_check_min», «std::cmp::cmp_tests::sanity_check_max», «std::cmp::cmp_tests::correctly_handles_unequal_length_slices»]
   [impl_78, impl_79, impl_80, impl_81, impl_82, impl_83, impl_84, impl_85, impl_86, impl_87, impl_88, impl_89, impl_90, impl_91, impl_92, impl_93, impl_94, impl_95, impl_96, impl_97, impl_98, impl_99, impl_100, impl_101, impl_102, impl_103, impl_104, impl_105, impl_106, impl_107, impl_108, impl_109, impl_110, impl_111, impl_112, impl_113, impl_114, impl_115]

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/BoundedVec.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/BoundedVec.lean
@@ -15,7 +15,7 @@ noir_def std::collections::bounded_vec::BoundedVec::new<T: Type, MaxLen: u32>() 
 
 noir_def std::collections::bounded_vec::BoundedVec::get<T: Type, MaxLen: u32>(self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, index: u32) -> T := {
   (#_assert returning Unit)((#_uLt returning bool)(index, self.1));
-  (std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, index)
+  (std::collections::bounded_vec::BoundedVec::get_unchecked<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, index)
 }
 
 noir_def std::collections::bounded_vec::BoundedVec::get_unchecked<T: Type, MaxLen: u32>(self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, index: u32) -> T := {
@@ -24,7 +24,7 @@ noir_def std::collections::bounded_vec::BoundedVec::get_unchecked<T: Type, MaxLe
 
 noir_def std::collections::bounded_vec::BoundedVec::set<T: Type, MaxLen: u32>(self: & std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, index: u32, value: T) -> Unit := {
   (#_assert returning Unit)((#_uLt returning bool)(index, (#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1));
-  (std::collections::bounded_vec::BoundedVec::set_unchecked<> as λ(& std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32, T) -> Unit)(self, index, value)
+  (std::collections::bounded_vec::BoundedVec::set_unchecked<T, MaxLen: u32> as λ(& std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32, T) -> Unit)(self, index, value)
 }
 
 noir_def std::collections::bounded_vec::BoundedVec::set_unchecked<T: Type, MaxLen: u32>(self: & std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, index: u32, value: T) -> Unit := {
@@ -80,13 +80,13 @@ noir_def std::collections::bounded_vec::BoundedVec::extend_from_slice<T: Type, M
 }
 
 noir_def std::collections::bounded_vec::BoundedVec::extend_from_bounded_vec<T: Type, MaxLen: u32, Len: u32>(self: & std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, vec: std::collections::bounded_vec::BoundedVec<T, Len: u32>) -> Unit := {
-  let (append_len: u32) = (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<T, Len: u32>) -> u32)(vec);
+  let (append_len: u32) = (std::collections::bounded_vec::BoundedVec::len<T, Len: u32> as λ(std::collections::bounded_vec::BoundedVec<T, Len: u32>) -> u32)(vec);
   let (new_len: u32) = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, append_len);
   (#_assert returning Unit)((#_uLeq returning bool)(new_len, uConst!(MaxLen: u32)));
   if (runtime::is_unconstrained<> as λ() -> bool)() then {
     for i in (0: u32) .. append_len do {
       let (i_3535: Unit) = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, i);
-      (((*self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>).0: Array<T, MaxLen: u32>)[i_3535]: T) = (std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<T, Len: u32>, u32) -> T)(vec, i);
+      (((*self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>).0: Array<T, MaxLen: u32>)[i_3535]: T) = (std::collections::bounded_vec::BoundedVec::get_unchecked<T, Len: u32> as λ(std::collections::bounded_vec::BoundedVec<T, Len: u32>, u32) -> T)(vec, i);
       #_skip
     };
     #_skip
@@ -96,7 +96,7 @@ noir_def std::collections::bounded_vec::BoundedVec::extend_from_bounded_vec<T: T
       exceeded_len = (#_bOr returning bool)(exceeded_len, (#_uEq returning bool)(i, append_len));
       if (#_bNot returning bool)(exceeded_len) then {
         let (i_3538: Unit) = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, i);
-        (((*self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>).0: Array<T, MaxLen: u32>)[i_3538]: T) = (std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<T, Len: u32>, u32) -> T)(vec, i);
+        (((*self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>).0: Array<T, MaxLen: u32>)[i_3538]: T) = (std::collections::bounded_vec::BoundedVec::get_unchecked<T, Len: u32> as λ(std::collections::bounded_vec::BoundedVec<T, Len: u32>, u32) -> T)(vec, i);
         #_skip
       }
     };
@@ -108,8 +108,8 @@ noir_def std::collections::bounded_vec::BoundedVec::extend_from_bounded_vec<T: T
 
 noir_def std::collections::bounded_vec::BoundedVec::from_array<T: Type, MaxLen: u32, Len: u32>(array: Array<T, Len: u32>) -> std::collections::bounded_vec::BoundedVec<T, MaxLen: u32> := {
   (static_assert<String<24: u32> > as λ(bool, String<24: u32>) -> Unit)((#_uLeq returning bool)(uConst!(Len: u32), uConst!(MaxLen: u32)), "from array out of bounds");
-  let mut (vec: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)();
-  (std::collections::bounded_vec::BoundedVec::extend_from_array<Len: u32> as λ(& std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, Array<T, Len: u32>) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(vec), array);
+  let mut (vec: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<T, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)();
+  (std::collections::bounded_vec::BoundedVec::extend_from_array<T, MaxLen: u32, Len: u32> as λ(& std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, Array<T, Len: u32>) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(vec), array);
   vec
 }
 
@@ -148,18 +148,18 @@ noir_def std::collections::bounded_vec::BoundedVec::any<T: Type, MaxLen: u32, En
 }
 
 noir_def std::collections::bounded_vec::BoundedVec::map<T: Type, MaxLen: u32, U: Type, Env: Type>(self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, f: λ(T) -> U) -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32> := {
-  let mut (ret: std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
-  (ret.1: u32) = (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self);
+  let mut (ret: std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<U, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
+  (ret.1: u32) = (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self);
   if (runtime::is_unconstrained<> as λ() -> bool)() then {
-    for i in (0: u32) .. (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self) do {
-      ((ret.0: Array<U, MaxLen: u32>)[i]: U) = (f as λ(T) -> U)((std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
+    for i in (0: u32) .. (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self) do {
+      ((ret.0: Array<U, MaxLen: u32>)[i]: U) = (f as λ(T) -> U)((std::collections::bounded_vec::BoundedVec::get_unchecked<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
       #_skip
     };
     #_skip
   } else {
     for i in (0: u32) .. uConst!(MaxLen: u32) do {
-      if (#_uLt returning bool)(i, (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self)) then {
-        ((ret.0: Array<U, MaxLen: u32>)[i]: U) = (f as λ(T) -> U)((std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
+      if (#_uLt returning bool)(i, (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self)) then {
+        ((ret.0: Array<U, MaxLen: u32>)[i]: U) = (f as λ(T) -> U)((std::collections::bounded_vec::BoundedVec::get_unchecked<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
         #_skip
       }
     };
@@ -169,18 +169,18 @@ noir_def std::collections::bounded_vec::BoundedVec::map<T: Type, MaxLen: u32, U:
 }
 
 noir_def std::collections::bounded_vec::BoundedVec::mapi<T: Type, MaxLen: u32, U: Type, Env: Type>(self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, f: λ(u32, T) -> U) -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32> := {
-  let mut (ret: std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
-  (ret.1: u32) = (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self);
+  let mut (ret: std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<U, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
+  (ret.1: u32) = (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self);
   if (runtime::is_unconstrained<> as λ() -> bool)() then {
-    for i in (0: u32) .. (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self) do {
-      ((ret.0: Array<U, MaxLen: u32>)[i]: U) = (f as λ(u32, T) -> U)(i, (std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
+    for i in (0: u32) .. (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self) do {
+      ((ret.0: Array<U, MaxLen: u32>)[i]: U) = (f as λ(u32, T) -> U)(i, (std::collections::bounded_vec::BoundedVec::get_unchecked<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
       #_skip
     };
     #_skip
   } else {
     for i in (0: u32) .. uConst!(MaxLen: u32) do {
-      if (#_uLt returning bool)(i, (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self)) then {
-        ((ret.0: Array<U, MaxLen: u32>)[i]: U) = (f as λ(u32, T) -> U)(i, (std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
+      if (#_uLt returning bool)(i, (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self)) then {
+        ((ret.0: Array<U, MaxLen: u32>)[i]: U) = (f as λ(u32, T) -> U)(i, (std::collections::bounded_vec::BoundedVec::get_unchecked<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
         #_skip
       }
     };
@@ -191,15 +191,15 @@ noir_def std::collections::bounded_vec::BoundedVec::mapi<T: Type, MaxLen: u32, U
 
 noir_def std::collections::bounded_vec::BoundedVec::for_each<T: Type, MaxLen: u32, Env: Type>(self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, f: λ(T) -> Unit) -> Unit := {
   if (runtime::is_unconstrained<> as λ() -> bool)() then {
-    for i in (0: u32) .. (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self) do {
-      (f as λ(T) -> Unit)((std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
+    for i in (0: u32) .. (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self) do {
+      (f as λ(T) -> Unit)((std::collections::bounded_vec::BoundedVec::get_unchecked<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
       #_skip
     };
     #_skip
   } else {
     for i in (0: u32) .. uConst!(MaxLen: u32) do {
-      if (#_uLt returning bool)(i, (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self)) then {
-        (f as λ(T) -> Unit)((std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
+      if (#_uLt returning bool)(i, (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self)) then {
+        (f as λ(T) -> Unit)((std::collections::bounded_vec::BoundedVec::get_unchecked<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
         #_skip
       }
     };
@@ -209,15 +209,15 @@ noir_def std::collections::bounded_vec::BoundedVec::for_each<T: Type, MaxLen: u3
 
 noir_def std::collections::bounded_vec::BoundedVec::for_eachi<T: Type, MaxLen: u32, Env: Type>(self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, f: λ(u32, T) -> Unit) -> Unit := {
   if (runtime::is_unconstrained<> as λ() -> bool)() then {
-    for i in (0: u32) .. (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self) do {
-      (f as λ(u32, T) -> Unit)(i, (std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
+    for i in (0: u32) .. (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self) do {
+      (f as λ(u32, T) -> Unit)(i, (std::collections::bounded_vec::BoundedVec::get_unchecked<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
       #_skip
     };
     #_skip
   } else {
     for i in (0: u32) .. uConst!(MaxLen: u32) do {
-      if (#_uLt returning bool)(i, (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self)) then {
-        (f as λ(u32, T) -> Unit)(i, (std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
+      if (#_uLt returning bool)(i, (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self)) then {
+        (f as λ(u32, T) -> Unit)(i, (std::collections::bounded_vec::BoundedVec::get_unchecked<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, u32) -> T)(self, i));
         #_skip
       }
     };
@@ -263,128 +263,128 @@ noir_trait_impl[impl_32]<T: Type, MaxLen: u32> std::cmp::Eq<> for std::collectio
 
 noir_trait_impl[impl_33]<Len: u32, T: Type, MaxLen: u32> std::convert::From<Array<T, Len: u32> > for std::collections::bounded_vec::BoundedVec<T, MaxLen: u32> where [] := {
   noir_def from<>(array: Array<T, Len: u32>) -> std::collections::bounded_vec::BoundedVec<T, MaxLen: u32> := {
-    (std::collections::bounded_vec::BoundedVec::from_array<Len: u32> as λ(Array<T, Len: u32>) -> std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(array)
+    (std::collections::bounded_vec::BoundedVec::from_array<T, MaxLen: u32, Len: u32> as λ(Array<T, Len: u32>) -> std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(array)
   };
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::get::panics_when_reading_elements_past_end_of_vec<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<Field, 5: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 5: u32>)();
-  let (_: Field) = (std::collections::bounded_vec::BoundedVec::get<> as λ(std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32) -> Field)(vec, (0: u32));
+noir_def std::collections::bounded_vec::bounded_vec_tests::get::panics_when_reading_elements_past_end_of_vec<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<Field, 5: u32>) = (std::collections::bounded_vec::BoundedVec::new<Field, 5: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 5: u32>)();
+  let (_: Field) = (std::collections::bounded_vec::BoundedVec::get<Field, 5: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32) -> Field)(vec, (0: u32));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::set::set_updates_values_properly<>() -> Unit := {
-  let mut (vec: std::collections::bounded_vec::BoundedVec<Field, 5: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<5: u32> as λ(Array<Field, 5: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 5: u32>)((#_mkArray returning Array<Field, 5: u32>)((0: Field), (0: Field), (0: Field), (0: Field), (0: Field)));
-  (std::collections::bounded_vec::BoundedVec::set<> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (0: u32), (42: Field));
+noir_def std::collections::bounded_vec::bounded_vec_tests::set::set_updates_values_properly<>() -> Unit := {
+  let mut (vec: std::collections::bounded_vec::BoundedVec<Field, 5: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 5: u32> as λ(Array<Field, 5: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 5: u32>)((#_mkArray returning Array<Field, 5: u32>)((0: Field), (0: Field), (0: Field), (0: Field), (0: Field)));
+  (std::collections::bounded_vec::BoundedVec::set<Field, 5: u32> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (0: u32), (42: Field));
   (#_assert returning Unit)(((Array<Field, 5: u32> as Eq<>)::eq<> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> bool)(vec.0, (#_mkArray returning Array<Field, 5: u32>)((42: Field), (0: Field), (0: Field), (0: Field), (0: Field))));
-  (std::collections::bounded_vec::BoundedVec::set<> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (1: u32), (43: Field));
+  (std::collections::bounded_vec::BoundedVec::set<Field, 5: u32> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (1: u32), (43: Field));
   (#_assert returning Unit)(((Array<Field, 5: u32> as Eq<>)::eq<> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> bool)(vec.0, (#_mkArray returning Array<Field, 5: u32>)((42: Field), (43: Field), (0: Field), (0: Field), (0: Field))));
-  (std::collections::bounded_vec::BoundedVec::set<> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (2: u32), (44: Field));
+  (std::collections::bounded_vec::BoundedVec::set<Field, 5: u32> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (2: u32), (44: Field));
   (#_assert returning Unit)(((Array<Field, 5: u32> as Eq<>)::eq<> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> bool)(vec.0, (#_mkArray returning Array<Field, 5: u32>)((42: Field), (43: Field), (44: Field), (0: Field), (0: Field))));
-  (std::collections::bounded_vec::BoundedVec::set<> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (1: u32), (10: Field));
+  (std::collections::bounded_vec::BoundedVec::set<Field, 5: u32> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (1: u32), (10: Field));
   (#_assert returning Unit)(((Array<Field, 5: u32> as Eq<>)::eq<> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> bool)(vec.0, (#_mkArray returning Array<Field, 5: u32>)((42: Field), (10: Field), (44: Field), (0: Field), (0: Field))));
-  (std::collections::bounded_vec::BoundedVec::set<> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (0: u32), (0: Field));
+  (std::collections::bounded_vec::BoundedVec::set<Field, 5: u32> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (0: u32), (0: Field));
   (#_assert returning Unit)(((Array<Field, 5: u32> as Eq<>)::eq<> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> bool)(vec.0, (#_mkArray returning Array<Field, 5: u32>)((0: Field), (10: Field), (44: Field), (0: Field), (0: Field))));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::set::panics_when_writing_elements_past_end_of_vec<>() -> Unit := {
-  let mut (vec: std::collections::bounded_vec::BoundedVec<Field, 5: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 5: u32>)();
-  (std::collections::bounded_vec::BoundedVec::set<> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (0: u32), (42: Field));
+noir_def std::collections::bounded_vec::bounded_vec_tests::set::panics_when_writing_elements_past_end_of_vec<>() -> Unit := {
+  let mut (vec: std::collections::bounded_vec::BoundedVec<Field, 5: u32>) = (std::collections::bounded_vec::BoundedVec::new<Field, 5: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 5: u32>)();
+  (std::collections::bounded_vec::BoundedVec::set<Field, 5: u32> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (0: u32), (42: Field));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::any::returns_false_if_predicate_not_satisfied<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<bool, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<bool, 4: u32>) -> std::collections::bounded_vec::BoundedVec<bool, 4: u32>)((#_mkArray returning Array<bool, 4: u32>)(#_false, #_false, #_false, #_false));
-  let (result: bool) = (std::collections::bounded_vec::BoundedVec::any<Unit> as λ(std::collections::bounded_vec::BoundedVec<bool, 4: u32>, λ(bool) -> bool) -> bool)(vec, (fn((value: bool)): bool := value));
+noir_def std::collections::bounded_vec::bounded_vec_tests::any::returns_false_if_predicate_not_satisfied<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<bool, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<bool, 4: u32> as λ(Array<bool, 4: u32>) -> std::collections::bounded_vec::BoundedVec<bool, 4: u32>)((#_mkArray returning Array<bool, 4: u32>)(#_false, #_false, #_false, #_false));
+  let (result: bool) = (std::collections::bounded_vec::BoundedVec::any<bool, 4: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<bool, 4: u32>, λ(bool) -> bool) -> bool)(vec, (fn((value: bool)): bool := value));
   (#_assert returning Unit)((#_bNot returning bool)(result));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::any::returns_true_if_predicate_satisfied<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<bool, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<bool, 4: u32>) -> std::collections::bounded_vec::BoundedVec<bool, 4: u32>)((#_mkArray returning Array<bool, 4: u32>)(#_false, #_false, #_true, #_true));
-  let (result: bool) = (std::collections::bounded_vec::BoundedVec::any<Unit> as λ(std::collections::bounded_vec::BoundedVec<bool, 4: u32>, λ(bool) -> bool) -> bool)(vec, (fn((value: bool)): bool := value));
+noir_def std::collections::bounded_vec::bounded_vec_tests::any::returns_true_if_predicate_satisfied<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<bool, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<bool, 4: u32> as λ(Array<bool, 4: u32>) -> std::collections::bounded_vec::BoundedVec<bool, 4: u32>)((#_mkArray returning Array<bool, 4: u32>)(#_false, #_false, #_true, #_true));
+  let (result: bool) = (std::collections::bounded_vec::BoundedVec::any<bool, 4: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<bool, 4: u32>, λ(bool) -> bool) -> bool)(vec, (fn((value: bool)): bool := value));
   (#_assert returning Unit)(result);
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::any::returns_false_on_empty_boundedvec<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<bool, 0: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<bool, 0: u32>)();
-  let (result: bool) = (std::collections::bounded_vec::BoundedVec::any<Unit> as λ(std::collections::bounded_vec::BoundedVec<bool, 0: u32>, λ(bool) -> bool) -> bool)(vec, (fn((value: bool)): bool := value));
+noir_def std::collections::bounded_vec::bounded_vec_tests::any::returns_false_on_empty_boundedvec<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<bool, 0: u32>) = (std::collections::bounded_vec::BoundedVec::new<bool, 0: u32> as λ() -> std::collections::bounded_vec::BoundedVec<bool, 0: u32>)();
+  let (result: bool) = (std::collections::bounded_vec::BoundedVec::any<bool, 0: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<bool, 0: u32>, λ(bool) -> bool) -> bool)(vec, (fn((value: bool)): bool := value));
   (#_assert returning Unit)((#_bNot returning bool)(result));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::map::applies_function_correctly<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::map<u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn((value: u32)): u32 := (#_uMul returning u32)(value, (2: u32))));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (4: u32), (6: u32), (8: u32)));
+noir_def std::collections::bounded_vec::bounded_vec_tests::map::applies_function_correctly<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+  let (result: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::map<u32, 4: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn((value: u32)): u32 := (#_uMul returning u32)(value, (2: u32))));
+  let (expected: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (4: u32), (6: u32), (8: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::map::applies_function_that_changes_return_type<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::map<Field, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn((value: u32)): Field := (#_cast returning Field)((#_uMul returning u32)(value, (2: u32)))));
-  let (expected: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (4: Field), (6: Field), (8: Field)));
+noir_def std::collections::bounded_vec::bounded_vec_tests::map::applies_function_that_changes_return_type<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+  let (result: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::map<u32, 4: u32, Field, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn((value: u32)): Field := (#_cast returning Field)((#_uMul returning u32)(value, (2: u32)))));
+  let (expected: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (4: Field), (6: Field), (8: Field)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<Field, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<Field, 4: u32>, std::collections::bounded_vec::BoundedVec<Field, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::map::does_not_apply_function_past_len<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::map<u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn((value: u32)): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
+noir_def std::collections::bounded_vec::bounded_vec_tests::map::does_not_apply_function_past_len<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
+  let (result: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::map<u32, 3: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn((value: u32)): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
     (5: u32)
   } else {
     value
   }));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
+  let (expected: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 3: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, std::collections::bounded_vec::BoundedVec<u32, 3: u32>) -> bool)(result, expected));
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, u32) -> u32)(result, (2: u32)), (0: u32)));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::get_unchecked<u32, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, u32) -> u32)(result, (2: u32)), (0: u32)));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::mapi::applies_function_correctly<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::mapi<u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn((i: u32), (value: u32)): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32)))));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (5: u32), (8: u32), (11: u32)));
+noir_def std::collections::bounded_vec::bounded_vec_tests::mapi::applies_function_correctly<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+  let (result: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::mapi<u32, 4: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn((i: u32), (value: u32)): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32)))));
+  let (expected: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (5: u32), (8: u32), (11: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::mapi::applies_function_that_changes_return_type<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::mapi<Field, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn((i: u32), (value: u32)): Field := (#_cast returning Field)((#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32))))));
-  let (expected: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (5: Field), (8: Field), (11: Field)));
+noir_def std::collections::bounded_vec::bounded_vec_tests::mapi::applies_function_that_changes_return_type<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+  let (result: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::mapi<u32, 4: u32, Field, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn((i: u32), (value: u32)): Field := (#_cast returning Field)((#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32))))));
+  let (expected: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (5: Field), (8: Field), (11: Field)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<Field, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<Field, 4: u32>, std::collections::bounded_vec::BoundedVec<Field, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::mapi::does_not_apply_function_past_len<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::mapi<u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn((_: u32), (value: u32)): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
+noir_def std::collections::bounded_vec::bounded_vec_tests::mapi::does_not_apply_function_past_len<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
+  let (result: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::mapi<u32, 3: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn((_: u32), (value: u32)): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
     (5: u32)
   } else {
     value
   }));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
+  let (expected: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 3: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, std::collections::bounded_vec::BoundedVec<u32, 3: u32>) -> bool)(result, expected));
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, u32) -> u32)(result, (2: u32)), (0: u32)));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::get_unchecked<u32, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, u32) -> u32)(result, (2: u32)), (0: u32)));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::for_each::for_each_map<T: Type, U: Type, Env: Type, MaxLen: u32>(input: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, f: λ(T) -> U) -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32> := {
-  let mut (output: std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
+noir_def std::collections::bounded_vec::bounded_vec_tests::for_each::for_each_map<T: Type, U: Type, Env: Type, MaxLen: u32>(input: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, f: λ(T) -> U) -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32> := {
+  let mut (output: std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<U, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
   let (output_ref: & std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (#_ref returning & std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)(output);
-  (std::collections::bounded_vec::BoundedVec::for_each<Tuple<& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, λ(T) -> U> > as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, λ(T) -> Unit) -> Unit)(input, (fn((x: T)): Unit := (std::collections::bounded_vec::BoundedVec::push<> as λ(& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, U) -> Unit)(output_ref, (f as λ(T) -> U)(x))));
+  (std::collections::bounded_vec::BoundedVec::for_each<T, MaxLen: u32, Tuple<& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, λ(T) -> U> > as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, λ(T) -> Unit) -> Unit)(input, (fn((x: T)): Unit := (std::collections::bounded_vec::BoundedVec::push<U, MaxLen: u32> as λ(& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, U) -> Unit)(output_ref, (f as λ(T) -> U)(x))));
   output
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::for_each::smoke_test<>() -> Unit := {
+noir_def std::collections::bounded_vec::bounded_vec_tests::for_each::smoke_test<>() -> Unit := {
   let mut (acc: u32) = (0: u32);
   let (acc_ref: & u32) = (#_ref returning & u32)(acc);
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<3: u32> as λ(Array<u32, 3: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32)));
-  (std::collections::bounded_vec::BoundedVec::for_each<Tuple<& u32> > as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32) -> Unit) -> Unit)(vec, (fn((value: u32)): Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32> as λ(Array<u32, 3: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32)));
+  (std::collections::bounded_vec::BoundedVec::for_each<u32, 3: u32, Tuple<& u32> > as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32) -> Unit) -> Unit)(vec, (fn((value: u32)): Unit := {
     (*acc_ref: u32) = (#_uAdd returning u32)((#_readRef returning u32)(acc_ref), value);
     #_skip
   }));
@@ -392,47 +392,47 @@ noir_def collections::bounded_vec::bounded_vec_tests::for_each::smoke_test<>() -
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::for_each::applies_function_correctly<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+noir_def std::collections::bounded_vec::bounded_vec_tests::for_each::applies_function_correctly<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
   let (result: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (collections::bounded_vec::bounded_vec_tests::for_each::for_each_map<u32, Unit, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn((value: u32)): u32 := (#_uMul returning u32)(value, (2: u32))));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (4: u32), (6: u32), (8: u32)));
+  let (expected: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (4: u32), (6: u32), (8: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::for_each::applies_function_that_changes_return_type<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+noir_def std::collections::bounded_vec::bounded_vec_tests::for_each::applies_function_that_changes_return_type<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
   let (result: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (collections::bounded_vec::bounded_vec_tests::for_each::for_each_map<u32, Field, Unit, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn((value: u32)): Field := (#_cast returning Field)((#_uMul returning u32)(value, (2: u32)))));
-  let (expected: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (4: Field), (6: Field), (8: Field)));
+  let (expected: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (4: Field), (6: Field), (8: Field)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<Field, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<Field, 4: u32>, std::collections::bounded_vec::BoundedVec<Field, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::for_each::does_not_apply_function_past_len<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
+noir_def std::collections::bounded_vec::bounded_vec_tests::for_each::does_not_apply_function_past_len<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
   let (result: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (collections::bounded_vec::bounded_vec_tests::for_each::for_each_map<u32, Unit, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn((value: u32)): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
     (5: u32)
   } else {
     value
   }));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
+  let (expected: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 3: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, std::collections::bounded_vec::BoundedVec<u32, 3: u32>) -> bool)(result, expected));
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, u32) -> u32)(result, (2: u32)), (0: u32)));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::get_unchecked<u32, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, u32) -> u32)(result, (2: u32)), (0: u32)));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi<T: Type, U: Type, Env: Type, MaxLen: u32>(input: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, f: λ(u32, T) -> U) -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32> := {
-  let mut (output: std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
+noir_def std::collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi<T: Type, U: Type, Env: Type, MaxLen: u32>(input: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, f: λ(u32, T) -> U) -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32> := {
+  let mut (output: std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<U, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
   let (output_ref: & std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (#_ref returning & std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)(output);
-  (std::collections::bounded_vec::BoundedVec::for_eachi<Tuple<& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, λ(u32, T) -> U> > as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, λ(u32, T) -> Unit) -> Unit)(input, (fn((i: u32), (x: T)): Unit := (std::collections::bounded_vec::BoundedVec::push<> as λ(& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, U) -> Unit)(output_ref, (f as λ(u32, T) -> U)(i, x))));
+  (std::collections::bounded_vec::BoundedVec::for_eachi<T, MaxLen: u32, Tuple<& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, λ(u32, T) -> U> > as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, λ(u32, T) -> Unit) -> Unit)(input, (fn((i: u32), (x: T)): Unit := (std::collections::bounded_vec::BoundedVec::push<U, MaxLen: u32> as λ(& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, U) -> Unit)(output_ref, (f as λ(u32, T) -> U)(i, x))));
   output
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::for_eachi::smoke_test<>() -> Unit := {
+noir_def std::collections::bounded_vec::bounded_vec_tests::for_eachi::smoke_test<>() -> Unit := {
   let mut (acc: u32) = (0: u32);
   let (acc_ref: & u32) = (#_ref returning & u32)(acc);
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<3: u32> as λ(Array<u32, 3: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32)));
-  (std::collections::bounded_vec::BoundedVec::for_eachi<Tuple<& u32> > as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32, u32) -> Unit) -> Unit)(vec, (fn((i: u32), (value: u32)): Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32> as λ(Array<u32, 3: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32)));
+  (std::collections::bounded_vec::BoundedVec::for_eachi<u32, 3: u32, Tuple<& u32> > as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32, u32) -> Unit) -> Unit)(vec, (fn((i: u32), (value: u32)): Unit := {
     (*acc_ref: u32) = (#_uAdd returning u32)((#_readRef returning u32)(acc_ref), (#_uMul returning u32)(i, value));
     #_skip
   }));
@@ -440,114 +440,114 @@ noir_def collections::bounded_vec::bounded_vec_tests::for_eachi::smoke_test<>() 
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::for_eachi::applies_function_correctly<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+noir_def std::collections::bounded_vec::bounded_vec_tests::for_eachi::applies_function_correctly<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
   let (result: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi<u32, Unit, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn((i: u32), (value: u32)): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32)))));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (5: u32), (8: u32), (11: u32)));
+  let (expected: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (5: u32), (8: u32), (11: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::for_eachi::applies_function_that_changes_return_type<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+noir_def std::collections::bounded_vec::bounded_vec_tests::for_eachi::applies_function_that_changes_return_type<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
   let (result: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi<u32, Field, Unit, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn((i: u32), (value: u32)): Field := (#_cast returning Field)((#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32))))));
-  let (expected: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (5: Field), (8: Field), (11: Field)));
+  let (expected: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (5: Field), (8: Field), (11: Field)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<Field, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<Field, 4: u32>, std::collections::bounded_vec::BoundedVec<Field, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::for_eachi::does_not_apply_function_past_len<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
+noir_def std::collections::bounded_vec::bounded_vec_tests::for_eachi::does_not_apply_function_past_len<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
   let (result: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi<u32, Unit, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn((_: u32), (value: u32)): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
     (5: u32)
   } else {
     value
   }));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
+  let (expected: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 3: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, std::collections::bounded_vec::BoundedVec<u32, 3: u32>) -> bool)(result, expected));
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, u32) -> u32)(result, (2: u32)), (0: u32)));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::get_unchecked<u32, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, u32) -> u32)(result, (2: u32)), (0: u32)));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::from_array::empty<>() -> Unit := {
+noir_def std::collections::bounded_vec::bounded_vec_tests::from_array::empty<>() -> Unit := {
   let (empty_array: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
-  let (bounded_vec: std::collections::bounded_vec::BoundedVec<Field, 0: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<0: u32> as λ(Array<Field, 0: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 0: u32>)((#_mkArray returning Array<Field, 0: u32>)());
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::max_len<> as λ(std::collections::bounded_vec::BoundedVec<Field, 0: u32>) -> u32)(bounded_vec), (0: u32)));
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<Field, 0: u32>) -> u32)(bounded_vec), (0: u32)));
-  (#_assert returning Unit)(((Array<Field, 0: u32> as Eq<>)::eq<> as λ(Array<Field, 0: u32>, Array<Field, 0: u32>) -> bool)((std::collections::bounded_vec::BoundedVec::storage<> as λ(std::collections::bounded_vec::BoundedVec<Field, 0: u32>) -> Array<Field, 0: u32>)(bounded_vec), empty_array));
+  let (bounded_vec: std::collections::bounded_vec::BoundedVec<Field, 0: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 0: u32> as λ(Array<Field, 0: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 0: u32>)((#_mkArray returning Array<Field, 0: u32>)());
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::max_len<Field, 0: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 0: u32>) -> u32)(bounded_vec), (0: u32)));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<Field, 0: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 0: u32>) -> u32)(bounded_vec), (0: u32)));
+  (#_assert returning Unit)(((Array<Field, 0: u32> as Eq<>)::eq<> as λ(Array<Field, 0: u32>, Array<Field, 0: u32>) -> bool)((std::collections::bounded_vec::BoundedVec::storage<Field, 0: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 0: u32>) -> Array<Field, 0: u32>)(bounded_vec), empty_array));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::from_array::equal_len<>() -> Unit := {
+noir_def std::collections::bounded_vec::bounded_vec_tests::from_array::equal_len<>() -> Unit := {
   let (array: Array<Field, 3: u32>) = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
-  let (bounded_vec: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<3: u32> as λ(Array<Field, 3: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)(array);
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::max_len<> as λ(std::collections::bounded_vec::BoundedVec<Field, 3: u32>) -> u32)(bounded_vec), (3: u32)));
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<Field, 3: u32>) -> u32)(bounded_vec), (3: u32)));
-  (#_assert returning Unit)(((Array<Field, 3: u32> as Eq<>)::eq<> as λ(Array<Field, 3: u32>, Array<Field, 3: u32>) -> bool)((std::collections::bounded_vec::BoundedVec::storage<> as λ(std::collections::bounded_vec::BoundedVec<Field, 3: u32>) -> Array<Field, 3: u32>)(bounded_vec), array));
+  let (bounded_vec: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 3: u32> as λ(Array<Field, 3: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)(array);
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::max_len<Field, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 3: u32>) -> u32)(bounded_vec), (3: u32)));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<Field, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 3: u32>) -> u32)(bounded_vec), (3: u32)));
+  (#_assert returning Unit)(((Array<Field, 3: u32> as Eq<>)::eq<> as λ(Array<Field, 3: u32>, Array<Field, 3: u32>) -> bool)((std::collections::bounded_vec::BoundedVec::storage<Field, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 3: u32>) -> Array<Field, 3: u32>)(bounded_vec), array));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::from_array::max_len_greater_then_array_len<>() -> Unit := {
+noir_def std::collections::bounded_vec::bounded_vec_tests::from_array::max_len_greater_then_array_len<>() -> Unit := {
   let (array: Array<Field, 3: u32>) = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
-  let (bounded_vec: std::collections::bounded_vec::BoundedVec<Field, 10: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<3: u32> as λ(Array<Field, 3: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 10: u32>)(array);
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::max_len<> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>) -> u32)(bounded_vec), (10: u32)));
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>) -> u32)(bounded_vec), (3: u32)));
-  (#_assert returning Unit)((#_fEq returning bool)((std::collections::bounded_vec::BoundedVec::get<> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>, u32) -> Field)(bounded_vec, (0: u32)), (1: Field)));
-  (#_assert returning Unit)((#_fEq returning bool)((std::collections::bounded_vec::BoundedVec::get<> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>, u32) -> Field)(bounded_vec, (1: u32)), (2: Field)));
-  (#_assert returning Unit)((#_fEq returning bool)((std::collections::bounded_vec::BoundedVec::get<> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>, u32) -> Field)(bounded_vec, (2: u32)), (3: Field)));
+  let (bounded_vec: std::collections::bounded_vec::BoundedVec<Field, 10: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 10: u32, 3: u32> as λ(Array<Field, 3: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 10: u32>)(array);
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::max_len<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>) -> u32)(bounded_vec), (10: u32)));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>) -> u32)(bounded_vec), (3: u32)));
+  (#_assert returning Unit)((#_fEq returning bool)((std::collections::bounded_vec::BoundedVec::get<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>, u32) -> Field)(bounded_vec, (0: u32)), (1: Field)));
+  (#_assert returning Unit)((#_fEq returning bool)((std::collections::bounded_vec::BoundedVec::get<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>, u32) -> Field)(bounded_vec, (1: u32)), (2: Field)));
+  (#_assert returning Unit)((#_fEq returning bool)((std::collections::bounded_vec::BoundedVec::get<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>, u32) -> Field)(bounded_vec, (2: u32)), (3: Field)));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::from_array::max_len_lower_then_array_len<>() -> Unit := {
-  let (_: std::collections::bounded_vec::BoundedVec<Field, 2: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<3: u32> as λ(Array<Field, 3: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 2: u32>)((#_mkRepeatedArray returning Array<Field, 3: u32>)((0: Field)));
+noir_def std::collections::bounded_vec::bounded_vec_tests::from_array::max_len_lower_then_array_len<>() -> Unit := {
+  let (_: std::collections::bounded_vec::BoundedVec<Field, 2: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 2: u32, 3: u32> as λ(Array<Field, 3: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 2: u32>)((#_mkRepeatedArray returning Array<Field, 3: u32>)((0: Field)));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::trait_from::simple<>() -> Unit := {
+noir_def std::collections::bounded_vec::bounded_vec_tests::trait_from::simple<>() -> Unit := {
   let (array: Array<Field, 2: u32>) = (#_mkArray returning Array<Field, 2: u32>)((1: Field), (2: Field));
   let (bounded_vec: std::collections::bounded_vec::BoundedVec<Field, 10: u32>) = ((std::collections::bounded_vec::BoundedVec<Field, 10: u32> as std::convert::From<Array<Field, 2: u32> >)::from<> as λ(Array<Field, 2: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 10: u32>)(array);
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::max_len<> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>) -> u32)(bounded_vec), (10: u32)));
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>) -> u32)(bounded_vec), (2: u32)));
-  (#_assert returning Unit)((#_fEq returning bool)((std::collections::bounded_vec::BoundedVec::get<> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>, u32) -> Field)(bounded_vec, (0: u32)), (1: Field)));
-  (#_assert returning Unit)((#_fEq returning bool)((std::collections::bounded_vec::BoundedVec::get<> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>, u32) -> Field)(bounded_vec, (1: u32)), (2: Field)));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::max_len<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>) -> u32)(bounded_vec), (10: u32)));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>) -> u32)(bounded_vec), (2: u32)));
+  (#_assert returning Unit)((#_fEq returning bool)((std::collections::bounded_vec::BoundedVec::get<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>, u32) -> Field)(bounded_vec, (0: u32)), (1: Field)));
+  (#_assert returning Unit)((#_fEq returning bool)((std::collections::bounded_vec::BoundedVec::get<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>, u32) -> Field)(bounded_vec, (1: u32)), (2: Field)));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::trait_eq::empty_equality<>() -> Unit := {
-  let mut (bounded_vec1: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
-  let mut (bounded_vec2: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
+noir_def std::collections::bounded_vec::bounded_vec_tests::trait_eq::empty_equality<>() -> Unit := {
+  let mut (bounded_vec1: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::new<Field, 3: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
+  let mut (bounded_vec2: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::new<Field, 3: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<Field, 3: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<Field, 3: u32>, std::collections::bounded_vec::BoundedVec<Field, 3: u32>) -> bool)(bounded_vec1, bounded_vec2));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::trait_eq::inequality<>() -> Unit := {
-  let mut (bounded_vec1: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
-  let mut (bounded_vec2: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
-  (std::collections::bounded_vec::BoundedVec::push<> as λ(& std::collections::bounded_vec::BoundedVec<Field, 3: u32>, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 3: u32>)(bounded_vec1), (1: Field));
-  (std::collections::bounded_vec::BoundedVec::push<> as λ(& std::collections::bounded_vec::BoundedVec<Field, 3: u32>, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 3: u32>)(bounded_vec2), (2: Field));
+noir_def std::collections::bounded_vec::bounded_vec_tests::trait_eq::inequality<>() -> Unit := {
+  let mut (bounded_vec1: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::new<Field, 3: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
+  let mut (bounded_vec2: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::new<Field, 3: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
+  (std::collections::bounded_vec::BoundedVec::push<Field, 3: u32> as λ(& std::collections::bounded_vec::BoundedVec<Field, 3: u32>, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 3: u32>)(bounded_vec1), (1: Field));
+  (std::collections::bounded_vec::BoundedVec::push<Field, 3: u32> as λ(& std::collections::bounded_vec::BoundedVec<Field, 3: u32>, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 3: u32>)(bounded_vec2), (2: Field));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<Field, 3: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<Field, 3: u32>, std::collections::bounded_vec::BoundedVec<Field, 3: u32>) -> bool)(bounded_vec1, bounded_vec2));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::from_parts::from_parts<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts<> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (0: u32)), (3: u32));
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> u32)(vec), (3: u32)));
-  let (vec1: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts<> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (1: u32)), (3: u32));
-  let (vec2: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts<> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (2: u32)), (3: u32));
+noir_def std::collections::bounded_vec::bounded_vec_tests::from_parts::from_parts<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (0: u32)), (3: u32));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<u32, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> u32)(vec), (3: u32)));
+  let (vec1: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (1: u32)), (3: u32));
+  let (vec2: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (2: u32)), (3: u32));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> bool)(vec1, vec2));
   #_skip
 }
 
-noir_def collections::bounded_vec::bounded_vec_tests::from_parts::from_parts_unchecked<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts_unchecked<> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (0: u32)), (3: u32));
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> u32)(vec), (3: u32)));
-  let (vec1: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts_unchecked<> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (1: u32)), (3: u32));
-  let (vec2: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts_unchecked<> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (2: u32)), (3: u32));
+noir_def std::collections::bounded_vec::bounded_vec_tests::from_parts::from_parts_unchecked<>() -> Unit := {
+  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts_unchecked<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (0: u32)), (3: u32));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<u32, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> u32)(vec), (3: u32)));
+  let (vec1: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts_unchecked<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (1: u32)), (3: u32));
+  let (vec2: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts_unchecked<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (2: u32)), (3: u32));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> bool)(vec1, vec2));
   #_skip
 }
 
 
 def Collections.BoundedVec.env : Env := Env.mk
-  [«std::collections::bounded_vec::BoundedVec::new», «std::collections::bounded_vec::BoundedVec::get», «std::collections::bounded_vec::BoundedVec::get_unchecked», «std::collections::bounded_vec::BoundedVec::set», «std::collections::bounded_vec::BoundedVec::set_unchecked», «std::collections::bounded_vec::BoundedVec::push», «std::collections::bounded_vec::BoundedVec::len», «std::collections::bounded_vec::BoundedVec::max_len», «std::collections::bounded_vec::BoundedVec::storage», «std::collections::bounded_vec::BoundedVec::extend_from_array», «std::collections::bounded_vec::BoundedVec::extend_from_slice», «std::collections::bounded_vec::BoundedVec::extend_from_bounded_vec», «std::collections::bounded_vec::BoundedVec::from_array», «std::collections::bounded_vec::BoundedVec::pop», «std::collections::bounded_vec::BoundedVec::any», «std::collections::bounded_vec::BoundedVec::map», «std::collections::bounded_vec::BoundedVec::mapi», «std::collections::bounded_vec::BoundedVec::for_each», «std::collections::bounded_vec::BoundedVec::for_eachi», «std::collections::bounded_vec::BoundedVec::from_parts», «std::collections::bounded_vec::BoundedVec::from_parts_unchecked», «collections::bounded_vec::bounded_vec_tests::get::panics_when_reading_elements_past_end_of_vec», «collections::bounded_vec::bounded_vec_tests::set::set_updates_values_properly», «collections::bounded_vec::bounded_vec_tests::set::panics_when_writing_elements_past_end_of_vec», «collections::bounded_vec::bounded_vec_tests::any::returns_false_if_predicate_not_satisfied», «collections::bounded_vec::bounded_vec_tests::any::returns_true_if_predicate_satisfied», «collections::bounded_vec::bounded_vec_tests::any::returns_false_on_empty_boundedvec», «collections::bounded_vec::bounded_vec_tests::map::applies_function_correctly», «collections::bounded_vec::bounded_vec_tests::map::applies_function_that_changes_return_type», «collections::bounded_vec::bounded_vec_tests::map::does_not_apply_function_past_len», «collections::bounded_vec::bounded_vec_tests::mapi::applies_function_correctly», «collections::bounded_vec::bounded_vec_tests::mapi::applies_function_that_changes_return_type», «collections::bounded_vec::bounded_vec_tests::mapi::does_not_apply_function_past_len», «collections::bounded_vec::bounded_vec_tests::for_each::for_each_map», «collections::bounded_vec::bounded_vec_tests::for_each::smoke_test», «collections::bounded_vec::bounded_vec_tests::for_each::applies_function_correctly», «collections::bounded_vec::bounded_vec_tests::for_each::applies_function_that_changes_return_type», «collections::bounded_vec::bounded_vec_tests::for_each::does_not_apply_function_past_len», «collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi», «collections::bounded_vec::bounded_vec_tests::for_eachi::smoke_test», «collections::bounded_vec::bounded_vec_tests::for_eachi::applies_function_correctly», «collections::bounded_vec::bounded_vec_tests::for_eachi::applies_function_that_changes_return_type», «collections::bounded_vec::bounded_vec_tests::for_eachi::does_not_apply_function_past_len», «collections::bounded_vec::bounded_vec_tests::from_array::empty», «collections::bounded_vec::bounded_vec_tests::from_array::equal_len», «collections::bounded_vec::bounded_vec_tests::from_array::max_len_greater_then_array_len», «collections::bounded_vec::bounded_vec_tests::from_array::max_len_lower_then_array_len», «collections::bounded_vec::bounded_vec_tests::trait_from::simple», «collections::bounded_vec::bounded_vec_tests::trait_eq::empty_equality», «collections::bounded_vec::bounded_vec_tests::trait_eq::inequality», «collections::bounded_vec::bounded_vec_tests::from_parts::from_parts», «collections::bounded_vec::bounded_vec_tests::from_parts::from_parts_unchecked»]
+  [«std::collections::bounded_vec::BoundedVec::new», «std::collections::bounded_vec::BoundedVec::get», «std::collections::bounded_vec::BoundedVec::get_unchecked», «std::collections::bounded_vec::BoundedVec::set», «std::collections::bounded_vec::BoundedVec::set_unchecked», «std::collections::bounded_vec::BoundedVec::push», «std::collections::bounded_vec::BoundedVec::len», «std::collections::bounded_vec::BoundedVec::max_len», «std::collections::bounded_vec::BoundedVec::storage», «std::collections::bounded_vec::BoundedVec::extend_from_array», «std::collections::bounded_vec::BoundedVec::extend_from_slice», «std::collections::bounded_vec::BoundedVec::extend_from_bounded_vec», «std::collections::bounded_vec::BoundedVec::from_array», «std::collections::bounded_vec::BoundedVec::pop», «std::collections::bounded_vec::BoundedVec::any», «std::collections::bounded_vec::BoundedVec::map», «std::collections::bounded_vec::BoundedVec::mapi», «std::collections::bounded_vec::BoundedVec::for_each», «std::collections::bounded_vec::BoundedVec::for_eachi», «std::collections::bounded_vec::BoundedVec::from_parts», «std::collections::bounded_vec::BoundedVec::from_parts_unchecked», «std::collections::bounded_vec::bounded_vec_tests::get::panics_when_reading_elements_past_end_of_vec», «std::collections::bounded_vec::bounded_vec_tests::set::set_updates_values_properly», «std::collections::bounded_vec::bounded_vec_tests::set::panics_when_writing_elements_past_end_of_vec», «std::collections::bounded_vec::bounded_vec_tests::any::returns_false_if_predicate_not_satisfied», «std::collections::bounded_vec::bounded_vec_tests::any::returns_true_if_predicate_satisfied», «std::collections::bounded_vec::bounded_vec_tests::any::returns_false_on_empty_boundedvec», «std::collections::bounded_vec::bounded_vec_tests::map::applies_function_correctly», «std::collections::bounded_vec::bounded_vec_tests::map::applies_function_that_changes_return_type», «std::collections::bounded_vec::bounded_vec_tests::map::does_not_apply_function_past_len», «std::collections::bounded_vec::bounded_vec_tests::mapi::applies_function_correctly», «std::collections::bounded_vec::bounded_vec_tests::mapi::applies_function_that_changes_return_type», «std::collections::bounded_vec::bounded_vec_tests::mapi::does_not_apply_function_past_len», «std::collections::bounded_vec::bounded_vec_tests::for_each::for_each_map», «std::collections::bounded_vec::bounded_vec_tests::for_each::smoke_test», «std::collections::bounded_vec::bounded_vec_tests::for_each::applies_function_correctly», «std::collections::bounded_vec::bounded_vec_tests::for_each::applies_function_that_changes_return_type», «std::collections::bounded_vec::bounded_vec_tests::for_each::does_not_apply_function_past_len», «std::collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi», «std::collections::bounded_vec::bounded_vec_tests::for_eachi::smoke_test», «std::collections::bounded_vec::bounded_vec_tests::for_eachi::applies_function_correctly», «std::collections::bounded_vec::bounded_vec_tests::for_eachi::applies_function_that_changes_return_type», «std::collections::bounded_vec::bounded_vec_tests::for_eachi::does_not_apply_function_past_len», «std::collections::bounded_vec::bounded_vec_tests::from_array::empty», «std::collections::bounded_vec::bounded_vec_tests::from_array::equal_len», «std::collections::bounded_vec::bounded_vec_tests::from_array::max_len_greater_then_array_len», «std::collections::bounded_vec::bounded_vec_tests::from_array::max_len_lower_then_array_len», «std::collections::bounded_vec::bounded_vec_tests::trait_from::simple», «std::collections::bounded_vec::bounded_vec_tests::trait_eq::empty_equality», «std::collections::bounded_vec::bounded_vec_tests::trait_eq::inequality», «std::collections::bounded_vec::bounded_vec_tests::from_parts::from_parts», «std::collections::bounded_vec::bounded_vec_tests::from_parts::from_parts_unchecked»]
   [impl_32, impl_33]

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/Map.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/Map.lean
@@ -14,16 +14,16 @@ noir_global_def MAX_LOAD_FACTOR_DEN0MINATOR: u32 = (4: u32);
 
 noir_trait_impl[impl_34]<K: Type, V: Type> std::default::Default<> for std::collections::map::Slot<K, V> where [] := {
   noir_def default<>() -> std::collections::map::Slot<K, V> := {
-    (#_makeData returning std::collections::map::Slot<K, V>)((std::option::Option::none<> as λ() -> std::option::Option<Tuple<K, V> >)(), #_false)
+    (#_makeData returning std::collections::map::Slot<K, V>)((std::option::Option::none<Tuple<K, V> > as λ() -> std::option::Option<Tuple<K, V> >)(), #_false)
   };
 }
 
 noir_def std::collections::map::Slot::is_valid<K: Type, V: Type>(self: std::collections::map::Slot<K, V>) -> bool := {
-  (#_bAnd returning bool)((#_bNot returning bool)(self.1), (std::option::Option::is_some<> as λ(std::option::Option<Tuple<K, V> >) -> bool)(self.0))
+  (#_bAnd returning bool)((#_bNot returning bool)(self.1), (std::option::Option::is_some<Tuple<K, V> > as λ(std::option::Option<Tuple<K, V> >) -> bool)(self.0))
 }
 
 noir_def std::collections::map::Slot::is_available<K: Type, V: Type>(self: std::collections::map::Slot<K, V>) -> bool := {
-  (#_bOr returning bool)(self.1, (std::option::Option::is_none<> as λ(std::option::Option<Tuple<K, V> >) -> bool)(self.0))
+  (#_bOr returning bool)(self.1, (std::option::Option::is_none<Tuple<K, V> > as λ(std::option::Option<Tuple<K, V> >) -> bool)(self.0))
 }
 
 noir_def std::collections::map::Slot::key_value<K: Type, V: Type>(self: std::collections::map::Slot<K, V>) -> std::option::Option<Tuple<K, V> > := {
@@ -31,11 +31,11 @@ noir_def std::collections::map::Slot::key_value<K: Type, V: Type>(self: std::col
 }
 
 noir_def std::collections::map::Slot::key_value_unchecked<K: Type, V: Type>(self: std::collections::map::Slot<K, V>) -> Tuple<K, V> := {
-  (std::option::Option::unwrap_unchecked<> as λ(std::option::Option<Tuple<K, V> >) -> Tuple<K, V>)(self.0)
+  (std::option::Option::unwrap_unchecked<Tuple<K, V> > as λ(std::option::Option<Tuple<K, V> >) -> Tuple<K, V>)(self.0)
 }
 
 noir_def std::collections::map::Slot::set<K: Type, V: Type>(self: & std::collections::map::Slot<K, V>, key: K, value: V) -> Unit := {
-  ((*self: std::collections::map::Slot<K, V>).0: std::option::Option<Tuple<K, V> >) = (std::option::Option::some<> as λ(Tuple<K, V>) -> std::option::Option<Tuple<K, V> >)((#_makeData returning Tuple<K, V>)(key, value));
+  ((*self: std::collections::map::Slot<K, V>).0: std::option::Option<Tuple<K, V> >) = (std::option::Option::some<Tuple<K, V> > as λ(Tuple<K, V>) -> std::option::Option<Tuple<K, V> >)((#_makeData returning Tuple<K, V>)(key, value));
   ((*self: std::collections::map::Slot<K, V>).1: bool) = #_false;
   #_skip
 }
@@ -58,7 +58,7 @@ noir_def std::collections::map::HashMap::clear<K: Type, V: Type, N: u32, B: Type
 }
 
 noir_def std::collections::map::HashMap::contains_key<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type>(self: std::collections::map::HashMap<K, V, N: u32, B>, key: K) -> bool := {
-  (std::option::Option::is_some<> as λ(std::option::Option<V>) -> bool)((std::collections::map::HashMap::get<> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> std::option::Option<V>)(self, key))
+  (std::option::Option::is_some<V> as λ(std::option::Option<V>) -> bool)((std::collections::map::HashMap::get<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> std::option::Option<V>)(self, key))
 }
 
 noir_def std::collections::map::HashMap::is_empty<K: Type, V: Type, N: u32, B: Type>(self: std::collections::map::HashMap<K, V, N: u32, B>) -> bool := {
@@ -66,15 +66,15 @@ noir_def std::collections::map::HashMap::is_empty<K: Type, V: Type, N: u32, B: T
 }
 
 noir_def std::collections::map::HashMap::entries<K: Type, V: Type, N: u32, B: Type>(self: std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32> := {
-  let mut (entries: std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)();
+  let mut (entries: std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) = (std::collections::bounded_vec::BoundedVec::new<Tuple<K, V>, N: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)();
   {
     let (ζi0: Array<std::collections::map::Slot<K, V>, N: u32>) = self.0;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
       let (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
       {
-        if (std::collections::map::Slot::is_valid<> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-          let (key_value: Tuple<K, V>) = (std::option::Option::unwrap_unchecked<> as λ(std::option::Option<Tuple<K, V> >) -> Tuple<K, V>)((std::collections::map::Slot::key_value<> as λ(std::collections::map::Slot<K, V>) -> std::option::Option<Tuple<K, V> >)(slot));
-          (std::collections::bounded_vec::BoundedVec::push<> as λ(& std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>, Tuple<K, V>) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)(entries), key_value);
+        if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
+          let (key_value: Tuple<K, V>) = (std::option::Option::unwrap_unchecked<Tuple<K, V> > as λ(std::option::Option<Tuple<K, V> >) -> Tuple<K, V>)((std::collections::map::Slot::key_value<K, V> as λ(std::collections::map::Slot<K, V>) -> std::option::Option<Tuple<K, V> >)(slot));
+          (std::collections::bounded_vec::BoundedVec::push<Tuple<K, V>, N: u32> as λ(& std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>, Tuple<K, V>) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)(entries), key_value);
           #_skip
         }
       }
@@ -82,22 +82,22 @@ noir_def std::collections::map::HashMap::entries<K: Type, V: Type, N: u32, B: Ty
     #_skip
   };
   let (self_len: u32) = self.1;
-  let (entries_len: u32) = (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) -> u32)(entries);
+  let (entries_len: u32) = (std::collections::bounded_vec::BoundedVec::len<Tuple<K, V>, N: u32> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) -> u32)(entries);
   let (msg: FmtString<82: u32, Tuple<u32, u32> >) = (#_mkFormatString returning FmtString<82: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{entries_len}{}.", self_len, entries_len);
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) -> u32)(entries), self.1));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<Tuple<K, V>, N: u32> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) -> u32)(entries), self.1));
   entries
 }
 
 noir_def std::collections::map::HashMap::keys<K: Type, V: Type, N: u32, B: Type>(self: std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<K, N: u32> := {
-  let mut (keys: std::collections::bounded_vec::BoundedVec<K, N: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<K, N: u32>)();
+  let mut (keys: std::collections::bounded_vec::BoundedVec<K, N: u32>) = (std::collections::bounded_vec::BoundedVec::new<K, N: u32> as λ() -> std::collections::bounded_vec::BoundedVec<K, N: u32>)();
   {
     let (ζi0: Array<std::collections::map::Slot<K, V>, N: u32>) = self.0;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
       let (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
       {
-        if (std::collections::map::Slot::is_valid<> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-          let ((key: K), (_: V)) = (std::collections::map::Slot::key_value_unchecked<> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
-          (std::collections::bounded_vec::BoundedVec::push<> as λ(& std::collections::bounded_vec::BoundedVec<K, N: u32>, K) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<K, N: u32>)(keys), key);
+        if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
+          let ((key: K), (_: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+          (std::collections::bounded_vec::BoundedVec::push<K, N: u32> as λ(& std::collections::bounded_vec::BoundedVec<K, N: u32>, K) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<K, N: u32>)(keys), key);
           #_skip
         }
       }
@@ -105,22 +105,22 @@ noir_def std::collections::map::HashMap::keys<K: Type, V: Type, N: u32, B: Type>
     #_skip
   };
   let (self_len: u32) = self.1;
-  let (keys_len: u32) = (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<K, N: u32>) -> u32)(keys);
+  let (keys_len: u32) = (std::collections::bounded_vec::BoundedVec::len<K, N: u32> as λ(std::collections::bounded_vec::BoundedVec<K, N: u32>) -> u32)(keys);
   let (msg: FmtString<79: u32, Tuple<u32, u32> >) = (#_mkFormatString returning FmtString<79: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{keys_len}{}.", self_len, keys_len);
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<K, N: u32>) -> u32)(keys), self.1));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<K, N: u32> as λ(std::collections::bounded_vec::BoundedVec<K, N: u32>) -> u32)(keys), self.1));
   keys
 }
 
 noir_def std::collections::map::HashMap::values<K: Type, V: Type, N: u32, B: Type>(self: std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<V, N: u32> := {
-  let mut (values: std::collections::bounded_vec::BoundedVec<V, N: u32>) = (std::collections::bounded_vec::BoundedVec::new<> as λ() -> std::collections::bounded_vec::BoundedVec<V, N: u32>)();
+  let mut (values: std::collections::bounded_vec::BoundedVec<V, N: u32>) = (std::collections::bounded_vec::BoundedVec::new<V, N: u32> as λ() -> std::collections::bounded_vec::BoundedVec<V, N: u32>)();
   {
     let (ζi0: Array<std::collections::map::Slot<K, V>, N: u32>) = self.0;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
       let (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
       {
-        if (std::collections::map::Slot::is_valid<> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-          let ((_: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
-          (std::collections::bounded_vec::BoundedVec::push<> as λ(& std::collections::bounded_vec::BoundedVec<V, N: u32>, V) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<V, N: u32>)(values), value);
+        if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
+          let ((_: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+          (std::collections::bounded_vec::BoundedVec::push<V, N: u32> as λ(& std::collections::bounded_vec::BoundedVec<V, N: u32>, V) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<V, N: u32>)(values), value);
           #_skip
         }
       }
@@ -128,20 +128,20 @@ noir_def std::collections::map::HashMap::values<K: Type, V: Type, N: u32, B: Typ
     #_skip
   };
   let (self_len: u32) = self.1;
-  let (values_len: u32) = (std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<V, N: u32>) -> u32)(values);
+  let (values_len: u32) = (std::collections::bounded_vec::BoundedVec::len<V, N: u32> as λ(std::collections::bounded_vec::BoundedVec<V, N: u32>) -> u32)(values);
   let (msg: FmtString<81: u32, Tuple<u32, u32> >) = (#_mkFormatString returning FmtString<81: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{values_len}{}.", self_len, values_len);
-  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<> as λ(std::collections::bounded_vec::BoundedVec<V, N: u32>) -> u32)(values), self.1));
+  (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<V, N: u32> as λ(std::collections::bounded_vec::BoundedVec<V, N: u32>) -> u32)(values), self.1));
   values
 }
 
 noir_def std::collections::map::HashMap::iter_mut<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type>(self: & std::collections::map::HashMap<K, V, N: u32, B>, f: λ(K, V) -> Tuple<K, V>) -> Unit := {
-  let mut (entries: std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) = (std::collections::map::HashMap::entries<> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self));
-  let mut (new_map: std::collections::map::HashMap<K, V, N: u32, B>) = (std::collections::map::HashMap::with_hasher<> as λ(B) -> std::collections::map::HashMap<K, V, N: u32, B>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).2);
+  let mut (entries: std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) = (std::collections::map::HashMap::entries<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self));
+  let mut (new_map: std::collections::map::HashMap<K, V, N: u32, B>) = (std::collections::map::HashMap::with_hasher<K, V, N: u32, B> as λ(B) -> std::collections::map::HashMap<K, V, N: u32, B>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).2);
   for i in (0: u32) .. uConst!(N: u32) do {
     if (#_uLt returning bool)(i, (#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).1) then {
-      let (entry: Tuple<K, V>) = (std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>, u32) -> Tuple<K, V>)(entries, i);
+      let (entry: Tuple<K, V>) = (std::collections::bounded_vec::BoundedVec::get_unchecked<Tuple<K, V>, N: u32> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>, u32) -> Tuple<K, V>)(entries, i);
       let ((key: K), (value: V)) = (f as λ(K, V) -> Tuple<K, V>)(entry.0, entry.1);
-      (std::collections::map::HashMap::insert<> as λ(& std::collections::map::HashMap<K, V, N: u32, B>, K, V) -> Unit)((#_ref returning & std::collections::map::HashMap<K, V, N: u32, B>)(new_map), key, value);
+      (std::collections::map::HashMap::insert<K, V, N: u32, B> as λ(& std::collections::map::HashMap<K, V, N: u32, B>, K, V) -> Unit)((#_ref returning & std::collections::map::HashMap<K, V, N: u32, B>)(new_map), key, value);
       #_skip
     }
   };
@@ -151,13 +151,13 @@ noir_def std::collections::map::HashMap::iter_mut<K: Type, V: Type, N: u32, B: T
 }
 
 noir_def std::collections::map::HashMap::iter_keys_mut<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type>(self: & std::collections::map::HashMap<K, V, N: u32, B>, f: λ(K) -> K) -> Unit := {
-  let mut (entries: std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) = (std::collections::map::HashMap::entries<> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self));
-  let mut (new_map: std::collections::map::HashMap<K, V, N: u32, B>) = (std::collections::map::HashMap::with_hasher<> as λ(B) -> std::collections::map::HashMap<K, V, N: u32, B>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).2);
+  let mut (entries: std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) = (std::collections::map::HashMap::entries<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self));
+  let mut (new_map: std::collections::map::HashMap<K, V, N: u32, B>) = (std::collections::map::HashMap::with_hasher<K, V, N: u32, B> as λ(B) -> std::collections::map::HashMap<K, V, N: u32, B>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).2);
   for i in (0: u32) .. uConst!(N: u32) do {
     if (#_uLt returning bool)(i, (#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).1) then {
-      let (entry: Tuple<K, V>) = (std::collections::bounded_vec::BoundedVec::get_unchecked<> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>, u32) -> Tuple<K, V>)(entries, i);
+      let (entry: Tuple<K, V>) = (std::collections::bounded_vec::BoundedVec::get_unchecked<Tuple<K, V>, N: u32> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>, u32) -> Tuple<K, V>)(entries, i);
       let ((key: K), (value: V)) = (#_makeData returning Tuple<K, V>)((f as λ(K) -> K)(entry.0), entry.1);
-      (std::collections::map::HashMap::insert<> as λ(& std::collections::map::HashMap<K, V, N: u32, B>, K, V) -> Unit)((#_ref returning & std::collections::map::HashMap<K, V, N: u32, B>)(new_map), key, value);
+      (std::collections::map::HashMap::insert<K, V, N: u32, B> as λ(& std::collections::map::HashMap<K, V, N: u32, B>, K, V) -> Unit)((#_ref returning & std::collections::map::HashMap<K, V, N: u32, B>)(new_map), key, value);
       #_skip
     }
   };
@@ -169,9 +169,9 @@ noir_def std::collections::map::HashMap::iter_keys_mut<K: Type, V: Type, N: u32,
 noir_def std::collections::map::HashMap::iter_values_mut<K: Type, V: Type, N: u32, B: Type>(self: & std::collections::map::HashMap<K, V, N: u32, B>, f: λ(V) -> V) -> Unit := {
   for i in (0: u32) .. uConst!(N: u32) do {
     let mut (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).0, (#_cast returning u32)(i));
-    if (std::collections::map::Slot::is_valid<> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-      let ((key: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
-      (std::collections::map::Slot::set<> as λ(& std::collections::map::Slot<K, V>, K, V) -> Unit)((#_ref returning & std::collections::map::Slot<K, V>)(slot), key, (f as λ(V) -> V)(value));
+    if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
+      let ((key: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+      (std::collections::map::Slot::set<K, V> as λ(& std::collections::map::Slot<K, V>, K, V) -> Unit)((#_ref returning & std::collections::map::Slot<K, V>)(slot), key, (f as λ(V) -> V)(value));
       (((*self: std::collections::map::HashMap<K, V, N: u32, B>).0: Array<std::collections::map::Slot<K, V>, N: u32>)[i]: std::collections::map::Slot<K, V>) = slot;
       #_skip
     }
@@ -182,10 +182,10 @@ noir_def std::collections::map::HashMap::iter_values_mut<K: Type, V: Type, N: u3
 noir_def std::collections::map::HashMap::retain<K: Type, V: Type, N: u32, B: Type>(self: & std::collections::map::HashMap<K, V, N: u32, B>, f: λ(K, V) -> bool) -> Unit := {
   for index in (0: u32) .. uConst!(N: u32) do {
     let mut (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).0, (#_cast returning u32)(index));
-    if (std::collections::map::Slot::is_valid<> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-      let ((key: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+    if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
+      let ((key: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
       if (#_bNot returning bool)((f as λ(K, V) -> bool)(key, value)) then {
-        (std::collections::map::Slot::mark_deleted<> as λ(& std::collections::map::Slot<K, V>) -> Unit)((#_ref returning & std::collections::map::Slot<K, V>)(slot));
+        (std::collections::map::Slot::mark_deleted<K, V> as λ(& std::collections::map::Slot<K, V>) -> Unit)((#_ref returning & std::collections::map::Slot<K, V>)(slot));
         ((*self: std::collections::map::HashMap<K, V, N: u32, B>).1: u32) = (#_uSub returning u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).1, (1: u32));
         (((*self: std::collections::map::HashMap<K, V, N: u32, B>).0: Array<std::collections::map::Slot<K, V>, N: u32>)[index]: std::collections::map::Slot<K, V>) = slot;
         #_skip
@@ -204,17 +204,17 @@ noir_def std::collections::map::HashMap::capacity<K: Type, V: Type, N: u32, B: T
 }
 
 noir_def std::collections::map::HashMap::get<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type>(self: std::collections::map::HashMap<K, V, N: u32, B>, key: K) -> std::option::Option<V> := {
-  let mut (result: std::option::Option<V>) = (std::option::Option::none<> as λ() -> std::option::Option<V>)();
-  let (hash: u32) = (std::collections::map::HashMap::hash<> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> u32)(self, key);
+  let mut (result: std::option::Option<V>) = (std::option::Option::none<V> as λ() -> std::option::Option<V>)();
+  let (hash: u32) = (std::collections::map::HashMap::hash<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> u32)(self, key);
   let mut (should_break: bool) = #_false;
   for attempt in (0: u32) .. uConst!(N: u32) do {
     if (#_bNot returning bool)(should_break) then {
-      let (index: u32) = (std::collections::map::HashMap::quadratic_probe<> as λ(std::collections::map::HashMap<K, V, N: u32, B>, u32, u32) -> u32)(self, hash, (#_cast returning u32)(attempt));
+      let (index: u32) = (std::collections::map::HashMap::quadratic_probe<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, u32, u32) -> u32)(self, hash, (#_cast returning u32)(attempt));
       let (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)(self.0, (#_cast returning u32)(index));
-      if (std::collections::map::Slot::is_valid<> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-        let ((current_key: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+      if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
+        let ((current_key: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
         if ((K as Eq<>)::eq<> as λ(K, K) -> bool)(current_key, key) then {
-          result = (std::option::Option::some<> as λ(V) -> std::option::Option<V>)(value);
+          result = (std::option::Option::some<V> as λ(V) -> std::option::Option<V>)(value);
           should_break = #_true;
           #_skip
         }
@@ -225,27 +225,27 @@ noir_def std::collections::map::HashMap::get<K: Type, V: Type, N: u32, B: Type, 
 }
 
 noir_def std::collections::map::HashMap::insert<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type>(self: & std::collections::map::HashMap<K, V, N: u32, B>, key: K, value: V) -> Unit := {
-  (std::collections::map::HashMap::assert_load_factor<> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> Unit)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self));
-  let (hash: u32) = (std::collections::map::HashMap::hash<> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), key);
+  (std::collections::map::HashMap::assert_load_factor<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> Unit)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self));
+  let (hash: u32) = (std::collections::map::HashMap::hash<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), key);
   let mut (should_break: bool) = #_false;
   for attempt in (0: u32) .. uConst!(N: u32) do {
     if (#_bNot returning bool)(should_break) then {
-      let (index: u32) = (std::collections::map::HashMap::quadratic_probe<> as λ(std::collections::map::HashMap<K, V, N: u32, B>, u32, u32) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), hash, (#_cast returning u32)(attempt));
+      let (index: u32) = (std::collections::map::HashMap::quadratic_probe<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, u32, u32) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), hash, (#_cast returning u32)(attempt));
       let mut (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).0, (#_cast returning u32)(index));
       let mut (insert: bool) = #_false;
-      if (std::collections::map::Slot::is_available<> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
+      if (std::collections::map::Slot::is_available<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
         insert = #_true;
         ((*self: std::collections::map::HashMap<K, V, N: u32, B>).1: u32) = (#_uAdd returning u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).1, (1: u32));
         #_skip
       } else {
-        let ((current_key: K), (_: V)) = (std::collections::map::Slot::key_value_unchecked<> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+        let ((current_key: K), (_: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
         if ((K as Eq<>)::eq<> as λ(K, K) -> bool)(current_key, key) then {
           insert = #_true;
           #_skip
         }
       };
       if insert then {
-        (std::collections::map::Slot::set<> as λ(& std::collections::map::Slot<K, V>, K, V) -> Unit)((#_ref returning & std::collections::map::Slot<K, V>)(slot), key, value);
+        (std::collections::map::Slot::set<K, V> as λ(& std::collections::map::Slot<K, V>, K, V) -> Unit)((#_ref returning & std::collections::map::Slot<K, V>)(slot), key, value);
         (((*self: std::collections::map::HashMap<K, V, N: u32, B>).0: Array<std::collections::map::Slot<K, V>, N: u32>)[index]: std::collections::map::Slot<K, V>) = slot;
         should_break = #_true;
         #_skip
@@ -256,16 +256,16 @@ noir_def std::collections::map::HashMap::insert<K: Type, V: Type, N: u32, B: Typ
 }
 
 noir_def std::collections::map::HashMap::remove<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type>(self: & std::collections::map::HashMap<K, V, N: u32, B>, key: K) -> Unit := {
-  let (hash: u32) = (std::collections::map::HashMap::hash<> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), key);
+  let (hash: u32) = (std::collections::map::HashMap::hash<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), key);
   let mut (should_break: bool) = #_false;
   for attempt in (0: u32) .. uConst!(N: u32) do {
     if (#_bNot returning bool)(should_break) then {
-      let (index: u32) = (std::collections::map::HashMap::quadratic_probe<> as λ(std::collections::map::HashMap<K, V, N: u32, B>, u32, u32) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), hash, (#_cast returning u32)(attempt));
+      let (index: u32) = (std::collections::map::HashMap::quadratic_probe<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, u32, u32) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), hash, (#_cast returning u32)(attempt));
       let mut (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).0, (#_cast returning u32)(index));
-      if (std::collections::map::Slot::is_valid<> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-        let ((current_key: K), (_: V)) = (std::collections::map::Slot::key_value_unchecked<> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+      if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
+        let ((current_key: K), (_: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
         if ((K as Eq<>)::eq<> as λ(K, K) -> bool)(current_key, key) then {
-          (std::collections::map::Slot::mark_deleted<> as λ(& std::collections::map::Slot<K, V>) -> Unit)((#_ref returning & std::collections::map::Slot<K, V>)(slot));
+          (std::collections::map::Slot::mark_deleted<K, V> as λ(& std::collections::map::Slot<K, V>) -> Unit)((#_ref returning & std::collections::map::Slot<K, V>)(slot));
           (((*self: std::collections::map::HashMap<K, V, N: u32, B>).0: Array<std::collections::map::Slot<K, V>, N: u32>)[index]: std::collections::map::Slot<K, V>) = slot;
           ((*self: std::collections::map::HashMap<K, V, N: u32, B>).1: u32) = (#_uSub returning u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).1, (1: u32));
           should_break = #_true;
@@ -298,21 +298,21 @@ noir_def std::collections::map::HashMap::assert_load_factor<K: Type, V: Type, N:
 noir_trait_impl[impl_35]<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type> std::cmp::Eq<> for std::collections::map::HashMap<K, V, N: u32, B> where [K: std::cmp::Eq<>, K: std::hash::Hash<>, V: std::cmp::Eq<>, B: std::hash::BuildHasher<B_as_BuildHasher_H>] := {
   noir_def eq<>(self: std::collections::map::HashMap<K, V, N: u32, B>, other: std::collections::map::HashMap<K, V, N: u32, B>) -> bool := {
     let mut (equal: bool) = #_false;
-    if (#_uEq returning bool)((std::collections::map::HashMap::len<> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> u32)(self), (std::collections::map::HashMap::len<> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> u32)(other)) then {
+    if (#_uEq returning bool)((std::collections::map::HashMap::len<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> u32)(self), (std::collections::map::HashMap::len<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> u32)(other)) then {
       equal = #_true;
       {
         let (ζi0: Array<std::collections::map::Slot<K, V>, N: u32>) = self.0;
         for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
           let (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
           {
-            if (#_bAnd returning bool)(equal, (std::collections::map::Slot::is_valid<> as λ(std::collections::map::Slot<K, V>) -> bool)(slot)) then {
-              let ((key: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
-              let (other_value: std::option::Option<V>) = (std::collections::map::HashMap::get<> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> std::option::Option<V>)(other, key);
-              if (std::option::Option::is_none<> as λ(std::option::Option<V>) -> bool)(other_value) then {
+            if (#_bAnd returning bool)(equal, (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot)) then {
+              let ((key: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+              let (other_value: std::option::Option<V>) = (std::collections::map::HashMap::get<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> std::option::Option<V>)(other, key);
+              if (std::option::Option::is_none<V> as λ(std::option::Option<V>) -> bool)(other_value) then {
                 equal = #_false;
                 #_skip
               } else {
-                let (other_value: V) = (std::option::Option::unwrap_unchecked<> as λ(std::option::Option<V>) -> V)(other_value);
+                let (other_value: V) = (std::option::Option::unwrap_unchecked<V> as λ(std::option::Option<V>) -> V)(other_value);
                 if ((V as Eq<>)::eq<> as λ(V, V) -> bool)(value, other_value) then {
                   equal = #_false;
                   #_skip
@@ -331,7 +331,7 @@ noir_trait_impl[impl_35]<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: 
 noir_trait_impl[impl_36]<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type> std::default::Default<> for std::collections::map::HashMap<K, V, N: u32, B> where [B: std::hash::BuildHasher<B_as_BuildHasher_H>, B: std::default::Default<>] := {
   noir_def default<>() -> std::collections::map::HashMap<K, V, N: u32, B> := {
     let (_build_hasher: B) = ((B as std::default::Default<>)::default<> as λ() -> B)();
-    let (map: std::collections::map::HashMap<K, V, N: u32, B>) = (std::collections::map::HashMap::with_hasher<> as λ(B) -> std::collections::map::HashMap<K, V, N: u32, B>)(_build_hasher);
+    let (map: std::collections::map::HashMap<K, V, N: u32, B>) = (std::collections::map::HashMap::with_hasher<K, V, N: u32, B> as λ(B) -> std::collections::map::HashMap<K, V, N: u32, B>)(_build_hasher);
     map
   };
 }

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/Umap.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/Umap.lean
@@ -10,16 +10,16 @@ namespace Extracted
 
 noir_trait_impl[impl_37]<K: Type, V: Type> std::default::Default<> for std::collections::umap::Slot<K, V> where [] := {
   noir_def default<>() -> std::collections::umap::Slot<K, V> := {
-    (#_makeData returning std::collections::umap::Slot<K, V>)((std::option::Option::none<> as λ() -> std::option::Option<Tuple<K, V> >)(), #_false)
+    (#_makeData returning std::collections::umap::Slot<K, V>)((std::option::Option::none<Tuple<K, V> > as λ() -> std::option::Option<Tuple<K, V> >)(), #_false)
   };
 }
 
 noir_def std::collections::umap::Slot::is_valid<K: Type, V: Type>(self: std::collections::umap::Slot<K, V>) -> bool := {
-  (#_bAnd returning bool)((#_bNot returning bool)(self.1), (std::option::Option::is_some<> as λ(std::option::Option<Tuple<K, V> >) -> bool)(self.0))
+  (#_bAnd returning bool)((#_bNot returning bool)(self.1), (std::option::Option::is_some<Tuple<K, V> > as λ(std::option::Option<Tuple<K, V> >) -> bool)(self.0))
 }
 
 noir_def std::collections::umap::Slot::is_available<K: Type, V: Type>(self: std::collections::umap::Slot<K, V>) -> bool := {
-  (#_bOr returning bool)(self.1, (std::option::Option::is_none<> as λ(std::option::Option<Tuple<K, V> >) -> bool)(self.0))
+  (#_bOr returning bool)(self.1, (std::option::Option::is_none<Tuple<K, V> > as λ(std::option::Option<Tuple<K, V> >) -> bool)(self.0))
 }
 
 noir_def std::collections::umap::Slot::key_value<K: Type, V: Type>(self: std::collections::umap::Slot<K, V>) -> std::option::Option<Tuple<K, V> > := {
@@ -27,11 +27,11 @@ noir_def std::collections::umap::Slot::key_value<K: Type, V: Type>(self: std::co
 }
 
 noir_def std::collections::umap::Slot::key_value_unchecked<K: Type, V: Type>(self: std::collections::umap::Slot<K, V>) -> Tuple<K, V> := {
-  (std::option::Option::unwrap_unchecked<> as λ(std::option::Option<Tuple<K, V> >) -> Tuple<K, V>)(self.0)
+  (std::option::Option::unwrap_unchecked<Tuple<K, V> > as λ(std::option::Option<Tuple<K, V> >) -> Tuple<K, V>)(self.0)
 }
 
 noir_def std::collections::umap::Slot::set<K: Type, V: Type>(self: & std::collections::umap::Slot<K, V>, key: K, value: V) -> Unit := {
-  ((*self: std::collections::umap::Slot<K, V>).0: std::option::Option<Tuple<K, V> >) = (std::option::Option::some<> as λ(Tuple<K, V>) -> std::option::Option<Tuple<K, V> >)((#_makeData returning Tuple<K, V>)(key, value));
+  ((*self: std::collections::umap::Slot<K, V>).0: std::option::Option<Tuple<K, V> >) = (std::option::Option::some<Tuple<K, V> > as λ(Tuple<K, V>) -> std::option::Option<Tuple<K, V> >)((#_makeData returning Tuple<K, V>)(key, value));
   ((*self: std::collections::umap::Slot<K, V>).1: bool) = #_false;
   #_skip
 }
@@ -64,8 +64,8 @@ noir_def std::collections::umap::UHashMap::clear<K: Type, V: Type, B: Type>(self
 }
 
 noir_def std::collections::umap::UHashMap::contains_key<K: Type, V: Type, B: Type, B_as_BuildHasher_H: Type>(self: std::collections::umap::UHashMap<K, V, B>, key: K) -> bool := {
-  (std::option::Option::is_some<> as λ(std::option::Option<V>) -> bool)({
-    (std::collections::umap::UHashMap::get<> as λ(std::collections::umap::UHashMap<K, V, B>, K) -> std::option::Option<V>)(self, key)
+  (std::option::Option::is_some<V> as λ(std::option::Option<V>) -> bool)({
+    (std::collections::umap::UHashMap::get<K, V, B> as λ(std::collections::umap::UHashMap<K, V, B>, K) -> std::option::Option<V>)(self, key)
   })
 }
 
@@ -80,8 +80,8 @@ noir_def std::collections::umap::UHashMap::entries<K: Type, V: Type, B: Type>(se
     for ζi1 in (0: u32) .. (#_sliceLen returning u32)(ζi0) do {
       let (slot: std::collections::umap::Slot<K, V>) = (#_sliceIndex returning std::collections::umap::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
       {
-        if (std::collections::umap::Slot::is_valid<> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
-          let (key_value: Tuple<K, V>) = (std::option::Option::unwrap_unchecked<> as λ(std::option::Option<Tuple<K, V> >) -> Tuple<K, V>)((std::collections::umap::Slot::key_value<> as λ(std::collections::umap::Slot<K, V>) -> std::option::Option<Tuple<K, V> >)(slot));
+        if (std::collections::umap::Slot::is_valid<K, V> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
+          let (key_value: Tuple<K, V>) = (std::option::Option::unwrap_unchecked<Tuple<K, V> > as λ(std::option::Option<Tuple<K, V> >) -> Tuple<K, V>)((std::collections::umap::Slot::key_value<K, V> as λ(std::collections::umap::Slot<K, V>) -> std::option::Option<Tuple<K, V> >)(slot));
           entries = (#_slicePushBack returning Slice<Tuple<K, V> >)(entries, key_value);
           #_skip
         }
@@ -103,8 +103,8 @@ noir_def std::collections::umap::UHashMap::keys<K: Type, V: Type, B: Type>(self:
     for ζi1 in (0: u32) .. (#_sliceLen returning u32)(ζi0) do {
       let (slot: std::collections::umap::Slot<K, V>) = (#_sliceIndex returning std::collections::umap::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
       {
-        if (std::collections::umap::Slot::is_valid<> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
-          let ((key: K), (_: V)) = (std::collections::umap::Slot::key_value_unchecked<> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
+        if (std::collections::umap::Slot::is_valid<K, V> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
+          let ((key: K), (_: V)) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
           keys = (#_slicePushBack returning Slice<K>)(keys, key);
           #_skip
         }
@@ -126,8 +126,8 @@ noir_def std::collections::umap::UHashMap::values<K: Type, V: Type, B: Type>(sel
     for ζi1 in (0: u32) .. (#_sliceLen returning u32)(ζi0) do {
       let (slot: std::collections::umap::Slot<K, V>) = (#_sliceIndex returning std::collections::umap::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
       {
-        if (std::collections::umap::Slot::is_valid<> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
-          let ((_: K), (value: V)) = (std::collections::umap::Slot::key_value_unchecked<> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
+        if (std::collections::umap::Slot::is_valid<K, V> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
+          let ((_: K), (value: V)) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
           values = (#_slicePushBack returning Slice<V>)(values, value);
           #_skip
         }
@@ -153,9 +153,9 @@ noir_def std::collections::umap::UHashMap::iter_keys_mut<K: Type, V: Type, B: Ty
 noir_def std::collections::umap::UHashMap::iter_values_mut<K: Type, V: Type, B: Type>(self: & std::collections::umap::UHashMap<K, V, B>, f: λ(V) -> V) -> Unit := {
   for i in (0: u32) .. (#_sliceLen returning u32)((#_readRef returning std::collections::umap::UHashMap<K, V, B>)(self).0) do {
     let mut (slot: std::collections::umap::Slot<K, V>) = (#_sliceIndex returning std::collections::umap::Slot<K, V>)((#_readRef returning std::collections::umap::UHashMap<K, V, B>)(self).0, (#_cast returning u32)(i));
-    if (std::collections::umap::Slot::is_valid<> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
-      let ((key: K), (value: V)) = (std::collections::umap::Slot::key_value_unchecked<> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
-      (std::collections::umap::Slot::set<> as λ(& std::collections::umap::Slot<K, V>, K, V) -> Unit)((#_ref returning & std::collections::umap::Slot<K, V>)(slot), key, (f as λ(V) -> V)(value));
+    if (std::collections::umap::Slot::is_valid<K, V> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
+      let ((key: K), (value: V)) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
+      (std::collections::umap::Slot::set<K, V> as λ(& std::collections::umap::Slot<K, V>, K, V) -> Unit)((#_ref returning & std::collections::umap::Slot<K, V>)(slot), key, (f as λ(V) -> V)(value));
       (((*self: std::collections::umap::UHashMap<K, V, B>).0: Slice<std::collections::umap::Slot<K, V> >)[[i]]: std::collections::umap::Slot<K, V>) = slot;
       #_skip
     }
@@ -166,10 +166,10 @@ noir_def std::collections::umap::UHashMap::iter_values_mut<K: Type, V: Type, B: 
 noir_def std::collections::umap::UHashMap::retain<K: Type, V: Type, B: Type>(self: & std::collections::umap::UHashMap<K, V, B>, f: λ(K, V) -> bool) -> Unit := {
   for index in (0: u32) .. (#_sliceLen returning u32)((#_readRef returning std::collections::umap::UHashMap<K, V, B>)(self).0) do {
     let mut (slot: std::collections::umap::Slot<K, V>) = (#_sliceIndex returning std::collections::umap::Slot<K, V>)((#_readRef returning std::collections::umap::UHashMap<K, V, B>)(self).0, (#_cast returning u32)(index));
-    if (std::collections::umap::Slot::is_valid<> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
-      let ((key: K), (value: V)) = (std::collections::umap::Slot::key_value_unchecked<> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
+    if (std::collections::umap::Slot::is_valid<K, V> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
+      let ((key: K), (value: V)) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
       if (#_bNot returning bool)((f as λ(K, V) -> bool)(key, value)) then {
-        (std::collections::umap::Slot::mark_deleted<> as λ(& std::collections::umap::Slot<K, V>) -> Unit)((#_ref returning & std::collections::umap::Slot<K, V>)(slot));
+        (std::collections::umap::Slot::mark_deleted<K, V> as λ(& std::collections::umap::Slot<K, V>) -> Unit)((#_ref returning & std::collections::umap::Slot<K, V>)(slot));
         ((*self: std::collections::umap::UHashMap<K, V, B>).1: u32) = (#_uSub returning u32)((#_readRef returning std::collections::umap::UHashMap<K, V, B>)(self).1, (1: u32));
         (((*self: std::collections::umap::UHashMap<K, V, B>).0: Slice<std::collections::umap::Slot<K, V> >)[[index]]: std::collections::umap::Slot<K, V>) = slot;
         #_skip
@@ -216,23 +216,23 @@ noir_def std::collections::umap::UHashMap::quadratic_probe<K: Type, V: Type, B: 
 noir_trait_impl[impl_38]<K: Type, V: Type, B: Type, B_as_BuildHasher_H: Type> std::cmp::Eq<> for std::collections::umap::UHashMap<K, V, B> where [K: std::cmp::Eq<>, K: std::hash::Hash<>, V: std::cmp::Eq<>, B: std::hash::BuildHasher<B_as_BuildHasher_H>] := {
   noir_def eq<>(self: std::collections::umap::UHashMap<K, V, B>, other: std::collections::umap::UHashMap<K, V, B>) -> bool := {
     let mut (equal: bool) = #_false;
-    if (#_uEq returning bool)((std::collections::umap::UHashMap::len<> as λ(std::collections::umap::UHashMap<K, V, B>) -> u32)(self), (std::collections::umap::UHashMap::len<> as λ(std::collections::umap::UHashMap<K, V, B>) -> u32)(other)) then {
+    if (#_uEq returning bool)((std::collections::umap::UHashMap::len<K, V, B> as λ(std::collections::umap::UHashMap<K, V, B>) -> u32)(self), (std::collections::umap::UHashMap::len<K, V, B> as λ(std::collections::umap::UHashMap<K, V, B>) -> u32)(other)) then {
       equal = #_true;
       {
         let (ζi0: Slice<std::collections::umap::Slot<K, V> >) = self.0;
         for ζi1 in (0: u32) .. (#_sliceLen returning u32)(ζi0) do {
           let (slot: std::collections::umap::Slot<K, V>) = (#_sliceIndex returning std::collections::umap::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
           {
-            if (#_bAnd returning bool)(equal, (std::collections::umap::Slot::is_valid<> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot)) then {
-              let ((key: K), (value: V)) = (std::collections::umap::Slot::key_value_unchecked<> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
+            if (#_bAnd returning bool)(equal, (std::collections::umap::Slot::is_valid<K, V> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot)) then {
+              let ((key: K), (value: V)) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
               let (other_value: std::option::Option<V>) = {
-                (std::collections::umap::UHashMap::get<> as λ(std::collections::umap::UHashMap<K, V, B>, K) -> std::option::Option<V>)(other, key)
+                (std::collections::umap::UHashMap::get<K, V, B> as λ(std::collections::umap::UHashMap<K, V, B>, K) -> std::option::Option<V>)(other, key)
               };
-              if (std::option::Option::is_none<> as λ(std::option::Option<V>) -> bool)(other_value) then {
+              if (std::option::Option::is_none<V> as λ(std::option::Option<V>) -> bool)(other_value) then {
                 equal = #_false;
                 #_skip
               } else {
-                let (other_value: V) = (std::option::Option::unwrap_unchecked<> as λ(std::option::Option<V>) -> V)(other_value);
+                let (other_value: V) = (std::option::Option::unwrap_unchecked<V> as λ(std::option::Option<V>) -> V)(other_value);
                 if ((V as Eq<>)::eq<> as λ(V, V) -> bool)(value, other_value) then {
                   equal = #_false;
                   #_skip
@@ -250,7 +250,7 @@ noir_trait_impl[impl_38]<K: Type, V: Type, B: Type, B_as_BuildHasher_H: Type> st
 
 noir_trait_impl[impl_39]<K: Type, V: Type, B: Type, B_as_BuildHasher_H: Type> std::default::Default<> for std::collections::umap::UHashMap<K, V, B> where [B: std::hash::BuildHasher<B_as_BuildHasher_H>, B: std::default::Default<>] := {
   noir_def default<>() -> std::collections::umap::UHashMap<K, V, B> := {
-    (std::collections::umap::UHashMap::with_hasher<> as λ(B) -> std::collections::umap::UHashMap<K, V, B>)(((B as std::default::Default<>)::default<> as λ() -> B)())
+    (std::collections::umap::UHashMap::with_hasher<K, V, B> as λ(B) -> std::collections::umap::UHashMap<K, V, B>)(((B as std::default::Default<>)::default<> as λ() -> B)())
   };
 }
 

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/Vec.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/Vec.lean
@@ -37,12 +37,12 @@ noir_def std::collections::vec::Vec::pop<T: Type>(self: & std::collections::vec:
 }
 
 noir_def std::collections::vec::Vec::insert<T: Type>(self: & std::collections::vec::Vec<T>, index: u32, elem: T) -> Unit := {
-  ((*self: std::collections::vec::Vec<T>).0: Slice<T>) = (std::slice::insert<> as λ(Slice<T>, u32, T) -> Slice<T>)((#_readRef returning std::collections::vec::Vec<T>)(self).0, index, elem);
+  ((*self: std::collections::vec::Vec<T>).0: Slice<T>) = (std::slice::insert<T> as λ(Slice<T>, u32, T) -> Slice<T>)((#_readRef returning std::collections::vec::Vec<T>)(self).0, index, elem);
   #_skip
 }
 
 noir_def std::collections::vec::Vec::remove<T: Type>(self: & std::collections::vec::Vec<T>, index: u32) -> T := {
-  let ((new_slice: Slice<T>), (elem: T)) = (std::slice::remove<> as λ(Slice<T>, u32) -> Tuple<Slice<T>, T>)((#_readRef returning std::collections::vec::Vec<T>)(self).0, index);
+  let ((new_slice: Slice<T>), (elem: T)) = (std::slice::remove<T> as λ(Slice<T>, u32) -> Tuple<Slice<T>, T>)((#_readRef returning std::collections::vec::Vec<T>)(self).0, index);
   ((*self: std::collections::vec::Vec<T>).0: Slice<T>) = new_slice;
   elem
 }
@@ -51,29 +51,29 @@ noir_def std::collections::vec::Vec::len<T: Type>(self: std::collections::vec::V
   (#_sliceLen returning u32)(self.0)
 }
 
-noir_def collections::vec::tests::set_updates_values_properly<>() -> Unit := {
+noir_def std::collections::vec::tests::set_updates_values_properly<>() -> Unit := {
   let mut (vec: std::collections::vec::Vec<Field>) = (#_makeData returning std::collections::vec::Vec<Field>)((#_mkSlice returning Slice<Field>)((0: Field), (0: Field), (0: Field), (0: Field), (0: Field)));
-  (std::collections::vec::Vec::set<> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (0: u32), (42: Field));
+  (std::collections::vec::Vec::set<Field> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (0: u32), (42: Field));
   (#_assert returning Unit)(((Slice<Field> as Eq<>)::eq<> as λ(Slice<Field>, Slice<Field>) -> bool)(vec.0, (#_mkSlice returning Slice<Field>)((42: Field), (0: Field), (0: Field), (0: Field), (0: Field))));
-  (std::collections::vec::Vec::set<> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (1: u32), (43: Field));
+  (std::collections::vec::Vec::set<Field> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (1: u32), (43: Field));
   (#_assert returning Unit)(((Slice<Field> as Eq<>)::eq<> as λ(Slice<Field>, Slice<Field>) -> bool)(vec.0, (#_mkSlice returning Slice<Field>)((42: Field), (43: Field), (0: Field), (0: Field), (0: Field))));
-  (std::collections::vec::Vec::set<> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (2: u32), (44: Field));
+  (std::collections::vec::Vec::set<Field> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (2: u32), (44: Field));
   (#_assert returning Unit)(((Slice<Field> as Eq<>)::eq<> as λ(Slice<Field>, Slice<Field>) -> bool)(vec.0, (#_mkSlice returning Slice<Field>)((42: Field), (43: Field), (44: Field), (0: Field), (0: Field))));
-  (std::collections::vec::Vec::set<> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (1: u32), (10: Field));
+  (std::collections::vec::Vec::set<Field> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (1: u32), (10: Field));
   (#_assert returning Unit)(((Slice<Field> as Eq<>)::eq<> as λ(Slice<Field>, Slice<Field>) -> bool)(vec.0, (#_mkSlice returning Slice<Field>)((42: Field), (10: Field), (44: Field), (0: Field), (0: Field))));
-  (std::collections::vec::Vec::set<> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (0: u32), (0: Field));
+  (std::collections::vec::Vec::set<Field> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (0: u32), (0: Field));
   (#_assert returning Unit)(((Slice<Field> as Eq<>)::eq<> as λ(Slice<Field>, Slice<Field>) -> bool)(vec.0, (#_mkSlice returning Slice<Field>)((0: Field), (10: Field), (44: Field), (0: Field), (0: Field))));
   #_skip
 }
 
-noir_def collections::vec::tests::panics_when_writing_elements_past_end_of_vec<>() -> Unit := {
-  let mut (vec: std::collections::vec::Vec<Field>) = (std::collections::vec::Vec::new<> as λ() -> std::collections::vec::Vec<Field>)();
-  (std::collections::vec::Vec::set<> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (0: u32), (42: Field));
-  let (_: Field) = (std::collections::vec::Vec::get<> as λ(std::collections::vec::Vec<Field>, u32) -> Field)(vec, (0: u32));
+noir_def std::collections::vec::tests::panics_when_writing_elements_past_end_of_vec<>() -> Unit := {
+  let mut (vec: std::collections::vec::Vec<Field>) = (std::collections::vec::Vec::new<Field> as λ() -> std::collections::vec::Vec<Field>)();
+  (std::collections::vec::Vec::set<Field> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (0: u32), (42: Field));
+  let (_: Field) = (std::collections::vec::Vec::get<Field> as λ(std::collections::vec::Vec<Field>, u32) -> Field)(vec, (0: u32));
   #_skip
 }
 
 
 def Collections.Vec.env : Env := Env.mk
-  [«std::collections::vec::Vec::new», «std::collections::vec::Vec::from_slice», «std::collections::vec::Vec::get», «std::collections::vec::Vec::set», «std::collections::vec::Vec::push», «std::collections::vec::Vec::pop», «std::collections::vec::Vec::insert», «std::collections::vec::Vec::remove», «std::collections::vec::Vec::len», «collections::vec::tests::set_updates_values_properly», «collections::vec::tests::panics_when_writing_elements_past_end_of_vec»]
+  [«std::collections::vec::Vec::new», «std::collections::vec::Vec::from_slice», «std::collections::vec::Vec::get», «std::collections::vec::Vec::set», «std::collections::vec::Vec::push», «std::collections::vec::Vec::pop», «std::collections::vec::Vec::insert», «std::collections::vec::Vec::remove», «std::collections::vec::Vec::len», «std::collections::vec::tests::set_updates_values_properly», «std::collections::vec::tests::panics_when_writing_elements_past_end_of_vec»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Compat.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Compat.lean
@@ -8,11 +8,11 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def compat::is_bn254<>() -> bool := {
+noir_def std::compat::is_bn254<>() -> bool := {
   #_true
 }
 
 
 def Compat.env : Env := Env.mk
-  [«compat::is_bn254»]
+  [«std::compat::is_bn254»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/EcdsaSecp256K1.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/EcdsaSecp256K1.lean
@@ -8,15 +8,15 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def ecdsa_secp256k1::verify_signature<N: u32>(public_key_x: Array<u8, 32: u32>, public_key_y: Array<u8, 32: u32>, signature: Array<u8, 64: u32>, message_hash: Array<u8, N: u32>) -> bool := {
+noir_def std::ecdsa_secp256k1::verify_signature<N: u32>(public_key_x: Array<u8, 32: u32>, public_key_y: Array<u8, 32: u32>, signature: Array<u8, 64: u32>, message_hash: Array<u8, N: u32>) -> bool := {
   (#_ecdsa_secp256k1 returning bool)(public_key_x, public_key_y, signature, message_hash)
 }
 
-noir_def ecdsa_secp256k1::verify_signature_slice<>(public_key_x: Array<u8, 32: u32>, public_key_y: Array<u8, 32: u32>, signature: Array<u8, 64: u32>, message_hash: Slice<u8>) -> bool := {
+noir_def std::ecdsa_secp256k1::verify_signature_slice<>(public_key_x: Array<u8, 32: u32>, public_key_y: Array<u8, 32: u32>, signature: Array<u8, 64: u32>, message_hash: Slice<u8>) -> bool := {
   (#_ecdsa_secp256k1 returning bool)(public_key_x, public_key_y, signature, message_hash)
 }
 
 
 def EcdsaSecp256K1.env : Env := Env.mk
-  [«ecdsa_secp256k1::verify_signature», «ecdsa_secp256k1::verify_signature_slice»]
+  [«std::ecdsa_secp256k1::verify_signature», «std::ecdsa_secp256k1::verify_signature_slice»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/EcdsaSecp256R1.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/EcdsaSecp256R1.lean
@@ -8,15 +8,15 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def ecdsa_secp256r1::verify_signature<N: u32>(public_key_x: Array<u8, 32: u32>, public_key_y: Array<u8, 32: u32>, signature: Array<u8, 64: u32>, message_hash: Array<u8, N: u32>) -> bool := {
+noir_def std::ecdsa_secp256r1::verify_signature<N: u32>(public_key_x: Array<u8, 32: u32>, public_key_y: Array<u8, 32: u32>, signature: Array<u8, 64: u32>, message_hash: Array<u8, N: u32>) -> bool := {
   (#_ecdsa_secp256r1 returning bool)(public_key_x, public_key_y, signature, message_hash)
 }
 
-noir_def ecdsa_secp256r1::verify_signature_slice<>(public_key_x: Array<u8, 32: u32>, public_key_y: Array<u8, 32: u32>, signature: Array<u8, 64: u32>, message_hash: Slice<u8>) -> bool := {
+noir_def std::ecdsa_secp256r1::verify_signature_slice<>(public_key_x: Array<u8, 32: u32>, public_key_y: Array<u8, 32: u32>, signature: Array<u8, 64: u32>, message_hash: Slice<u8>) -> bool := {
   (#_ecdsa_secp256r1 returning bool)(public_key_x, public_key_y, signature, message_hash)
 }
 
 
 def EcdsaSecp256R1.env : Env := Env.mk
-  [«ecdsa_secp256r1::verify_signature», «ecdsa_secp256r1::verify_signature_slice»]
+  [«std::ecdsa_secp256r1::verify_signature», «std::ecdsa_secp256r1::verify_signature_slice»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/EmbeddedCurveOps.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/EmbeddedCurveOps.lean
@@ -94,19 +94,19 @@ noir_trait_impl[impl_31]<> std::hash::Hash<> for std::embedded_curve_ops::Embedd
   };
 }
 
-noir_def embedded_curve_ops::multi_scalar_mul<N: u32>(points: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>, scalars: Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, N: u32>) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
+noir_def std::embedded_curve_ops::multi_scalar_mul<N: u32>(points: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>, scalars: Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, N: u32>) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
   (#_arrayIndex returning std::embedded_curve_ops::EmbeddedCurvePoint<>)((embedded_curve_ops::multi_scalar_mul_array_return<N: u32> as λ(Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>, Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, N: u32>) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>)(points, scalars), (0: u32))
 }
 
-noir_def embedded_curve_ops::multi_scalar_mul_array_return<N: u32>(points: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>, scalars: Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, N: u32>) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32> := {
+noir_def std::embedded_curve_ops::multi_scalar_mul_array_return<N: u32>(points: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>, scalars: Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, N: u32>) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32> := {
   (#_multi_scalar_mul returning Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>)(points, scalars)
 }
 
-noir_def embedded_curve_ops::fixed_base_scalar_mul<>(scalar: std::embedded_curve_ops::EmbeddedCurveScalar<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
+noir_def std::embedded_curve_ops::fixed_base_scalar_mul<>(scalar: std::embedded_curve_ops::EmbeddedCurveScalar<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
   (embedded_curve_ops::multi_scalar_mul<1: u32> as λ(Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>, Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, 1: u32>) -> std::embedded_curve_ops::EmbeddedCurvePoint<>)((#_mkArray returning Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>)((std::embedded_curve_ops::EmbeddedCurvePoint::generator<> as λ() -> std::embedded_curve_ops::EmbeddedCurvePoint<>)()), (#_mkArray returning Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, 1: u32>)(scalar))
 }
 
-noir_def embedded_curve_ops::embedded_curve_add<>(point1: std::embedded_curve_ops::EmbeddedCurvePoint<>, point2: std::embedded_curve_ops::EmbeddedCurvePoint<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
+noir_def std::embedded_curve_ops::embedded_curve_add<>(point1: std::embedded_curve_ops::EmbeddedCurvePoint<>, point2: std::embedded_curve_ops::EmbeddedCurvePoint<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
   if (runtime::is_unconstrained<> as λ() -> bool)() then {
     if point1.2 then {
       point2
@@ -143,11 +143,11 @@ noir_def embedded_curve_ops::embedded_curve_add<>(point1: std::embedded_curve_op
   }
 }
 
-noir_def embedded_curve_ops::embedded_curve_add_array_return<>(_point1: std::embedded_curve_ops::EmbeddedCurvePoint<>, _point2: std::embedded_curve_ops::EmbeddedCurvePoint<>) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32> := {
+noir_def std::embedded_curve_ops::embedded_curve_add_array_return<>(_point1: std::embedded_curve_ops::EmbeddedCurvePoint<>, _point2: std::embedded_curve_ops::EmbeddedCurvePoint<>) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32> := {
   (#_embedded_curve_add returning Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>)(_point1, _point2)
 }
 
-noir_def embedded_curve_ops::embedded_curve_add_not_nul<>(point1: std::embedded_curve_ops::EmbeddedCurvePoint<>, point2: std::embedded_curve_ops::EmbeddedCurvePoint<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
+noir_def std::embedded_curve_ops::embedded_curve_add_not_nul<>(point1: std::embedded_curve_ops::EmbeddedCurvePoint<>, point2: std::embedded_curve_ops::EmbeddedCurvePoint<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
   (#_assert returning Unit)((#_fNeq returning bool)(point1.0, point2.0));
   (#_assert returning Unit)((#_bNot returning bool)(point1.2));
   (#_assert returning Unit)((#_bNot returning bool)(point2.2));
@@ -156,11 +156,11 @@ noir_def embedded_curve_ops::embedded_curve_add_not_nul<>(point1: std::embedded_
   (embedded_curve_ops::embedded_curve_add_unsafe<> as λ(std::embedded_curve_ops::EmbeddedCurvePoint<>, std::embedded_curve_ops::EmbeddedCurvePoint<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<>)(point1_1, point2_1)
 }
 
-noir_def embedded_curve_ops::embedded_curve_add_unsafe<>(point1: std::embedded_curve_ops::EmbeddedCurvePoint<>, point2: std::embedded_curve_ops::EmbeddedCurvePoint<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
+noir_def std::embedded_curve_ops::embedded_curve_add_unsafe<>(point1: std::embedded_curve_ops::EmbeddedCurvePoint<>, point2: std::embedded_curve_ops::EmbeddedCurvePoint<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
   (#_arrayIndex returning std::embedded_curve_ops::EmbeddedCurvePoint<>)((embedded_curve_ops::embedded_curve_add_array_return<> as λ(std::embedded_curve_ops::EmbeddedCurvePoint<>, std::embedded_curve_ops::EmbeddedCurvePoint<>) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>)(point1, point2), (0: u32))
 }
 
 
 def EmbeddedCurveOps.env : Env := Env.mk
-  [«std::embedded_curve_ops::EmbeddedCurvePoint::double», «std::embedded_curve_ops::EmbeddedCurvePoint::point_at_infinity», «std::embedded_curve_ops::EmbeddedCurvePoint::generator», «std::embedded_curve_ops::EmbeddedCurveScalar::new», «std::embedded_curve_ops::EmbeddedCurveScalar::from_field», «std::embedded_curve_ops::EmbeddedCurveScalar::from_bytes», «embedded_curve_ops::multi_scalar_mul», «embedded_curve_ops::multi_scalar_mul_array_return», «embedded_curve_ops::fixed_base_scalar_mul», «embedded_curve_ops::embedded_curve_add», «embedded_curve_ops::embedded_curve_add_array_return», «embedded_curve_ops::embedded_curve_add_not_nul», «embedded_curve_ops::embedded_curve_add_unsafe»]
+  [«std::embedded_curve_ops::EmbeddedCurvePoint::double», «std::embedded_curve_ops::EmbeddedCurvePoint::point_at_infinity», «std::embedded_curve_ops::EmbeddedCurvePoint::generator», «std::embedded_curve_ops::EmbeddedCurveScalar::new», «std::embedded_curve_ops::EmbeddedCurveScalar::from_field», «std::embedded_curve_ops::EmbeddedCurveScalar::from_bytes», «std::embedded_curve_ops::multi_scalar_mul», «std::embedded_curve_ops::multi_scalar_mul_array_return», «std::embedded_curve_ops::fixed_base_scalar_mul», «std::embedded_curve_ops::embedded_curve_add», «std::embedded_curve_ops::embedded_curve_add_array_return», «std::embedded_curve_ops::embedded_curve_add_not_nul», «std::embedded_curve_ops::embedded_curve_add_unsafe»]
   [impl_25, impl_26, impl_27, impl_28, impl_29, impl_30, impl_31]

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Field/Bn254.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Field/Bn254.lean
@@ -14,21 +14,21 @@ noir_global_def PHI: Field = (64323764613183177041862057485226039389: Field);
 
 noir_global_def TWO_POW_128: Field = (340282366920938463463374607431768211456: Field);
 
-noir_def field::bn254::compute_decomposition<>(x: Field) -> Tuple<Field, Field> := {
+noir_def std::field::bn254::compute_decomposition<>(x: Field) -> Tuple<Field, Field> := {
   let (low: Field) = (#_cast returning Field)((#_cast returning u128)(x));
   let (high: Field) = (#_fDiv returning Field)((#_fSub returning Field)(x, low), (TWO_POW_128<> as λ() -> Field)());
   (#_makeData returning Tuple<Field, Field>)(low, high)
 }
 
-noir_def field::bn254::decompose_hint<>(x: Field) -> Tuple<Field, Field> := {
+noir_def std::field::bn254::decompose_hint<>(x: Field) -> Tuple<Field, Field> := {
   (#_fresh returning Tuple<Field, Field>)()
 }
 
-noir_def field::bn254::lte_hint<>(x: Field, y: Field) -> bool := {
+noir_def std::field::bn254::lte_hint<>(x: Field, y: Field) -> bool := {
   (#_fresh returning bool)()
 }
 
-noir_def field::bn254::assert_gt_limbs<>(a: Tuple<Field, Field>, b: Tuple<Field, Field>) -> Unit := {
+noir_def std::field::bn254::assert_gt_limbs<>(a: Tuple<Field, Field>, b: Tuple<Field, Field>) -> Unit := {
   let ((alo: Field), (ahi: Field)) = a;
   let ((blo: Field), (bhi: Field)) = b;
   {
@@ -41,7 +41,7 @@ noir_def field::bn254::assert_gt_limbs<>(a: Tuple<Field, Field>, b: Tuple<Field,
   }
 }
 
-noir_def field::bn254::decompose<>(x: Field) -> Tuple<Field, Field> := {
+noir_def std::field::bn254::decompose<>(x: Field) -> Tuple<Field, Field> := {
   if (runtime::is_unconstrained<> as λ() -> bool)() then {
     (field::bn254::compute_decomposition<> as λ(Field) -> Tuple<Field, Field>)(x)
   } else {
@@ -54,7 +54,7 @@ noir_def field::bn254::decompose<>(x: Field) -> Tuple<Field, Field> := {
   }
 }
 
-noir_def field::bn254::assert_gt<>(a: Field, b: Field) -> Unit := {
+noir_def std::field::bn254::assert_gt<>(a: Field, b: Field) -> Unit := {
   if (runtime::is_unconstrained<> as λ() -> bool)() then {
     (#_assert returning Unit)({
       (field::field_less_than<> as λ(Field, Field) -> bool)(b, a)
@@ -67,12 +67,12 @@ noir_def field::bn254::assert_gt<>(a: Field, b: Field) -> Unit := {
   }
 }
 
-noir_def field::bn254::assert_lt<>(a: Field, b: Field) -> Unit := {
+noir_def std::field::bn254::assert_lt<>(a: Field, b: Field) -> Unit := {
   (field::bn254::assert_gt<> as λ(Field, Field) -> Unit)(b, a);
   #_skip
 }
 
-noir_def field::bn254::gt<>(a: Field, b: Field) -> bool := {
+noir_def std::field::bn254::gt<>(a: Field, b: Field) -> bool := {
   if (runtime::is_unconstrained<> as λ() -> bool)() then {
     (field::field_less_than<> as λ(Field, Field) -> bool)(b, a)
   } else if (#_fEq returning bool)(a, b) then {
@@ -88,26 +88,26 @@ noir_def field::bn254::gt<>(a: Field, b: Field) -> bool := {
   }
 }
 
-noir_def field::bn254::lt<>(a: Field, b: Field) -> bool := {
+noir_def std::field::bn254::lt<>(a: Field, b: Field) -> bool := {
   (field::bn254::gt<> as λ(Field, Field) -> bool)(b, a)
 }
 
-noir_def field::bn254::tests::check_decompose<>() -> Unit := {
+noir_def std::field::bn254::tests::check_decompose<>() -> Unit := {
   (#_assert returning Unit)(((Tuple<Field, Field> as Eq<>)::eq<> as λ(Tuple<Field, Field>, Tuple<Field, Field>) -> bool)((field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)((TWO_POW_128<> as λ() -> Field)()), (#_makeData returning Tuple<Field, Field>)((0: Field), (1: Field))));
   (#_assert returning Unit)(((Tuple<Field, Field> as Eq<>)::eq<> as λ(Tuple<Field, Field>, Tuple<Field, Field>) -> bool)((field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)((#_fAdd returning Field)((TWO_POW_128<> as λ() -> Field)(), (78187493520: Field))), (#_makeData returning Tuple<Field, Field>)((78187493520: Field), (1: Field))));
   (#_assert returning Unit)(((Tuple<Field, Field> as Eq<>)::eq<> as λ(Tuple<Field, Field>, Tuple<Field, Field>) -> bool)((field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)((78187493520: Field)), (#_makeData returning Tuple<Field, Field>)((78187493520: Field), (0: Field))));
   #_skip
 }
 
-noir_def field::bn254::tests::check_decompose_unconstrained<>() -> Unit := {
+noir_def std::field::bn254::tests::check_decompose_unconstrained<>() -> Unit := {
   (#_fresh returning Unit)()
 }
 
-noir_def field::bn254::tests::check_lte_hint<>() -> Unit := {
+noir_def std::field::bn254::tests::check_lte_hint<>() -> Unit := {
   (#_fresh returning Unit)()
 }
 
-noir_def field::bn254::tests::check_assert_gt<>() -> Unit := {
+noir_def std::field::bn254::tests::check_assert_gt<>() -> Unit := {
   (field::bn254::assert_gt<> as λ(Field, Field) -> Unit)((1: Field), (0: Field));
   (field::bn254::assert_gt<> as λ(Field, Field) -> Unit)((256: Field), (0: Field));
   (field::bn254::assert_gt<> as λ(Field, Field) -> Unit)((#_fSub returning Field)((0: Field), (1: Field)), (#_fSub returning Field)((0: Field), (2: Field)));
@@ -116,11 +116,11 @@ noir_def field::bn254::tests::check_assert_gt<>() -> Unit := {
   #_skip
 }
 
-noir_def field::bn254::tests::check_assert_gt_unconstrained<>() -> Unit := {
+noir_def std::field::bn254::tests::check_assert_gt_unconstrained<>() -> Unit := {
   (#_fresh returning Unit)()
 }
 
-noir_def field::bn254::tests::check_gt<>() -> Unit := {
+noir_def std::field::bn254::tests::check_gt<>() -> Unit := {
   (#_assert returning Unit)((field::bn254::gt<> as λ(Field, Field) -> bool)((1: Field), (0: Field)));
   (#_assert returning Unit)((field::bn254::gt<> as λ(Field, Field) -> bool)((256: Field), (0: Field)));
   (#_assert returning Unit)((field::bn254::gt<> as λ(Field, Field) -> bool)((#_fSub returning Field)((0: Field), (1: Field)), (#_fSub returning Field)((0: Field), (2: Field))));
@@ -132,11 +132,11 @@ noir_def field::bn254::tests::check_gt<>() -> Unit := {
   #_skip
 }
 
-noir_def field::bn254::tests::check_gt_unconstrained<>() -> Unit := {
+noir_def std::field::bn254::tests::check_gt_unconstrained<>() -> Unit := {
   (#_fresh returning Unit)()
 }
 
-noir_def field::bn254::tests::check_plo_phi<>() -> Unit := {
+noir_def std::field::bn254::tests::check_plo_phi<>() -> Unit := {
   (#_assert returning Unit)((#_fEq returning bool)((#_fAdd returning Field)((PLO<> as λ() -> Field)(), (#_fMul returning Field)((PHI<> as λ() -> Field)(), (TWO_POW_128<> as λ() -> Field)())), (0: Field)));
   let (p_bytes: Slice<u8>) = (field::modulus_le_bytes<> as λ() -> Slice<u8>)();
   let mut (p_low: Field) = (0: Field);
@@ -155,5 +155,5 @@ noir_def field::bn254::tests::check_plo_phi<>() -> Unit := {
 
 
 def Field.Bn254.env : Env := Env.mk
-  [PLO, PHI, TWO_POW_128, «field::bn254::compute_decomposition», «field::bn254::decompose_hint», «field::bn254::lte_hint», «field::bn254::assert_gt_limbs», «field::bn254::decompose», «field::bn254::assert_gt», «field::bn254::assert_lt», «field::bn254::gt», «field::bn254::lt», «field::bn254::tests::check_decompose», «field::bn254::tests::check_decompose_unconstrained», «field::bn254::tests::check_lte_hint», «field::bn254::tests::check_assert_gt», «field::bn254::tests::check_assert_gt_unconstrained», «field::bn254::tests::check_gt», «field::bn254::tests::check_gt_unconstrained», «field::bn254::tests::check_plo_phi»]
+  [PLO, PHI, TWO_POW_128, «std::field::bn254::compute_decomposition», «std::field::bn254::decompose_hint», «std::field::bn254::lte_hint», «std::field::bn254::assert_gt_limbs», «std::field::bn254::decompose», «std::field::bn254::assert_gt», «std::field::bn254::assert_lt», «std::field::bn254::gt», «std::field::bn254::lt», «std::field::bn254::tests::check_decompose», «std::field::bn254::tests::check_decompose_unconstrained», «std::field::bn254::tests::check_lte_hint», «std::field::bn254::tests::check_assert_gt», «std::field::bn254::tests::check_assert_gt_unconstrained», «std::field::bn254::tests::check_gt», «std::field::bn254::tests::check_gt_unconstrained», «std::field::bn254::tests::check_plo_phi»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Field/Mod.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Field/Mod.lean
@@ -8,35 +8,35 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def field::__assert_max_bit_size<>(value: Field, bit_size: u32) -> Unit := {
+noir_def std::field::__assert_max_bit_size<>(value: Field, bit_size: u32) -> Unit := {
   (#_apply_range_constraint returning Unit)(value, bit_size)
 }
 
-noir_def field::__to_le_radix<N: u32>(value: Field, radix: u32) -> Array<u8, N: u32> := {
+noir_def std::field::__to_le_radix<N: u32>(value: Field, radix: u32) -> Array<u8, N: u32> := {
   (#_to_le_radix returning Array<u8, N: u32>)(value, radix)
 }
 
-noir_def field::__to_be_radix<N: u32>(value: Field, radix: u32) -> Array<u8, N: u32> := {
+noir_def std::field::__to_be_radix<N: u32>(value: Field, radix: u32) -> Array<u8, N: u32> := {
   (#_to_be_radix returning Array<u8, N: u32>)(value, radix)
 }
 
-noir_def field::__to_le_bits<N: u32>(value: Field) -> Array<u1, N: u32> := {
+noir_def std::field::__to_le_bits<N: u32>(value: Field) -> Array<u1, N: u32> := {
   (#_to_le_bits returning Array<u1, N: u32>)(value)
 }
 
-noir_def field::__to_be_bits<N: u32>(value: Field) -> Array<u1, N: u32> := {
+noir_def std::field::__to_be_bits<N: u32>(value: Field) -> Array<u1, N: u32> := {
   (#_to_be_bits returning Array<u1, N: u32>)(value)
 }
 
-noir_def field::__field_less_than<>(x: Field, y: Field) -> bool := {
+noir_def std::field::__field_less_than<>(x: Field, y: Field) -> bool := {
   (#_fresh returning bool)()
 }
 
-noir_def field::field_less_than<>(x: Field, y: Field) -> bool := {
+noir_def std::field::field_less_than<>(x: Field, y: Field) -> bool := {
   (#_fresh returning bool)()
 }
 
-noir_def field::bytes32_to_field<>(bytes32: Array<u8, 32: u32>) -> Field := {
+noir_def std::field::bytes32_to_field<>(bytes32: Array<u8, 32: u32>) -> Field := {
   let mut (v: Field) = (1: Field);
   let mut (high: Field) = (#_cast returning Field)((0: Field));
   let mut (low: Field) = (#_cast returning Field)((0: Field));
@@ -49,7 +49,7 @@ noir_def field::bytes32_to_field<>(bytes32: Array<u8, 32: u32>) -> Field := {
   (#_fAdd returning Field)(low, (#_fMul returning Field)(high, v))
 }
 
-noir_def field::lt_fallback<>(x: Field, y: Field) -> bool := {
+noir_def std::field::lt_fallback<>(x: Field, y: Field) -> bool := {
   if (runtime::is_unconstrained<> as λ() -> bool)() then {
     (field::field_less_than<> as λ(Field, Field) -> bool)(x, y)
   } else {
@@ -73,21 +73,21 @@ noir_def field::lt_fallback<>(x: Field, y: Field) -> bool := {
   }
 }
 
-noir_def field::tests::test_to_be_bits<>() -> Unit := {
+noir_def std::field::tests::test_to_be_bits<>() -> Unit := {
   let (field: Field) = (2: Field);
   let (bits: Array<u1, 8: u32>) = (std::field::to_be_bits<8: u32> as λ(Field) -> Array<u1, 8: u32>)(field);
   (#_assert returning Unit)(((Array<u1, 8: u32> as Eq<>)::eq<> as λ(Array<u1, 8: u32>, Array<u1, 8: u32>) -> bool)(bits, (#_mkArray returning Array<u1, 8: u32>)((0: u1), (0: u1), (0: u1), (0: u1), (0: u1), (0: u1), (1: u1), (0: u1))));
   #_skip
 }
 
-noir_def field::tests::test_to_le_bits<>() -> Unit := {
+noir_def std::field::tests::test_to_le_bits<>() -> Unit := {
   let (field: Field) = (2: Field);
   let (bits: Array<u1, 8: u32>) = (std::field::to_le_bits<8: u32> as λ(Field) -> Array<u1, 8: u32>)(field);
   (#_assert returning Unit)(((Array<u1, 8: u32> as Eq<>)::eq<> as λ(Array<u1, 8: u32>, Array<u1, 8: u32>) -> bool)(bits, (#_mkArray returning Array<u1, 8: u32>)((0: u1), (1: u1), (0: u1), (0: u1), (0: u1), (0: u1), (0: u1), (0: u1))));
   #_skip
 }
 
-noir_def field::tests::test_to_be_bytes<>() -> Unit := {
+noir_def std::field::tests::test_to_be_bytes<>() -> Unit := {
   let (field: Field) = (2: Field);
   let (bytes: Array<u8, 8: u32>) = (std::field::to_be_bytes<8: u32> as λ(Field) -> Array<u8, 8: u32>)(field);
   (#_assert returning Unit)(((Array<u8, 8: u32> as Eq<>)::eq<> as λ(Array<u8, 8: u32>, Array<u8, 8: u32>) -> bool)(bytes, (#_mkArray returning Array<u8, 8: u32>)((0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (2: u8))));
@@ -95,7 +95,7 @@ noir_def field::tests::test_to_be_bytes<>() -> Unit := {
   #_skip
 }
 
-noir_def field::tests::test_to_le_bytes<>() -> Unit := {
+noir_def std::field::tests::test_to_le_bytes<>() -> Unit := {
   let (field: Field) = (2: Field);
   let (bytes: Array<u8, 8: u32>) = (std::field::to_le_bytes<8: u32> as λ(Field) -> Array<u8, 8: u32>)(field);
   (#_assert returning Unit)(((Array<u8, 8: u32> as Eq<>)::eq<> as λ(Array<u8, 8: u32>, Array<u8, 8: u32>) -> bool)(bytes, (#_mkArray returning Array<u8, 8: u32>)((2: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8))));
@@ -103,7 +103,7 @@ noir_def field::tests::test_to_le_bytes<>() -> Unit := {
   #_skip
 }
 
-noir_def field::tests::test_to_be_radix<>() -> Unit := {
+noir_def std::field::tests::test_to_be_radix<>() -> Unit := {
   let (field: Field) = (259: Field);
   let (bytes: Array<u8, 8: u32>) = (std::field::to_be_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (256: u32));
   (#_assert returning Unit)(((Array<u8, 8: u32> as Eq<>)::eq<> as λ(Array<u8, 8: u32>, Array<u8, 8: u32>) -> bool)(bytes, (#_mkArray returning Array<u8, 8: u32>)((0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (1: u8), (3: u8))));
@@ -111,7 +111,7 @@ noir_def field::tests::test_to_be_radix<>() -> Unit := {
   #_skip
 }
 
-noir_def field::tests::test_to_le_radix<>() -> Unit := {
+noir_def std::field::tests::test_to_le_radix<>() -> Unit := {
   let (field: Field) = (259: Field);
   let (bytes: Array<u8, 8: u32>) = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (256: u32));
   (#_assert returning Unit)(((Array<u8, 8: u32> as Eq<>)::eq<> as λ(Array<u8, 8: u32>, Array<u8, 8: u32>) -> bool)(bytes, (#_mkArray returning Array<u8, 8: u32>)((3: u8), (1: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8))));
@@ -119,7 +119,7 @@ noir_def field::tests::test_to_le_radix<>() -> Unit := {
   #_skip
 }
 
-noir_def field::tests::test_to_le_radix_1<>() -> Unit := {
+noir_def std::field::tests::test_to_le_radix_1<>() -> Unit := {
   if (#_bNot returning bool)((runtime::is_unconstrained<> as λ() -> bool)()) then {
     let (field: Field) = (2: Field);
     let (_: Array<u8, 8: u32>) = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (1: u32));
@@ -130,7 +130,7 @@ noir_def field::tests::test_to_le_radix_1<>() -> Unit := {
   }
 }
 
-noir_def field::tests::test_to_le_radix_3<>() -> Unit := {
+noir_def std::field::tests::test_to_le_radix_3<>() -> Unit := {
   if (#_bNot returning bool)((runtime::is_unconstrained<> as λ() -> bool)()) then {
     let (field: Field) = (2: Field);
     let (_: Array<u8, 8: u32>) = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (3: u32));
@@ -141,7 +141,7 @@ noir_def field::tests::test_to_le_radix_3<>() -> Unit := {
   }
 }
 
-noir_def field::tests::test_to_le_radix_brillig_3<>() -> Unit := {
+noir_def std::field::tests::test_to_le_radix_brillig_3<>() -> Unit := {
   if (runtime::is_unconstrained<> as λ() -> bool)() then {
     let (field: Field) = (1: Field);
     let (out: Array<u8, 8: u32>) = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (3: u32));
@@ -152,7 +152,7 @@ noir_def field::tests::test_to_le_radix_brillig_3<>() -> Unit := {
   }
 }
 
-noir_def field::tests::test_to_le_radix_512<>() -> Unit := {
+noir_def std::field::tests::test_to_le_radix_512<>() -> Unit := {
   if (#_bNot returning bool)((runtime::is_unconstrained<> as λ() -> bool)()) then {
     let (field: Field) = (2: Field);
     let (_: Array<u8, 8: u32>) = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (512: u32));
@@ -162,20 +162,20 @@ noir_def field::tests::test_to_le_radix_512<>() -> Unit := {
   }
 }
 
-noir_def field::tests::not_enough_limbs_brillig<>() -> Unit := {
+noir_def std::field::tests::not_enough_limbs_brillig<>() -> Unit := {
   (#_fresh returning Unit)()
 }
 
-noir_def field::tests::not_enough_limbs<>() -> Unit := {
+noir_def std::field::tests::not_enough_limbs<>() -> Unit := {
   let (_: Array<u8, 16: u32>) = (std::field::to_le_bytes<16: u32> as λ(Field) -> Array<u8, 16: u32>)((340282366920938463463374607431768211456: Field));
   #_skip
 }
 
-noir_def field::tests::test_field_less_than<>() -> Unit := {
+noir_def std::field::tests::test_field_less_than<>() -> Unit := {
   (#_fresh returning Unit)()
 }
 
 
 def Field.Mod.env : Env := Env.mk
-  [«field::__assert_max_bit_size», «field::__to_le_radix», «field::__to_be_radix», «field::__to_le_bits», «field::__to_be_bits», «field::__field_less_than», «field::field_less_than», «field::bytes32_to_field», «field::lt_fallback», «field::tests::test_to_be_bits», «field::tests::test_to_le_bits», «field::tests::test_to_be_bytes», «field::tests::test_to_le_bytes», «field::tests::test_to_be_radix», «field::tests::test_to_le_radix», «field::tests::test_to_le_radix_1», «field::tests::test_to_le_radix_3», «field::tests::test_to_le_radix_brillig_3», «field::tests::test_to_le_radix_512», «field::tests::not_enough_limbs_brillig», «field::tests::not_enough_limbs», «field::tests::test_field_less_than»]
+  [«std::field::__assert_max_bit_size», «std::field::__to_le_radix», «std::field::__to_be_radix», «std::field::__to_le_bits», «std::field::__to_be_bits», «std::field::__field_less_than», «std::field::field_less_than», «std::field::bytes32_to_field», «std::field::lt_fallback», «std::field::tests::test_to_be_bits», «std::field::tests::test_to_le_bits», «std::field::tests::test_to_be_bytes», «std::field::tests::test_to_le_bytes», «std::field::tests::test_to_be_radix», «std::field::tests::test_to_le_radix», «std::field::tests::test_to_le_radix_1», «std::field::tests::test_to_le_radix_3», «std::field::tests::test_to_le_radix_brillig_3», «std::field::tests::test_to_le_radix_512», «std::field::tests::not_enough_limbs_brillig», «std::field::tests::not_enough_limbs», «std::field::tests::test_field_less_than»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Hash/Mod.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Hash/Mod.lean
@@ -8,23 +8,23 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def hash::sha256_compression<>(input: Array<u32, 16: u32>, state: Array<u32, 8: u32>) -> Array<u32, 8: u32> := {
+noir_def std::hash::sha256_compression<>(input: Array<u32, 16: u32>, state: Array<u32, 8: u32>) -> Array<u32, 8: u32> := {
   (#_sha256_compression returning Array<u32, 8: u32>)(input, state)
 }
 
-noir_def hash::keccakf1600<>(input: Array<u64, 25: u32>) -> Array<u64, 25: u32> := {
+noir_def std::hash::keccakf1600<>(input: Array<u64, 25: u32>) -> Array<u64, 25: u32> := {
   (#_keccakf1600 returning Array<u64, 25: u32>)(input)
 }
 
-noir_def hash::keccak::keccakf1600<>(input: Array<u64, 25: u32>) -> Array<u64, 25: u32> := {
+noir_def std::hash::keccak::keccakf1600<>(input: Array<u64, 25: u32>) -> Array<u64, 25: u32> := {
   (hash::keccakf1600<> as λ(Array<u64, 25: u32>) -> Array<u64, 25: u32>)(input)
 }
 
-noir_def hash::blake2s<N: u32>(input: Array<u8, N: u32>) -> Array<u8, 32: u32> := {
+noir_def std::hash::blake2s<N: u32>(input: Array<u8, N: u32>) -> Array<u8, 32: u32> := {
   (#_blake2s returning Array<u8, 32: u32>)(input)
 }
 
-noir_def hash::blake3<N: u32>(input: Array<u8, N: u32>) -> Array<u8, 32: u32> := {
+noir_def std::hash::blake3<N: u32>(input: Array<u8, N: u32>) -> Array<u8, 32: u32> := {
   if (runtime::is_unconstrained<> as λ() -> bool)() then {
     (static_assert<String<74: u32> > as λ(bool, String<74: u32>) -> Unit)((#_uLeq returning bool)(uConst!(N: u32), (1024: u32)), "Barretenberg cannot prove blake3 hashes with inputs larger than 1024 bytes");
     #_skip
@@ -32,53 +32,53 @@ noir_def hash::blake3<N: u32>(input: Array<u8, N: u32>) -> Array<u8, 32: u32> :=
   (hash::__blake3<N: u32> as λ(Array<u8, N: u32>) -> Array<u8, 32: u32>)(input)
 }
 
-noir_def hash::__blake3<N: u32>(input: Array<u8, N: u32>) -> Array<u8, 32: u32> := {
+noir_def std::hash::__blake3<N: u32>(input: Array<u8, N: u32>) -> Array<u8, 32: u32> := {
   (#_blake3 returning Array<u8, 32: u32>)(input)
 }
 
-noir_def hash::pedersen_commitment<N: u32>(input: Array<Field, N: u32>) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
+noir_def std::hash::pedersen_commitment<N: u32>(input: Array<Field, N: u32>) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
   (hash::pedersen_commitment_with_separator<N: u32> as λ(Array<Field, N: u32>, u32) -> std::embedded_curve_ops::EmbeddedCurvePoint<>)(input, (0: u32))
 }
 
-noir_def hash::pedersen_commitment_with_separator<N: u32>(input: Array<Field, N: u32>, separator: u32) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
+noir_def std::hash::pedersen_commitment_with_separator<N: u32>(input: Array<Field, N: u32>, separator: u32) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
   let mut (points: Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, N: u32>) = (#_mkRepeatedArray returning Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, N: u32>)((#_makeData returning std::embedded_curve_ops::EmbeddedCurveScalar<>)((0: Field), (0: Field)));
   for i in (0: u32) .. uConst!(N: u32) do {
     (points[i]: std::embedded_curve_ops::EmbeddedCurveScalar<>) = (hash::from_field_unsafe<> as λ(Field) -> std::embedded_curve_ops::EmbeddedCurveScalar<>)((#_arrayIndex returning Field)(input, (#_cast returning u32)(i)));
     #_skip
   };
-  let (generators: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>) = (hash::derive_generators<N: u32, 24: u32> as λ(Array<u8, 24: u32>, u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>)((std::string::as_bytes<> as λ(String<24: u32>) -> Array<u8, 24: u32>)("DEFAULT_DOMAIN_SEPARATOR"), separator);
+  let (generators: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>) = (hash::derive_generators<N: u32, 24: u32> as λ(Array<u8, 24: u32>, u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>)((std::string::as_bytes<24: u32> as λ(String<24: u32>) -> Array<u8, 24: u32>)("DEFAULT_DOMAIN_SEPARATOR"), separator);
   (embedded_curve_ops::multi_scalar_mul<N: u32> as λ(Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>, Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, N: u32>) -> std::embedded_curve_ops::EmbeddedCurvePoint<>)(generators, points)
 }
 
-noir_def hash::pedersen_hash<N: u32>(input: Array<Field, N: u32>) -> Field := {
+noir_def std::hash::pedersen_hash<N: u32>(input: Array<Field, N: u32>) -> Field := {
   (hash::pedersen_hash_with_separator<N: u32> as λ(Array<Field, N: u32>, u32) -> Field)(input, (0: u32))
 }
 
-noir_def hash::pedersen_hash_with_separator<N: u32>(input: Array<Field, N: u32>, separator: u32) -> Field := {
+noir_def std::hash::pedersen_hash_with_separator<N: u32>(input: Array<Field, N: u32>, separator: u32) -> Field := {
   let mut (scalars: Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, (N + 1): u32>) = (#_mkRepeatedArray returning Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, (N + 1): u32>)((#_makeData returning std::embedded_curve_ops::EmbeddedCurveScalar<>)((0: Field), (0: Field)));
   let mut (generators: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, (N + 1): u32>) = (#_mkRepeatedArray returning Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, (N + 1): u32>)((std::embedded_curve_ops::EmbeddedCurvePoint::point_at_infinity<> as λ() -> std::embedded_curve_ops::EmbeddedCurvePoint<>)());
-  let (domain_generators: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>) = (hash::derive_generators<N: u32, 24: u32> as λ(Array<u8, 24: u32>, u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>)((std::string::as_bytes<> as λ(String<24: u32>) -> Array<u8, 24: u32>)("DEFAULT_DOMAIN_SEPARATOR"), separator);
+  let (domain_generators: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>) = (hash::derive_generators<N: u32, 24: u32> as λ(Array<u8, 24: u32>, u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>)((std::string::as_bytes<24: u32> as λ(String<24: u32>) -> Array<u8, 24: u32>)("DEFAULT_DOMAIN_SEPARATOR"), separator);
   for i in (0: u32) .. uConst!(N: u32) do {
     (scalars[i]: std::embedded_curve_ops::EmbeddedCurveScalar<>) = (hash::from_field_unsafe<> as λ(Field) -> std::embedded_curve_ops::EmbeddedCurveScalar<>)((#_arrayIndex returning Field)(input, (#_cast returning u32)(i)));
     (generators[i]: std::embedded_curve_ops::EmbeddedCurvePoint<>) = (#_arrayIndex returning std::embedded_curve_ops::EmbeddedCurvePoint<>)(domain_generators, (#_cast returning u32)(i));
     #_skip
   };
   (scalars[uConst!(N: u32)]: std::embedded_curve_ops::EmbeddedCurveScalar<>) = (#_makeData returning std::embedded_curve_ops::EmbeddedCurveScalar<>)((#_cast returning Field)(uConst!(N: u32)), (#_cast returning Field)((0: Field)));
-  let (length_generator: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>) = (hash::derive_generators<1: u32, 20: u32> as λ(Array<u8, 20: u32>, u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>)((std::string::as_bytes<> as λ(String<20: u32>) -> Array<u8, 20: u32>)("pedersen_hash_length"), (0: u32));
+  let (length_generator: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>) = (hash::derive_generators<1: u32, 20: u32> as λ(Array<u8, 20: u32>, u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>)((std::string::as_bytes<20: u32> as λ(String<20: u32>) -> Array<u8, 20: u32>)("pedersen_hash_length"), (0: u32));
   (generators[uConst!(N: u32)]: std::embedded_curve_ops::EmbeddedCurvePoint<>) = (#_arrayIndex returning std::embedded_curve_ops::EmbeddedCurvePoint<>)(length_generator, (0: u32));
   (#_arrayIndex returning std::embedded_curve_ops::EmbeddedCurvePoint<>)((embedded_curve_ops::multi_scalar_mul_array_return<(N + 1): u32> as λ(Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, (N + 1): u32>, Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, (N + 1): u32>) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>)(generators, scalars), (0: u32)).0
 }
 
-noir_def hash::derive_generators<N: u32, M: u32>(domain_separator_bytes: Array<u8, M: u32>, starting_index: u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32> := {
+noir_def std::hash::derive_generators<N: u32, M: u32>(domain_separator_bytes: Array<u8, M: u32>, starting_index: u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32> := {
   (assert_constant<Array<u8, M: u32> > as λ(Array<u8, M: u32>) -> Unit)(domain_separator_bytes);
   (hash::__derive_generators<N: u32, M: u32> as λ(Array<u8, M: u32>, u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>)(domain_separator_bytes, starting_index)
 }
 
-noir_def hash::__derive_generators<N: u32, M: u32>(domain_separator_bytes: Array<u8, M: u32>, starting_index: u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32> := {
+noir_def std::hash::__derive_generators<N: u32, M: u32>(domain_separator_bytes: Array<u8, M: u32>, starting_index: u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32> := {
   (#_derive_pedersen_generators returning Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>)(domain_separator_bytes, starting_index)
 }
 
-noir_def hash::from_field_unsafe<>(scalar: Field) -> std::embedded_curve_ops::EmbeddedCurveScalar<> := {
+noir_def std::hash::from_field_unsafe<>(scalar: Field) -> std::embedded_curve_ops::EmbeddedCurveScalar<> := {
   let ((xlo: Field), (xhi: Field)) = {
     (field::bn254::decompose_hint<> as λ(Field) -> Tuple<Field, Field>)(scalar)
   };
@@ -86,7 +86,7 @@ noir_def hash::from_field_unsafe<>(scalar: Field) -> std::embedded_curve_ops::Em
   (#_makeData returning std::embedded_curve_ops::EmbeddedCurveScalar<>)(xlo, xhi)
 }
 
-noir_def hash::poseidon2_permutation<N: u32>(_input: Array<Field, N: u32>, _state_length: u32) -> Array<Field, N: u32> := {
+noir_def std::hash::poseidon2_permutation<N: u32>(_input: Array<Field, N: u32>, _state_length: u32) -> Array<Field, N: u32> := {
   (#_poseidon2_permutation returning Array<Field, N: u32>)(_input, _state_length)
 }
 
@@ -261,7 +261,7 @@ noir_trait_impl[impl_22]<A: Type, B: Type, C: Type, D: Type, E: Type> std::hash:
   };
 }
 
-noir_def hash::assert_pedersen<>() -> Unit := {
+noir_def std::hash::assert_pedersen<>() -> Unit := {
   (#_assert returning Unit)((#_fEq returning bool)((hash::pedersen_hash_with_separator<1: u32> as λ(Array<Field, 1: u32>, u32) -> Field)((#_mkArray returning Array<Field, 1: u32>)((1: Field)), (1: u32)), (-9563966249275741675388072609438711537348680428347819854678797696612266004386: Field)));
   (#_assert returning Unit)(((std::embedded_curve_ops::EmbeddedCurvePoint<> as Eq<>)::eq<> as λ(std::embedded_curve_ops::EmbeddedCurvePoint<>, std::embedded_curve_ops::EmbeddedCurvePoint<>) -> bool)((hash::pedersen_commitment_with_separator<1: u32> as λ(Array<Field, 1: u32>, u32) -> std::embedded_curve_ops::EmbeddedCurvePoint<>)((#_mkArray returning Array<Field, 1: u32>)((1: Field)), (1: u32)), (#_makeData returning std::embedded_curve_ops::EmbeddedCurvePoint<>)((2393473289045184898987089634332637236754766663897650125720167164137088869378: Field), (-7135402912423807765050323395026152633898511180575289670895350565966806597339: Field), #_false)));
   (#_assert returning Unit)((#_fEq returning bool)((hash::pedersen_hash_with_separator<2: u32> as λ(Array<Field, 2: u32>, u32) -> Field)((#_mkArray returning Array<Field, 2: u32>)((1: Field), (2: Field)), (2: u32)), (-4514641934080458214240751313245257091597283372119704256508270041112972328364: Field)));
@@ -287,5 +287,5 @@ noir_def hash::assert_pedersen<>() -> Unit := {
 
 
 def Hash.Mod.env : Env := Env.mk
-  [«hash::sha256_compression», «hash::keccakf1600», «hash::keccak::keccakf1600», «hash::blake2s», «hash::blake3», «hash::__blake3», «hash::pedersen_commitment», «hash::pedersen_commitment_with_separator», «hash::pedersen_hash», «hash::pedersen_hash_with_separator», «hash::derive_generators», «hash::__derive_generators», «hash::from_field_unsafe», «hash::poseidon2_permutation», «hash::assert_pedersen»]
+  [«std::hash::sha256_compression», «std::hash::keccakf1600», «std::hash::keccak::keccakf1600», «std::hash::blake2s», «std::hash::blake3», «std::hash::__blake3», «std::hash::pedersen_commitment», «std::hash::pedersen_commitment_with_separator», «std::hash::pedersen_hash», «std::hash::pedersen_hash_with_separator», «std::hash::derive_generators», «std::hash::__derive_generators», «std::hash::from_field_unsafe», «std::hash::poseidon2_permutation», «std::hash::assert_pedersen»]
   [impl_2, impl_3, impl_4, impl_5, impl_6, impl_7, impl_8, impl_9, impl_10, impl_11, impl_12, impl_13, impl_14, impl_15, impl_16, impl_17, impl_18, impl_19, impl_20, impl_21, impl_22]

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Hint.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Hint.lean
@@ -8,11 +8,11 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def hint::black_box<T: Type>(value: T) -> T := {
+noir_def std::hint::black_box<T: Type>(value: T) -> T := {
   (#_black_box returning T)(value)
 }
 
 
 def Hint.env : Env := Env.mk
-  [«hint::black_box»]
+  [«std::hint::black_box»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Lib.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Lib.lean
@@ -8,25 +8,25 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def print_oracle<T: Type>(with_newline: bool, input: T) -> Unit := {
+noir_def std::print_oracle<T: Type>(with_newline: bool, input: T) -> Unit := {
   (#_fresh returning Unit)()
 }
 
-noir_def print_unconstrained<T: Type>(with_newline: bool, input: T) -> Unit := {
+noir_def std::print_unconstrained<T: Type>(with_newline: bool, input: T) -> Unit := {
   (#_fresh returning Unit)()
 }
 
-noir_def println<T: Type>(input: T) -> Unit := {
+noir_def std::println<T: Type>(input: T) -> Unit := {
   (print_unconstrained<T> as λ(bool, T) -> Unit)(#_true, input);
   #_skip
 }
 
-noir_def print<T: Type>(input: T) -> Unit := {
+noir_def std::print<T: Type>(input: T) -> Unit := {
   (print_unconstrained<T> as λ(bool, T) -> Unit)(#_false, input);
   #_skip
 }
 
-noir_def verify_proof_with_type<N: u32, M: u32, K: u32>(verification_key: Array<Field, N: u32>, proof: Array<Field, M: u32>, public_inputs: Array<Field, K: u32>, key_hash: Field, proof_type: u32) -> Unit := {
+noir_def std::verify_proof_with_type<N: u32, M: u32, K: u32>(verification_key: Array<Field, N: u32>, proof: Array<Field, M: u32>, public_inputs: Array<Field, K: u32>, key_hash: Field, proof_type: u32) -> Unit := {
   if (#_bNot returning bool)((runtime::is_unconstrained<> as λ() -> bool)()) then {
     (assert_constant<u32> as λ(u32) -> Unit)(proof_type);
     #_skip
@@ -35,40 +35,40 @@ noir_def verify_proof_with_type<N: u32, M: u32, K: u32>(verification_key: Array<
   #_skip
 }
 
-noir_def verify_proof_internal<N: u32, M: u32, K: u32>(verification_key: Array<Field, N: u32>, proof: Array<Field, M: u32>, public_inputs: Array<Field, K: u32>, key_hash: Field, proof_type: u32) -> Unit := {
+noir_def std::verify_proof_internal<N: u32, M: u32, K: u32>(verification_key: Array<Field, N: u32>, proof: Array<Field, M: u32>, public_inputs: Array<Field, K: u32>, key_hash: Field, proof_type: u32) -> Unit := {
   (#_recursive_aggregation returning Unit)(verification_key, proof, public_inputs, key_hash, proof_type)
 }
 
-noir_def assert_constant<T: Type>(x: T) -> Unit := {
+noir_def std::assert_constant<T: Type>(x: T) -> Unit := {
   (#_assert_constant returning Unit)(x)
 }
 
-noir_def static_assert<T: Type>(predicate: bool, message: T) -> Unit := {
+noir_def std::static_assert<T: Type>(predicate: bool, message: T) -> Unit := {
   (#_static_assert returning Unit)(predicate, message)
 }
 
-noir_def wrapping_add<T: Type>(x: T, y: T) -> T := {
+noir_def std::wrapping_add<T: Type>(x: T, y: T) -> T := {
   ((Field as std::convert::AsPrimitive<T>)::as_<> as λ(Field) -> T)((#_fAdd returning Field)(((T as std::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(x), ((T as std::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(y)))
 }
 
-noir_def wrapping_sub<T: Type>(x: T, y: T) -> T := {
+noir_def std::wrapping_sub<T: Type>(x: T, y: T) -> T := {
   ((Field as std::convert::AsPrimitive<T>)::as_<> as λ(Field) -> T)((#_fSub returning Field)((#_fAdd returning Field)(((T as std::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(x), (340282366920938463463374607431768211456: Field)), ((T as std::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(y)))
 }
 
-noir_def wrapping_mul<T: Type>(x: T, y: T) -> T := {
+noir_def std::wrapping_mul<T: Type>(x: T, y: T) -> T := {
   ((Field as std::convert::AsPrimitive<T>)::as_<> as λ(Field) -> T)((#_fMul returning Field)(((T as std::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(x), ((T as std::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(y)))
 }
 
-noir_def as_witness<>(x: Field) -> Unit := {
+noir_def std::as_witness<>(x: Field) -> Unit := {
   (#_as_witness returning Unit)(x)
 }
 
-noir_def tests::test_static_assert_custom_message<>() -> Unit := {
+noir_def std::tests::test_static_assert_custom_message<>() -> Unit := {
   (static_assert<String<14: u32> > as λ(bool, String<14: u32>) -> Unit)((#_fEq returning bool)((1: Field), (2: Field)), "custom message");
   #_skip
 }
 
-noir_def tests::test_wrapping_mul<>() -> Unit := {
+noir_def std::tests::test_wrapping_mul<>() -> Unit := {
   let (zero: u128) = (0: u128);
   let (one: u128) = (1: u128);
   let (two_pow_64: u128) = (18446744073709551616: u128);
@@ -87,5 +87,5 @@ noir_def tests::test_wrapping_mul<>() -> Unit := {
 
 
 def Lib.env : Env := Env.mk
-  [print_oracle, print_unconstrained, println, print, verify_proof_with_type, verify_proof_internal, assert_constant, static_assert, wrapping_add, wrapping_sub, wrapping_mul, as_witness, «tests::test_static_assert_custom_message», «tests::test_wrapping_mul»]
+  [«std::print_oracle», «std::print_unconstrained», «std::println», «std::print», «std::verify_proof_with_type», «std::verify_proof_internal», «std::assert_constant», «std::static_assert», «std::wrapping_add», «std::wrapping_sub», «std::wrapping_mul», «std::as_witness», «std::tests::test_static_assert_custom_message», «std::tests::test_wrapping_mul»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Mem.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Mem.lean
@@ -8,23 +8,23 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def mem::zeroed<T: Type>() -> T := {
+noir_def std::mem::zeroed<T: Type>() -> T := {
   (#_zeroed returning T)()
 }
 
-noir_def mem::checked_transmute<T: Type, U: Type>(value: T) -> U := {
+noir_def std::mem::checked_transmute<T: Type, U: Type>(value: T) -> U := {
   (#_checked_transmute returning U)(value)
 }
 
-noir_def mem::array_refcount<T: Type, N: u32>(array: Array<T, N: u32>) -> u32 := {
+noir_def std::mem::array_refcount<T: Type, N: u32>(array: Array<T, N: u32>) -> u32 := {
   (#_array_refcount returning u32)(array)
 }
 
-noir_def mem::slice_refcount<T: Type>(slice: Slice<T>) -> u32 := {
+noir_def std::mem::slice_refcount<T: Type>(slice: Slice<T>) -> u32 := {
   (#_slice_refcount returning u32)(slice)
 }
 
 
 def Mem.env : Env := Env.mk
-  [«mem::zeroed», «mem::checked_transmute», «mem::array_refcount», «mem::slice_refcount»]
+  [«std::mem::zeroed», «std::mem::checked_transmute», «std::mem::array_refcount», «std::mem::slice_refcount»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Meta/Ctstring.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Meta/Ctstring.lean
@@ -20,11 +20,11 @@ noir_trait_impl[impl_293]<N: u32, T: Type> std::meta::ctstring::AsCtString<> for
   };
 }
 
-noir_def meta::ctstring::test::as_quoted_str_example<>() -> Unit := {
+noir_def std::meta::ctstring::test::as_quoted_str_example<>() -> Unit := {
   #_unit
 }
 
 
 def Meta.Ctstring.env : Env := Env.mk
-  [«meta::ctstring::test::as_quoted_str_example»]
+  [«std::meta::ctstring::test::as_quoted_str_example»]
   [impl_292, impl_293]

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Meta/Mod.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Meta/Mod.lean
@@ -8,7 +8,7 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def meta::tests::returning_versus_macro_insertion<>() -> Unit := {
+noir_def std::meta::tests::returning_versus_macro_insertion<>() -> Unit := {
   #_unit
 }
 
@@ -24,11 +24,11 @@ noir_trait_impl[impl_314]<> std::meta::tests::DoNothing<> for std::meta::tests::
   };
 }
 
-noir_def meta::tests::concatenate_test<>() -> Unit := {
+noir_def std::meta::tests::concatenate_test<>() -> Unit := {
   #_unit
 }
 
-noir_def meta::tests::remove_unused_warnings<>() -> Unit := {
+noir_def std::meta::tests::remove_unused_warnings<>() -> Unit := {
   let (_: std::meta::tests::Bar<>) = (#_makeData returning std::meta::tests::Bar<>)((1: Field), (#_mkArray returning Array<Field, 2: u32>)((2: Field), (3: Field)));
   let (_: std::meta::tests::MyStruct<>) = (#_makeData returning std::meta::tests::MyStruct<>)((1: i32));
   let (_: std::meta::tests::MyOtherStruct<>) = (#_makeData returning std::meta::tests::MyOtherStruct<>)((2: u32));
@@ -42,5 +42,5 @@ noir_def meta::tests::remove_unused_warnings<>() -> Unit := {
 
 
 def Meta.Mod.env : Env := Env.mk
-  [«meta::tests::returning_versus_macro_insertion», «meta::tests::concatenate_test», «meta::tests::remove_unused_warnings»]
+  [«std::meta::tests::returning_versus_macro_insertion», «std::meta::tests::concatenate_test», «std::meta::tests::remove_unused_warnings»]
   [impl_429, impl_314]

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Ops/Arith.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Ops/Arith.lean
@@ -572,25 +572,25 @@ noir_trait_impl[impl_207]<> std::ops::arith::WrappingMul<> for Field where [] :=
   };
 }
 
-noir_def ops::arith::wrapping_add_hlp<T: Type>(x: T, y: T) -> T := {
+noir_def std::ops::arith::wrapping_add_hlp<T: Type>(x: T, y: T) -> T := {
   ((Field as std::convert::AsPrimitive<T>)::as_<> as λ(Field) -> T)((#_fAdd returning Field)(((T as std::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(x), ((T as std::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(y)))
 }
 
-noir_def ops::arith::wrapping_sub_hlp<T: Type>(x: T, y: T) -> Field := {
+noir_def std::ops::arith::wrapping_sub_hlp<T: Type>(x: T, y: T) -> Field := {
   (#_fSub returning Field)((#_fAdd returning Field)(((T as std::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(x), (340282366920938463463374607431768211456: Field)), ((T as std::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(y))
 }
 
-noir_def ops::arith::wrapping_mul_hlp<T: Type>(x: T, y: T) -> T := {
+noir_def std::ops::arith::wrapping_mul_hlp<T: Type>(x: T, y: T) -> T := {
   ((Field as std::convert::AsPrimitive<T>)::as_<> as λ(Field) -> T)((#_fMul returning Field)(((T as std::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(x), ((T as std::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(y)))
 }
 
 noir_global_def two_pow_64: u128 = (18446744073709551616: u128);
 
-noir_def ops::arith::split64<>(x: u128) -> Tuple<u64, u64> := {
+noir_def std::ops::arith::split64<>(x: u128) -> Tuple<u64, u64> := {
   (#_fresh returning Tuple<u64, u64>)()
 }
 
-noir_def ops::arith::split_into_64_bit_limbs<>(x: u128) -> Tuple<u64, u64> := {
+noir_def std::ops::arith::split_into_64_bit_limbs<>(x: u128) -> Tuple<u64, u64> := {
   let ((x_lo: u64), (x_hi: u64)) = {
     (ops::arith::split64<> as λ(u128) -> Tuple<u64, u64>)(x)
   };
@@ -598,7 +598,7 @@ noir_def ops::arith::split_into_64_bit_limbs<>(x: u128) -> Tuple<u64, u64> := {
   (#_makeData returning Tuple<u64, u64>)(x_lo, x_hi)
 }
 
-noir_def ops::arith::wrapping_mul128_hlp<>(x: u128, y: u128) -> u128 := {
+noir_def std::ops::arith::wrapping_mul128_hlp<>(x: u128, y: u128) -> u128 := {
   let ((x_lo: u64), (x_hi: u64)) = (ops::arith::split_into_64_bit_limbs<> as λ(u128) -> Tuple<u64, u64>)(x);
   let ((y_lo: u64), (y_hi: u64)) = (ops::arith::split_into_64_bit_limbs<> as λ(u128) -> Tuple<u64, u64>)(y);
   let (low: Field) = (#_fMul returning Field)((#_cast returning Field)(x_lo), (#_cast returning Field)(y_lo));
@@ -611,5 +611,5 @@ noir_def ops::arith::wrapping_mul128_hlp<>(x: u128, y: u128) -> u128 := {
 
 
 def Ops.Arith.env : Env := Env.mk
-  [«ops::arith::wrapping_add_hlp», «ops::arith::wrapping_sub_hlp», «ops::arith::wrapping_mul_hlp», two_pow_64, «ops::arith::split64», «ops::arith::split_into_64_bit_limbs», «ops::arith::wrapping_mul128_hlp»]
+  [«std::ops::arith::wrapping_add_hlp», «std::ops::arith::wrapping_sub_hlp», «std::ops::arith::wrapping_mul_hlp», two_pow_64, «std::ops::arith::split64», «std::ops::arith::split_into_64_bit_limbs», «std::ops::arith::wrapping_mul128_hlp»]
   [impl_116, impl_117, impl_118, impl_119, impl_120, impl_121, impl_122, impl_123, impl_124, impl_125, impl_126, impl_127, impl_128, impl_129, impl_130, impl_131, impl_132, impl_133, impl_134, impl_135, impl_136, impl_137, impl_138, impl_139, impl_140, impl_141, impl_142, impl_143, impl_144, impl_145, impl_146, impl_147, impl_148, impl_149, impl_150, impl_151, impl_152, impl_153, impl_154, impl_155, impl_156, impl_157, impl_158, impl_159, impl_160, impl_161, impl_162, impl_163, impl_164, impl_165, impl_166, impl_167, impl_168, impl_169, impl_170, impl_171, impl_172, impl_173, impl_174, impl_175, impl_176, impl_177, impl_178, impl_179, impl_180, impl_181, impl_182, impl_183, impl_184, impl_185, impl_186, impl_187, impl_188, impl_189, impl_190, impl_191, impl_192, impl_193, impl_194, impl_195, impl_196, impl_197, impl_198, impl_199, impl_200, impl_201, impl_202, impl_203, impl_204, impl_205, impl_206, impl_207]

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Option.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Option.lean
@@ -50,15 +50,15 @@ noir_def std::option::Option::unwrap_or_else<T: Type, Env: Type>(self: std::opti
 }
 
 noir_def std::option::Option::expect<T: Type, N: u32, MessageTypes: Type>(self: std::option::Option<T>, message: FmtString<N: u32, MessageTypes>) -> T := {
-  (#_assert returning Unit)((std::option::Option::is_some<> as λ(std::option::Option<T>) -> bool)(self));
+  (#_assert returning Unit)((std::option::Option::is_some<T> as λ(std::option::Option<T>) -> bool)(self));
   self.1
 }
 
 noir_def std::option::Option::map<T: Type, U: Type, Env: Type>(self: std::option::Option<T>, f: λ(T) -> U) -> std::option::Option<U> := {
   if self.0 then {
-    (std::option::Option::some<> as λ(U) -> std::option::Option<U>)((f as λ(T) -> U)(self.1))
+    (std::option::Option::some<U> as λ(U) -> std::option::Option<U>)((f as λ(T) -> U)(self.1))
   } else {
-    (std::option::Option::none<> as λ() -> std::option::Option<U>)()
+    (std::option::Option::none<U> as λ() -> std::option::Option<U>)()
   }
 }
 
@@ -79,8 +79,8 @@ noir_def std::option::Option::map_or_else<T: Type, U: Type, Env1: Type, Env2: Ty
 }
 
 noir_def std::option::Option::and<T: Type>(self: std::option::Option<T>, other: std::option::Option<T>) -> std::option::Option<T> := {
-  if (std::option::Option::is_none<> as λ(std::option::Option<T>) -> bool)(self) then {
-    (std::option::Option::none<> as λ() -> std::option::Option<T>)()
+  if (std::option::Option::is_none<T> as λ(std::option::Option<T>) -> bool)(self) then {
+    (std::option::Option::none<T> as λ() -> std::option::Option<T>)()
   } else {
     other
   }
@@ -90,7 +90,7 @@ noir_def std::option::Option::and_then<T: Type, U: Type, Env: Type>(self: std::o
   if self.0 then {
     (f as λ(T) -> std::option::Option<U>)(self.1)
   } else {
-    (std::option::Option::none<> as λ() -> std::option::Option<U>)()
+    (std::option::Option::none<U> as λ() -> std::option::Option<U>)()
   }
 }
 
@@ -113,14 +113,14 @@ noir_def std::option::Option::or_else<T: Type, Env: Type>(self: std::option::Opt
 noir_def std::option::Option::xor<T: Type>(self: std::option::Option<T>, other: std::option::Option<T>) -> std::option::Option<T> := {
   if self.0 then {
     if other.0 then {
-      (std::option::Option::none<> as λ() -> std::option::Option<T>)()
+      (std::option::Option::none<T> as λ() -> std::option::Option<T>)()
     } else {
       self
     }
   } else if other.0 then {
     other
   } else {
-    (std::option::Option::none<> as λ() -> std::option::Option<T>)()
+    (std::option::Option::none<T> as λ() -> std::option::Option<T>)()
   }
 }
 
@@ -129,10 +129,10 @@ noir_def std::option::Option::filter<T: Type, Env: Type>(self: std::option::Opti
     if (predicate as λ(T) -> bool)(self.1) then {
       self
     } else {
-      (std::option::Option::none<> as λ() -> std::option::Option<T>)()
+      (std::option::Option::none<T> as λ() -> std::option::Option<T>)()
     }
   } else {
-    (std::option::Option::none<> as λ() -> std::option::Option<T>)()
+    (std::option::Option::none<T> as λ() -> std::option::Option<T>)()
   }
 }
 
@@ -140,13 +140,13 @@ noir_def std::option::Option::flatten<T: Type>(option: std::option::Option<std::
   if option.0 then {
     option.1
   } else {
-    (std::option::Option::none<> as λ() -> std::option::Option<T>)()
+    (std::option::Option::none<T> as λ() -> std::option::Option<T>)()
   }
 }
 
 noir_trait_impl[impl_73]<T: Type> std::default::Default<> for std::option::Option<T> where [] := {
   noir_def default<>() -> std::option::Option<T> := {
-    (std::option::Option::none<> as λ() -> std::option::Option<T>)()
+    (std::option::Option::none<T> as λ() -> std::option::Option<T>)()
   };
 }
 

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Panic.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Panic.lean
@@ -8,12 +8,12 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def panic::panic<T: Type, U: Type, N: u32>(message: FmtString<N: u32, T>) -> U := {
+noir_def std::panic::panic<T: Type, U: Type, N: u32>(message: FmtString<N: u32, T>) -> U := {
   (#_assert returning Unit)(#_false);
   (#_zeroed returning U)()
 }
 
 
 def Panic.env : Env := Env.mk
-  [«panic::panic»]
+  [«std::panic::panic»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Runtime.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Runtime.lean
@@ -8,11 +8,11 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def runtime::is_unconstrained<>() -> bool := {
+noir_def std::runtime::is_unconstrained<>() -> bool := {
   (#_is_unconstrained returning bool)()
 }
 
 
 def Runtime.env : Env := Env.mk
-  [«runtime::is_unconstrained»]
+  [«std::runtime::is_unconstrained»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Slice.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Slice.lean
@@ -8,47 +8,47 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def slice::test::map_empty<>() -> Unit := {
+noir_def std::slice::test::map_empty<>() -> Unit := {
   (#_assert returning Unit)(((Slice<Field> as Eq<>)::eq<> as λ(Slice<Field>, Slice<Field>) -> bool)((std::slice::map<Field, Unit> as λ(Slice<Field>, λ(Field) -> Field) -> Slice<Field>)((#_mkSlice returning Slice<Field>)(), (fn((x: Field)): Field := (#_fAdd returning Field)(x, (1: Field)))), (#_mkSlice returning Slice<Field>)()));
   #_skip
 }
 
-noir_def slice::test::mapi_empty<>() -> Unit := {
+noir_def std::slice::test::mapi_empty<>() -> Unit := {
   (#_assert returning Unit)(((Slice<u32> as Eq<>)::eq<> as λ(Slice<u32>, Slice<u32>) -> bool)((std::slice::mapi<u32, Unit> as λ(Slice<u32>, λ(u32, u32) -> u32) -> Slice<u32>)((#_mkSlice returning Slice<u32>)(), (fn((i: u32), (x: u32)): u32 := (#_uAdd returning u32)((#_uMul returning u32)(i, x), (1: u32)))), (#_mkSlice returning Slice<u32>)()));
   #_skip
 }
 
-noir_def slice::test::for_each_empty<>() -> Unit := {
+noir_def std::slice::test::for_each_empty<>() -> Unit := {
   let (empty_slice: Slice<Field>) = (#_mkSlice returning Slice<Field>)();
-  (std::slice::for_each<Unit> as λ(Slice<Field>, λ(Field) -> Unit) -> Unit)(empty_slice, (fn((_x: Field)): Unit := (#_assert returning Unit)(#_false)));
+  (std::slice::for_each<Field, Unit> as λ(Slice<Field>, λ(Field) -> Unit) -> Unit)(empty_slice, (fn((_x: Field)): Unit := (#_assert returning Unit)(#_false)));
   #_skip
 }
 
-noir_def slice::test::for_eachi_empty<>() -> Unit := {
+noir_def std::slice::test::for_eachi_empty<>() -> Unit := {
   let (empty_slice: Slice<Field>) = (#_mkSlice returning Slice<Field>)();
-  (std::slice::for_eachi<Unit> as λ(Slice<Field>, λ(u32, Field) -> Unit) -> Unit)(empty_slice, (fn((_i: u32), (_x: Field)): Unit := (#_assert returning Unit)(#_false)));
+  (std::slice::for_eachi<Field, Unit> as λ(Slice<Field>, λ(u32, Field) -> Unit) -> Unit)(empty_slice, (fn((_i: u32), (_x: Field)): Unit := (#_assert returning Unit)(#_false)));
   #_skip
 }
 
-noir_def slice::test::map_example<>() -> Unit := {
+noir_def std::slice::test::map_example<>() -> Unit := {
   let (a: Slice<Field>) = (#_mkSlice returning Slice<Field>)((1: Field), (2: Field), (3: Field));
   let (b: Slice<Field>) = (std::slice::map<Field, Unit> as λ(Slice<Field>, λ(Field) -> Field) -> Slice<Field>)(a, (fn((a: Field)): Field := (#_fMul returning Field)(a, (2: Field))));
   (#_assert returning Unit)(((Slice<Field> as Eq<>)::eq<> as λ(Slice<Field>, Slice<Field>) -> bool)(b, (#_mkSlice returning Slice<Field>)((2: Field), (4: Field), (6: Field))));
   #_skip
 }
 
-noir_def slice::test::mapi_example<>() -> Unit := {
+noir_def std::slice::test::mapi_example<>() -> Unit := {
   let (a: Slice<u32>) = (#_mkSlice returning Slice<u32>)((1: u32), (2: u32), (3: u32));
   let (b: Slice<u32>) = (std::slice::mapi<u32, Unit> as λ(Slice<u32>, λ(u32, u32) -> u32) -> Slice<u32>)(a, (fn((i: u32), (a: u32)): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(a, (2: u32)))));
   (#_assert returning Unit)(((Slice<u32> as Eq<>)::eq<> as λ(Slice<u32>, Slice<u32>) -> bool)(b, (#_mkSlice returning Slice<u32>)((2: u32), (5: u32), (8: u32))));
   #_skip
 }
 
-noir_def slice::test::for_each_example<>() -> Unit := {
+noir_def std::slice::test::for_each_example<>() -> Unit := {
   let (a: Slice<Field>) = (#_mkSlice returning Slice<Field>)((1: Field), (2: Field), (3: Field));
   let mut (b: Slice<Field>) = (#_mkSlice returning Slice<Field>)();
   let (b_ref: & Slice<Field>) = (#_ref returning & Slice<Field>)(b);
-  (std::slice::for_each<Tuple<& Slice<Field> > > as λ(Slice<Field>, λ(Field) -> Unit) -> Unit)(a, (fn((a: Field)): Unit := {
+  (std::slice::for_each<Field, Tuple<& Slice<Field> > > as λ(Slice<Field>, λ(Field) -> Unit) -> Unit)(a, (fn((a: Field)): Unit := {
     (*b_ref: Slice<Field>) = (#_slicePushBack returning Slice<Field>)((#_readRef returning Slice<Field>)(b_ref), (#_fMul returning Field)(a, (2: Field)));
     #_skip
   }));
@@ -56,11 +56,11 @@ noir_def slice::test::for_each_example<>() -> Unit := {
   #_skip
 }
 
-noir_def slice::test::for_eachi_example<>() -> Unit := {
+noir_def std::slice::test::for_eachi_example<>() -> Unit := {
   let (a: Slice<u32>) = (#_mkSlice returning Slice<u32>)((1: u32), (2: u32), (3: u32));
   let mut (b: Slice<u32>) = (#_mkSlice returning Slice<u32>)();
   let (b_ref: & Slice<u32>) = (#_ref returning & Slice<u32>)(b);
-  (std::slice::for_eachi<Tuple<& Slice<u32> > > as λ(Slice<u32>, λ(u32, u32) -> Unit) -> Unit)(a, (fn((i: u32), (a: u32)): Unit := {
+  (std::slice::for_eachi<u32, Tuple<& Slice<u32> > > as λ(Slice<u32>, λ(u32, u32) -> Unit) -> Unit)(a, (fn((i: u32), (a: u32)): Unit := {
     (*b_ref: Slice<u32>) = (#_slicePushBack returning Slice<u32>)((#_readRef returning Slice<u32>)(b_ref), (#_uAdd returning u32)(i, (#_uMul returning u32)(a, (2: u32))));
     #_skip
   }));
@@ -70,5 +70,5 @@ noir_def slice::test::for_eachi_example<>() -> Unit := {
 
 
 def Slice.env : Env := Env.mk
-  [«slice::test::map_empty», «slice::test::mapi_empty», «slice::test::for_each_empty», «slice::test::for_eachi_empty», «slice::test::map_example», «slice::test::mapi_example», «slice::test::for_each_example», «slice::test::for_eachi_example»]
+  [«std::slice::test::map_empty», «std::slice::test::mapi_empty», «std::slice::test::for_each_empty», «std::slice::test::for_eachi_empty», «std::slice::test::map_example», «std::slice::test::mapi_example», «std::slice::test::for_each_example», «std::slice::test::for_eachi_example»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/String.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/String.lean
@@ -10,7 +10,7 @@ namespace Extracted
 
 noir_trait_impl[impl_77]<N: u32> std::convert::From<Array<u8, N: u32> > for String<N: u32> where [] := {
   noir_def from<>(bytes: Array<u8, N: u32>) -> String<N: u32> := {
-    (std::array::as_str_unchecked<> as λ(Array<u8, N: u32>) -> String<N: u32>)(bytes)
+    (std::array::as_str_unchecked<N: u32> as λ(Array<u8, N: u32>) -> String<N: u32>)(bytes)
   };
 }
 

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Test.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Test.lean
@@ -8,31 +8,31 @@ open Lampe
 namespace «std-1.0.0-beta.11»
 namespace Extracted
 
-noir_def test::create_mock_oracle<N: u32>(name: String<N: u32>) -> Field := {
+noir_def std::test::create_mock_oracle<N: u32>(name: String<N: u32>) -> Field := {
   (#_fresh returning Field)()
 }
 
-noir_def test::set_mock_params_oracle<P: Type>(id: Field, params: P) -> Unit := {
+noir_def std::test::set_mock_params_oracle<P: Type>(id: Field, params: P) -> Unit := {
   (#_fresh returning Unit)()
 }
 
-noir_def test::get_mock_last_params_oracle<P: Type>(id: Field) -> P := {
+noir_def std::test::get_mock_last_params_oracle<P: Type>(id: Field) -> P := {
   (#_fresh returning P)()
 }
 
-noir_def test::set_mock_returns_oracle<R: Type>(id: Field, returns: R) -> Unit := {
+noir_def std::test::set_mock_returns_oracle<R: Type>(id: Field, returns: R) -> Unit := {
   (#_fresh returning Unit)()
 }
 
-noir_def test::set_mock_times_oracle<>(id: Field, times: u64) -> Unit := {
+noir_def std::test::set_mock_times_oracle<>(id: Field, times: u64) -> Unit := {
   (#_fresh returning Unit)()
 }
 
-noir_def test::clear_mock_oracle<>(id: Field) -> Unit := {
+noir_def std::test::clear_mock_oracle<>(id: Field) -> Unit := {
   (#_fresh returning Unit)()
 }
 
-noir_def test::get_times_mock_called<>(id: Field) -> Field := {
+noir_def std::test::get_times_mock_called<>(id: Field) -> Field := {
   (#_fresh returning Field)()
 }
 
@@ -66,5 +66,5 @@ noir_def std::test::OracleMock::times_called<>(self: std::test::OracleMock<>) ->
 
 
 def Test.env : Env := Env.mk
-  [«test::create_mock_oracle», «test::set_mock_params_oracle», «test::get_mock_last_params_oracle», «test::set_mock_returns_oracle», «test::set_mock_times_oracle», «test::clear_mock_oracle», «test::get_times_mock_called», «std::test::OracleMock::mock», «std::test::OracleMock::with_params», «std::test::OracleMock::get_last_params», «std::test::OracleMock::returns», «std::test::OracleMock::times», «std::test::OracleMock::clear», «std::test::OracleMock::times_called»]
+  [«std::test::create_mock_oracle», «std::test::set_mock_params_oracle», «std::test::get_mock_last_params_oracle», «std::test::set_mock_returns_oracle», «std::test::set_mock_times_oracle», «std::test::clear_mock_oracle», «std::test::get_times_mock_called», «std::test::OracleMock::mock», «std::test::OracleMock::with_params», «std::test::OracleMock::get_last_params», «std::test::OracleMock::returns», «std::test::OracleMock::times», «std::test::OracleMock::clear», «std::test::OracleMock::times_called»]
   []

--- a/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/Experiments.lean
+++ b/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/Experiments.lean
@@ -72,7 +72,7 @@ noir_def experiments::check<>(x: u8) -> Unit := {
 
 noir_trait_impl[impl_431]<T: Type> std::default::Default<> for experiments::Option2<T> where [] := {
   noir_def default<>() -> experiments::Option2<T> := {
-    (experiments::Option2::none<> as λ() -> experiments::Option2<T>)()
+    (experiments::Option2::none<T> as λ() -> experiments::Option2<T>)()
   };
 }
 
@@ -85,7 +85,7 @@ noir_def experiments::Option2::some<T: Type>(_value: T) -> experiments::Option2<
 }
 
 noir_def experiments::Option2::is_none<T: Type>(self: experiments::Option2<T>) -> bool := {
-  (#_bNot returning bool)((experiments::Option2::is_some<> as λ(experiments::Option2<T>) -> bool)(self))
+  (#_bNot returning bool)((experiments::Option2::is_some<T> as λ(experiments::Option2<T>) -> bool)(self))
 }
 
 noir_def experiments::Option2::is_some<T: Type>(self: experiments::Option2<T>) -> bool := {
@@ -116,18 +116,18 @@ noir_def experiments::fmtstr_test<>(x: Field, y: Field) -> Field := {
 }
 
 noir_def experiments::is_alias_some<T: Type>(x: @AliasedOpt<T>) -> bool := {
-  (experiments::Option2::is_some<> as λ(experiments::Option2<T>) -> bool)(x)
+  (experiments::Option2::is_some<T> as λ(experiments::Option2<T>) -> bool)(x)
 }
 
 noir_def experiments::main<>() -> Unit := {
-  let mut (op1: experiments::Option2<Field>) = (experiments::Option2::some<> as λ(Field) -> experiments::Option2<Field>)((5: Field));
+  let mut (op1: experiments::Option2<Field>) = (experiments::Option2::some<Field> as λ(Field) -> experiments::Option2<Field>)((5: Field));
   let (op2: experiments::Option2<Field>) = ((experiments::Option2<Field> as std::default::Default<>)::default<> as λ() -> experiments::Option2<Field>)();
   let (_op3: experiments::Option2<Field>) = ((experiments::Option2<Field> as experiments::MyTrait<>)::foo<> as λ(experiments::Option2<Field>) -> experiments::Option2<Field>)(if #_true then {
     op1
   } else {
     op2
   });
-  let (_: bool) = (experiments::Option2::is_some<> as λ(experiments::Option2<Field>) -> bool)(op1);
+  let (_: bool) = (experiments::Option2::is_some<Field> as λ(experiments::Option2<Field>) -> bool)(op1);
   let mut (l: Array<Field, 3: u32>) = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
   let (_: Field) = (#_arrayIndex returning Field)(l, (0: u32));
   let (t: Tuple<Field, bool, Field>) = (#_makeData returning Tuple<Field, bool, Field>)((1: Field), #_true, (3: Field));

--- a/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/Patterns.lean
+++ b/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/Patterns.lean
@@ -13,7 +13,7 @@ noir_def patterns::Option2::some<T: Type>(value: T) -> patterns::Option2<T> := {
 }
 
 noir_def patterns::pattern_test<>() -> Unit := {
-  let (opt: patterns::Option2<bool>) = (patterns::Option2::some<> as λ(bool) -> patterns::Option2<bool>)(#_true);
+  let (opt: patterns::Option2<bool>) = (patterns::Option2::some<bool> as λ(bool) -> patterns::Option2<bool>)(#_true);
   let (t: Tuple<Field, patterns::Option2<bool>, Field>) = (#_makeData returning Tuple<Field, patterns::Option2<bool>, Field>)((1: Field), opt, (3: Field));
   let ((_x: Field), ((_: bool), (_: bool)), mut (_z: Field)) = t;
   #_skip


### PR DESCRIPTION
They were not being extracted properly into function references at the use-site if they were defined on an enclosing non-trait `impl` block. This commit fixes that issue.