### PR TITLE
Change `arrayLen` builtin to handle slices as well

### DIFF
--- a/Lampe/Lampe/Builtin/Array.lean
+++ b/Lampe/Lampe/Builtin/Array.lean
@@ -103,16 +103,6 @@ def arrayIndex := newGenericPureBuiltin
     fun h => l.get (Fin.mk i.toNat h)⟩)
 
 /--
-Defines the function that evaluates to an array's length `n`.
-This builtin evaluates to an `U 32`. Hence, we assume that `n < 2^32`.
-
-In Noir, this corresponds to `fn len(self) -> u32` implemented for `[_; n]`.
--/
-def arrayLen := newGenericTotalPureBuiltin
-  (fun (tp, n) => ⟨[.array tp n], .u 32⟩)
-  (fun (_, n) _ => n)
-
-/--
 Defines the function that converts an array to a slice.
 
 In Noir, this corresponds to `fn as_slice(self) -> [T]` implemented for `[T; n]`.

--- a/Lampe/Lampe/Builtin/Basic.lean
+++ b/Lampe/Lampe/Builtin/Basic.lean
@@ -204,18 +204,20 @@ def arrayLen : Builtin := {
     unfold omni_conseq
     intros
     cases_type arrayLenOmni
-    · next h₁ h₂ => constructor; assumption; tauto
-    · next h => constructor; tauto
+    · apply arrayLenOmni.mkSlice
+      assumption
+      tauto
+    · apply arrayLenOmni.mkArray
+      tauto
   frame := by
     unfold omni_frame
     intros
     cases_type arrayLenOmni
-    · next h₁ h₂ =>
-      constructor <;> try assumption
+    · apply arrayLenOmni.mkSlice
+      assumption
       unfold SLP.star
       tauto
-    · next h =>
-      constructor ; try assumption
+    · apply arrayLenOmni.mkArray
       unfold SLP.star
       tauto
 }

--- a/Lampe/Lampe/Builtin/Basic.lean
+++ b/Lampe/Lampe/Builtin/Basic.lean
@@ -188,38 +188,28 @@ def fresh : Builtin := {
     tauto
 }
 
-inductive arrayLenOmni : Omni where
-| mkSlice {P st tp x Q} : x.length < 2 ^ 32 → (Q (some (st, x.length))) → arrayLenOmni P st [Tp.slice tp] (Tp.u 32) h![x] Q
-| mkArray {P st tp N x Q} : (Q (some (st, N))) → arrayLenOmni P st [Tp.array tp N] (Tp.u 32) h![x] Q
+inductive ArrayLenCase where
+| slice (tp : Tp)
+| array (tp : Tp) (N : U 32)
 
-/--
-Defines the function that evaluates to an array (or slice)'s length `n`.
-This builtin evaluates to an `U 32`. Hence, we assume that `n < 2^32`.
+def arrayLenSgn : ArrayLenCase → List Tp × Tp
+| .slice tp => ⟨[Tp.slice tp], Tp.u 32⟩
+| .array tp N => ⟨[Tp.array tp N], Tp.u 32⟩
 
-In Noir, this corresponds to `fn len(self) -> u32` implemented for `[_; n]`.
--/
-def arrayLen : Builtin := {
-  omni := arrayLenOmni
-  conseq := by
-    unfold omni_conseq
-    intros
-    cases_type arrayLenOmni
-    · apply arrayLenOmni.mkSlice
-      assumption
-      tauto
-    · apply arrayLenOmni.mkArray
-      tauto
-  frame := by
-    unfold omni_frame
-    intros
-    cases_type arrayLenOmni
-    · apply arrayLenOmni.mkSlice
-      assumption
-      unfold SLP.star
-      tauto
-    · apply arrayLenOmni.mkArray
-      unfold SLP.star
-      tauto
-}
+def arrayLenDesc : {p : Prime}
+  → (a : ArrayLenCase)
+  → (args : HList (Tp.denote p) (arrayLenSgn a).fst)
+  → (h : Prop) × (h → Tp.denote p (arrayLenSgn a).snd)
+| _, .slice tp, h![x] => ⟨x.length < 2 ^ 32, fun _ => BitVec.ofNat 32 x.length⟩
+| _, .array tp N, h![_] => ⟨True, fun _ => N⟩
+
+-- /--
+-- Defines the function that evaluates to an array (or slice)'s length `n`.
+-- This builtin evaluates to an `U 32`. Hence, we assume that `n < 2^32`.
+
+-- In Noir, this corresponds to `fn len(self) -> u32` implemented for `[_; n]`.
+-- -/
+def arrayLen : Builtin :=
+  newGenericPureBuiltin arrayLenSgn arrayLenDesc
 
 end Lampe.Builtin

--- a/Lampe/Lampe/Builtin/Slice.lean
+++ b/Lampe/Lampe/Builtin/Slice.lean
@@ -44,20 +44,6 @@ def sliceIndex := newGenericPureBuiltin
     fun h => l.get (Fin.mk i.toNat h)⟩)
 
 /--
-Defines the builtin that returns the length of a slice `l : List tp`
-We make the following assumptions:
-- If `l.length < 2^32`, then the builtin returns `l.length : U 32`
-- Else (integer overflow), an exception is thrown.
-
-In Noir, this builtin corresponds to `fn len(self) -> u32` implemented for `[T]`.
--/
-def sliceLen := newGenericPureBuiltin
-  (fun tp => ⟨[.slice tp], .u 32⟩)
-  (fun _ h![l] => ⟨l.length < 2^32,
-    fun _ => l.length⟩)
-
-
-/--
 Defines the builtin that pushes back an element `e : Tp.denote tp` to a slice `l : List tp`.
 On these inputs, the builtin is assumed to return `l ++ [e]`.
 

--- a/Lampe/Lampe/Hoare/Builtins.lean
+++ b/Lampe/Lampe/Hoare/Builtins.lean
@@ -160,9 +160,38 @@ theorem arrayIndex_intro : STHoarePureBuiltin p Γ Builtin.arrayIndex (by tauto)
   apply pureBuiltin_intro_consequence <;> try tauto
   tauto
 
-theorem arrayLen_intro : STHoarePureBuiltin p Γ Builtin.arrayLen (by tauto) h![arr] (a := (tp, n)) := by
-  apply pureBuiltin_intro_consequence <;> try tauto
-  tauto
+theorem array_arrayLen_intro : STHoare p Γ ⟦⟧ (.callBuiltin [Tp.array tp N] (Tp.u 32) Builtin.arrayLen h![x])
+    fun v => v = x.length := by
+  unfold STHoare
+  unfold THoare
+  intros H st Q
+  constructor
+  constructor
+  unfold mapToValHeapCondition
+  simp
+  simp at Q
+  unfold SLP.star
+  use st
+  use ∅
+  simp
+  assumption
+
+theorem slice_arrayLen_intro (hLen : x.length < 2^32) : STHoare p Γ ⟦⟧ (.callBuiltin [Tp.slice tp] (Tp.u 32) Builtin.arrayLen h![x])
+    fun v => v = x.length := by
+  unfold STHoare
+  unfold THoare
+  intros H st Q
+  constructor
+  constructor
+  assumption
+  unfold mapToValHeapCondition
+  simp
+  simp at Q
+  unfold SLP.star
+  use st
+  use ∅
+  simp
+  assumption
 
 theorem asSlice_intro : STHoarePureBuiltin p Γ Builtin.asSlice (by tauto) h![arr] (a := (tp, n)) := by
   apply pureBuiltin_intro_consequence <;> try tauto
@@ -305,10 +334,6 @@ theorem iAsField_intro {p Γ s f} : STHoarePureBuiltin p Γ Builtin.iAsField (by
   tauto
 
 -- Slice
-
-theorem sliceLen_intro : STHoarePureBuiltin p Γ Builtin.sliceLen (by tauto) h![s] := by
-  apply pureBuiltin_intro_consequence <;> try rfl
-  tauto
 
 theorem sliceIndex_intro : STHoarePureBuiltin p Γ Builtin.sliceIndex (by tauto) h![sl, i] := by
   apply pureBuiltin_intro_consequence <;> try rfl

--- a/Lampe/Lampe/Hoare/Builtins.lean
+++ b/Lampe/Lampe/Hoare/Builtins.lean
@@ -162,32 +162,19 @@ theorem arrayIndex_intro : STHoarePureBuiltin p Γ Builtin.arrayIndex (by tauto)
 
 theorem array_arrayLen_intro : STHoare p Γ ⟦⟧ (.callBuiltin [Tp.array tp N] (Tp.u 32) Builtin.arrayLen h![x])
     fun v => v = x.length := by
-  unfold STHoare
-  unfold THoare
-  intros _ st Q
-  apply Omni.callBuiltin
-  apply Builtin.arrayLenOmni.mkArray
-  unfold mapToValHeapCondition
-  simp
-  rw [SLP.true_star] at Q
-  refine ⟨st, ∅, ?_⟩
-  simp only [LawfulHeap.disjoint_empty, LawfulHeap.union_empty, SLP.apply_top, and_true, true_and]
-  assumption
+  apply pureBuiltin_intro_consequence (sgn := Builtin.arrayLenSgn) (desc := Builtin.arrayLenDesc) rfl rfl ?_
+    (a := Builtin.ArrayLenCase.array tp N)
+  intro h
+  simp [Builtin.arrayLenDesc]
 
-theorem slice_arrayLen_intro (hLen : x.length < 2^32) : STHoare p Γ ⟦⟧ (.callBuiltin [Tp.slice tp] (Tp.u 32) Builtin.arrayLen h![x])
-    fun v => v = x.length := by
-  unfold STHoare
-  unfold THoare
-  intros _ st Q
-  apply Omni.callBuiltin
-  apply Builtin.arrayLenOmni.mkSlice
-  · exact hLen
-  unfold mapToValHeapCondition
+theorem slice_arrayLen_intro : STHoare p Γ ⟦⟧ (.callBuiltin [Tp.slice tp] (Tp.u 32) Builtin.arrayLen h![x])
+    fun v => ⟦v = x.length⟧ ⋆ ⟦x.length < 2^32⟧ := by
+  simp only [SLP.lift_star_lift]
+  apply pureBuiltin_intro_consequence (sgn := Builtin.arrayLenSgn) (desc := Builtin.arrayLenDesc) (a := Builtin.ArrayLenCase.slice tp) rfl rfl
+  intro h
+  simp [Builtin.arrayLenDesc] at h
   simp
-  rw [SLP.true_star] at Q
-  refine ⟨st, ∅, ?_⟩
-  simp only [LawfulHeap.disjoint_empty, LawfulHeap.union_empty, SLP.apply_top, and_true, true_and]
-  assumption
+  refine ⟨rfl, h⟩
 
 theorem asSlice_intro : STHoarePureBuiltin p Γ Builtin.asSlice (by tauto) h![arr] (a := (tp, n)) := by
   apply pureBuiltin_intro_consequence <;> try tauto

--- a/Lampe/Lampe/Hoare/Builtins.lean
+++ b/Lampe/Lampe/Hoare/Builtins.lean
@@ -164,33 +164,29 @@ theorem array_arrayLen_intro : STHoare p Γ ⟦⟧ (.callBuiltin [Tp.array tp N]
     fun v => v = x.length := by
   unfold STHoare
   unfold THoare
-  intros H st Q
-  constructor
-  constructor
+  intros _ st Q
+  apply Omni.callBuiltin
+  apply Builtin.arrayLenOmni.mkArray
   unfold mapToValHeapCondition
   simp
-  simp at Q
-  unfold SLP.star
-  use st
-  use ∅
-  simp
+  rw [SLP.true_star] at Q
+  refine ⟨st, ∅, ?_⟩
+  simp only [LawfulHeap.disjoint_empty, LawfulHeap.union_empty, SLP.apply_top, and_true, true_and]
   assumption
 
 theorem slice_arrayLen_intro (hLen : x.length < 2^32) : STHoare p Γ ⟦⟧ (.callBuiltin [Tp.slice tp] (Tp.u 32) Builtin.arrayLen h![x])
     fun v => v = x.length := by
   unfold STHoare
   unfold THoare
-  intros H st Q
-  constructor
-  constructor
-  assumption
+  intros _ st Q
+  apply Omni.callBuiltin
+  apply Builtin.arrayLenOmni.mkSlice
+  · exact hLen
   unfold mapToValHeapCondition
   simp
-  simp at Q
-  unfold SLP.star
-  use st
-  use ∅
-  simp
+  rw [SLP.true_star] at Q
+  refine ⟨st, ∅, ?_⟩
+  simp only [LawfulHeap.disjoint_empty, LawfulHeap.union_empty, SLP.apply_top, and_true, true_and]
   assumption
 
 theorem asSlice_intro : STHoarePureBuiltin p Γ Builtin.asSlice (by tauto) h![arr] (a := (tp, n)) := by

--- a/Lampe/Lampe/SeparationLogic/SLP.lean
+++ b/Lampe/Lampe/SeparationLogic/SLP.lean
@@ -324,4 +324,10 @@ theorem exists_star [LawfulHeap α] {P : SLP α} {Q : β → SLP α} : (∃∃x,
   conv => lhs; arg 1; ext x; rw [SLP.star_comm]
   simp [star_exists]
 
+theorem lift_star_lift [LawfulHeap α] {P Q : Prop} : (⟦P⟧ ⋆ ⟦Q⟧) = (⟦P ∧ Q⟧ : SLP α) := by
+  funext st
+  unfold star lift
+  simp
+  tauto
+
 end Lampe.SLP

--- a/Lampe/Lampe/Tactic/Steps.lean
+++ b/Lampe/Lampe/Tactic/Steps.lean
@@ -116,7 +116,8 @@ def getClosingTerm (val : Expr) : TacticM (Option (TSyntax `term × Bool)) := wi
         | ``Lampe.Builtin.mkRepeatedArray =>
           return some (←``(genericTotalPureBuiltin_intro Builtin.mkRepeatedArray (a := (_, _)) rfl), true)
         | ``Lampe.Builtin.arrayIndex => return some (←``(arrayIndex_intro), false)
-        | ``Lampe.Builtin.arrayLen => return some (←``(genericTotalPureBuiltin_intro Builtin.arrayLen (a := (_,_)) rfl), true)
+        | ``Lampe.Builtin.arrayLen => sorry
+          -- return some (←``(genericTotalPureBuiltin_intro Builtin.arrayLen (a := (_,_)) rfl), true)
         | ``Lampe.Builtin.asSlice => return some (←``(genericTotalPureBuiltin_intro Builtin.asSlice (a := (_,_)) rfl), true)
 
         -- Slice builtins
@@ -128,7 +129,6 @@ def getClosingTerm (val : Expr) : TacticM (Option (TSyntax `term × Bool)) := wi
           return some (←``(genericTotalPureBuiltin_intro Builtin.mkRepeatedSlice (a := _) rfl), true)
         | ``Lampe.Builtin.slicePushBack => return some (←``(genericTotalPureBuiltin_intro Builtin.slicePushBack rfl), true)
         | ``Lampe.Builtin.slicePushFront => return some (←``(genericTotalPureBuiltin_intro Builtin.slicePushFront rfl), true)
-        | ``Lampe.Builtin.sliceLen => return some (←``(sliceLen_intro), false)
         | ``Lampe.Builtin.sliceIndex => return some (←``(sliceIndex_intro), false)
         | ``Lampe.Builtin.ref => return some (←``(ref_intro), false)
         | ``Lampe.Builtin.readRef => return some (←``(readRef_intro), false)

--- a/Lampe/Lampe/Tactic/Steps.lean
+++ b/Lampe/Lampe/Tactic/Steps.lean
@@ -37,7 +37,6 @@ def getLetInVarName (e : Expr) : TacticM (Option Name) := do
   | Lean.Expr.lam n _ _ _ => return some n
   | _ => return none
 
-#check Lampe.Expr.callBuiltin
 /--
 Attempts to get a term that can close the goal, returning the result and whether the resultant
 variable should be substituted (akin to `subst_vars`).

--- a/Lampe/Tests/LenBuiltin.lean
+++ b/Lampe/Tests/LenBuiltin.lean
@@ -23,13 +23,12 @@ noir_def simple_array<T: Type, N: u32>(x: Array<T, N: u32>) -> u32 := {
 
 def thmEnv : Env := .mk [«std::slice::append», simple_array] []
 
-example (hLen : s₂.length < 2 ^ 32) : STHoare p thmEnv ⟦⟧ («std::slice::append».call h![T] h![s₁, s₂])
+example  : STHoare p thmEnv ⟦⟧ («std::slice::append».call h![T] h![s₁, s₂])
     fun v => v = s₁ ++ s₂ := by
   enter_decl
   steps
   step_as ([self ↦ ⟨Tp.slice T, s₁⟩]) (fun (v : Tp.denote p Tp.unit) => ⟦v = ()⟧ ⋆ [self ↦ ⟨Tp.slice T, s₁ ++ s₂⟩])
   · steps
-    subst_vars; assumption
     loop_inv nat (fun i _ _ => [self ↦ ⟨Tp.slice T, s₁ ++ (s₂.take i)⟩])
     · simp
     · congr; simp

--- a/Lampe/Tests/LenBuiltin.lean
+++ b/Lampe/Tests/LenBuiltin.lean
@@ -1,0 +1,30 @@
+import Lampe
+
+open Lampe
+
+noir_def std::slice::append<T: Type>(mut self: Slice<T>, other: Slice<T>) -> Slice<T> := {
+  {
+    let (ζi0: Slice<T>) = other;
+    for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
+      let (elem: T) = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      {
+        self = (#_slicePushBack returning Slice<T>)(self, elem);
+        #_skip
+      }
+    };
+    #_skip
+  };
+  self
+}
+
+def appendEnv : Env := .mk [«std::slice::append»] []
+
+set_option Lampe.pp.Expr true
+set_option Lampe.pp.STHoare true
+
+example : STHoare p appendEnv ⟦⟧ («std::slice::append».call h![T] h![s₁, s₂])
+    fun v => v = s₁ ++ s₂ := by
+  enter_decl
+  steps
+  step_as ([self ↦ ⟨Tp.slice T, s₁⟩]) (fun v => v = ())
+  · steps

--- a/Lampe/Tests/LenBuiltin.lean
+++ b/Lampe/Tests/LenBuiltin.lean
@@ -17,14 +17,67 @@ noir_def std::slice::append<T: Type>(mut self: Slice<T>, other: Slice<T>) -> Sli
   self
 }
 
-def appendEnv : Env := .mk [«std::slice::append»] []
+noir_def std::array::concat<T: Type, N: u32, M: u32>(self: Array<T, N: u32>, array2: Array<T, M: u32>) -> Array<T, (N + M): u32> := {
+  let mut (result: Array<T, (N + M): u32>) = (#_mkRepeatedArray returning Array<T, (N + M): u32>)((#_zeroed returning T)());
+  for i in (0: u32) .. uConst!(N: u32) do {
+    (result[i]: T) = (#_arrayIndex returning T)(self, (#_cast returning u32)(i));
+    #_skip
+  };
+  for i in (0: u32) .. uConst!(M: u32) do {
+    let (i_3606: Unit) = (#_uAdd returning u32)(i, uConst!(N: u32));
+    (result[i_3606]: T) = (#_arrayIndex returning T)(array2, (#_cast returning u32)(i));
+    #_skip
+  };
+  result
+}
 
-set_option Lampe.pp.Expr true
-set_option Lampe.pp.STHoare true
+def thmEnv : Env := .mk [«std::slice::append», «std::array::concat»] []
 
-example : STHoare p appendEnv ⟦⟧ («std::slice::append».call h![T] h![s₁, s₂])
+example (hLen : s₂.length < 2 ^ 32) : STHoare p thmEnv ⟦⟧ («std::slice::append».call h![T] h![s₁, s₂])
     fun v => v = s₁ ++ s₂ := by
   enter_decl
   steps
-  step_as ([self ↦ ⟨Tp.slice T, s₁⟩]) (fun v => v = ())
+  step_as ([self ↦ ⟨Tp.slice T, s₁⟩]) (fun v => ⟦v = ()⟧⋆[self ↦ ⟨Tp.slice T, s₁ ++ s₂⟩])
   · steps
+    subst_vars; assumption
+    loop_inv nat (fun i _ _ => [self ↦ ⟨Tp.slice T, s₁ ++ (s₂.take i)⟩])
+    · simp
+    · congr; simp
+    · intros i hlo hhi
+      steps
+      simp_all
+      subst_vars
+      congr
+      rename_i ha _
+      let ⟨_, h⟩ := ha
+      have : i % 4294967296 = i := by omega
+      simp [this] at h
+      simp [h]
+    steps
+    subst_vars
+    congr
+    simp
+    rw [Nat.mod_eq_of_lt]
+    assumption
+  steps
+  assumption
+
+lemma innercast : (Tp.denote p (Tp.array T (N + M))) = List.Vector (Tp.denote p T) (N.toNat + M.toNat) := by
+  sorry
+
+lemma outercast : («std::array::concat».fn.body (Tp.denote p) h![T, N, M]).outTp = (Tp.array T (N + M)) := by
+  sorry
+
+set_option trace.Lampe.STHoare.Helpers true
+
+example : STHoare p thmEnv ⟦⟧ («std::array::concat».call h![T, N, M] h![arr₁, arr₂])
+    fun v => v = outercast ▸ innercast ▸ (arr₁ ++ arr₂) := by
+  enter_decl
+  steps
+  let x := List.Vector.replicate (N + M).toNat (Tp.zero p T) -- not right, but testing for now
+  loop_inv nat fun i hlo hhi => [result ↦ ⟨Tp.array T (BitVec.add N M), x⟩]
+  · sorry
+  -- apply STHoare.letIn_trivial_intro
+  -- -- let h := @STHoare.loop_inv_intro 32 0 (N + M).toNat p Tp.unit thmEnv
+  -- --   fun i _ _ => [result ↦ ⟨Tp.array T (N + M), x⟩]
+  -- apply STHoare.loop_inv_intro (fun i _ _ => [result ↦ ⟨Tp.array T (N + M), x⟩])

--- a/Lampe/Tests/Syntax.lean
+++ b/Lampe/Tests/Syntax.lean
@@ -71,7 +71,6 @@ example {selfV that : Tp.denote p (.slice tp)} (hLen : that.length < 2 ^ 32)
     fun v => v = selfV ++ that := by
   simp only [slice_append]
   steps
-  assumption
   loop_inv nat (fun i _ _ => [self ↦ ⟨.slice tp, selfV ++ that.take i⟩])
   . simp_all
   . simp

--- a/Lampe/Tests/Syntax.lean
+++ b/Lampe/Tests/Syntax.lean
@@ -60,19 +60,18 @@ example {x y : Tp.denote p .field} :
 
 noir_def slice_append<I: Type>(x: Slice<I>, y: Slice<I>) → Slice<I> := {
   let mut (self: Slice<I>) = x;
-  for i in (0 : u32) .. (#_sliceLen returning u32)(y) do {
+  for i in (0 : u32) .. (#_arrayLen returning u32)(y) do {
     self = (#_slicePushBack returning Slice<I>)(self, (#_sliceIndex returning I)(y, i));
   };
   self
 }
 
-example {selfV that : Tp.denote p (.slice tp)}
+example {selfV that : Tp.denote p (.slice tp)} (hLen : that.length < 2 ^ 32)
   : STHoare p Γ ⟦⟧ (slice_append.fn.body _ h![tp] |>.body h![selfV, that])
     fun v => v = selfV ++ that := by
   simp only [slice_append]
   steps
-  casesm* ∃ _, _
-  subst_vars
+  assumption
   loop_inv nat (fun i _ _ => [self ↦ ⟨.slice tp, selfV ++ that.take i⟩])
   . simp_all
   . simp

--- a/stdlib/lampe/lake-manifest.json
+++ b/stdlib/lampe/lake-manifest.json
@@ -98,5 +98,5 @@
    "inputRev": "main",
    "inherited": true,
    "configFile": "lakefile.toml"}],
- "name": "«std-1.0.0-beta.3»",
+ "name": "«std-1.0.0-beta.11»",
  "lakeDir": ".lake"}

--- a/testing/Merkle/lampe/Merkle-0.0.0/Spec.lean
+++ b/testing/Merkle/lampe/Merkle-0.0.0/Spec.lean
@@ -550,7 +550,7 @@ theorem bar_intro : STHoare lp env ⟦⟧ («bar::bar».call h![] h![input])
   steps
 
   · loop_inv fun i _ _ => [new_bytes ↦ ⟨(Tp.u 8).slice, v.toList ++ ζi0.toList.take i.toNat⟩]
-    · decide
+    · subst_vars; simp
     · congr 1
       simp [Int.cast, IntCast.intCast]
     · intro i _ hlt
@@ -564,9 +564,12 @@ theorem bar_intro : STHoare lp env ⟦⟧ («bar::bar».call h![] h![input])
       conv at hlt => congr <;> whnf
       casesm* ∃_,_
       subst «#v_32» elem
-      have : i + 1 < 4294967296 := by linarith
+      have : i + 1 < 4294967296 := by
+        simp_all
+        linarith
       simp [Nat.mod_eq_of_lt, this, List.take_succ]
-      simp [List.Vector.toList_length, hlt, ↓reduceDIte, Option.toList_some, List.cons.injEq, and_true]
+      have hlt' : i < 16 := by simp_all
+      simp [List.Vector.toList_length, hlt', ↓reduceDIte, Option.toList_some, List.cons.injEq, and_true]
       rfl
     · subst_vars
       steps
@@ -574,7 +577,6 @@ theorem bar_intro : STHoare lp env ⟦⟧ («bar::bar».call h![] h![input])
   rotate_left
   · subst_vars; rfl
   · subst_vars; rfl
-
 
 theorem sigma_intro : STHoare lp env (⟦⟧)
     (Extracted.SIGMA.call h![] h![])

--- a/testing/MerkleFromScratch/user_files/Spec.lean
+++ b/testing/MerkleFromScratch/user_files/Spec.lean
@@ -550,7 +550,7 @@ theorem bar_intro : STHoare lp env ⟦⟧ («bar::bar».call h![] h![input])
   steps
 
   · loop_inv fun i _ _ => [new_bytes ↦ ⟨(Tp.u 8).slice, v.toList ++ ζi0.toList.take i.toNat⟩]
-    · decide
+    · subst_vars; simp
     · congr 1
       simp [Int.cast, IntCast.intCast]
     · intro i _ hlt
@@ -564,9 +564,12 @@ theorem bar_intro : STHoare lp env ⟦⟧ («bar::bar».call h![] h![input])
       conv at hlt => congr <;> whnf
       casesm* ∃_,_
       subst «#v_32» elem
-      have : i + 1 < 4294967296 := by linarith
+      have : i + 1 < 4294967296 := by
+        simp_all
+        linarith
       simp [Nat.mod_eq_of_lt, this, List.take_succ]
-      simp [List.Vector.toList_length, hlt, ↓reduceDIte, Option.toList_some, List.cons.injEq, and_true]
+      have hlt' : i < 16 := by simp_all
+      simp [List.Vector.toList_length, hlt', ↓reduceDIte, Option.toList_some, List.cons.injEq, and_true]
       rfl
     · subst_vars
       steps


### PR DESCRIPTION
This PR addresses #197 by adding a single `arrayLen` builtin that handles both slices and arrays. 