### PR TITLE
Remove type annotations from binders

### DIFF
--- a/Lampe/Lampe/Syntax/Rules.lean
+++ b/Lampe/Lampe/Syntax/Rules.lean
@@ -159,13 +159,14 @@ syntax "(" "(" noir_type ppSpace "as" ppSpace noir_ident "<" noir_gen_val,* ">" 
 
 -- LAMBDAS ----------------------------------------------------------------------------------------
 
-syntax "fn" "(" noir_pat,* ")" ppSpace ":" ppSpace noir_type ppSpace ":=" ppSpace noir_expr : noir_lambda -- Lambda expressions.
+syntax noir_pat ppSpace ":" ppSpace noir_type : noir_lam_param -- Lambda parameters
+syntax "fn" "(" noir_lam_param,* ")" ppSpace ":" ppSpace noir_type ppSpace ":=" ppSpace noir_expr : noir_lambda -- Lambda expressions.
 
 -- PATTERNS ---------------------------------------------------------------------------------------
 -- These are used in let bindings and lambda parameters to destructure things.
 
-syntax "(" noir_ident ppSpace ":" ppSpace noir_type ")" : noir_pat -- A bare identifier.
-syntax "mut" ppSpace "(" noir_ident ppSpace ":" ppSpace noir_type ")" : noir_pat -- A mutable identifier.
+syntax noir_ident : noir_pat -- A bare identifier.
+syntax "mut" ppSpace noir_ident : noir_pat -- A mutable identifier.
 syntax "(" noir_pat,* ")" : noir_pat -- A tuple pattern stands in for both tuples and structs.
 
 -- L-VALUES ---------------------------------------------------------------------------------------

--- a/Lampe/Lampe/Syntax/State.lean
+++ b/Lampe/Lampe/Syntax/State.lean
@@ -9,13 +9,18 @@ open Lampe
 
 /-- Carries information on patterns that can be used for destructuring. -/
 inductive Binder where
-| variable (name : Lean.Ident) (type : TSyntax `noir_type)
-| mutable (name : Lean.Ident) (type : TSyntax `noir_type)
+| variable (name : Lean.Ident)
+| mutable (name : Lean.Ident)
 | tuple (elems : List Binder)
 | invalid
 
 instance : Inhabited Binder where
   default := Binder.invalid
+
+/-- A container for a lambda parameter, including both pattern and type. -/
+structure LambdaParam where
+  binder : Binder
+  type : TSyntax `term
 
 /-- The state for the desugaring process from the DSL syntax into native Lean/lampe constructs. -/
 structure DSLState where

--- a/Lampe/Tests/Envs.lean
+++ b/Lampe/Tests/Envs.lean
@@ -36,9 +36,9 @@ noir_trait_impl[trait1u8]<> Trait1<> for u8 where [] := {
 }
 
 noir_def both_trait_call<>(x: Field, y: u8) → Field := {
-  let (z: u8) = ((u8 as Trait1<>)::function<> as λ(u8) -> u8)(y);
-  let (_t: u8) = (foo<u8> as λ(u8) → u8)(z);
-  let (w: Field) = ((Field as Trait1<>)::function<> as λ(Field) → Field)(x);
+  let z = ((u8 as Trait1<>)::function<> as λ(u8) -> u8)(y);
+  let _t = (foo<u8> as λ(u8) → u8)(z);
+  let w = ((Field as Trait1<>)::function<> as λ(Field) → Field)(x);
   (foo<Field> as λ(Field) → Field)(w)
 }
 

--- a/Lampe/Tests/Errors.lean
+++ b/Lampe/Tests/Errors.lean
@@ -45,7 +45,7 @@ theorem steps_error : STHoare p helloEnv ⟦⟧ (hello.call h![] h![])
   sorry
 
 noir_def loop_fn<>() -> Field := {
-  let mut (t : Field) = 1 : Field;
+  let mut t = 1 : Field;
 
   for _i in (0 : u32)..(5 : u32) do {
     t = (#_fMul returning Field)(t, 2 : Field);

--- a/Lampe/Tests/FieldGenerics.lean
+++ b/Lampe/Tests/FieldGenerics.lean
@@ -11,7 +11,7 @@ noir_def foo<A: Field>() → Field := {
 }
 
 noir_def test<>() → Field := {
-  let (a: Field) = (foo<4294967297: Field> as λ() → Field)();
+  let a = (foo<4294967297: Field> as λ() → Field)();
   a
 }
 

--- a/Lampe/Tests/LenBuiltin.lean
+++ b/Lampe/Tests/LenBuiltin.lean
@@ -4,9 +4,9 @@ open Lampe
 
 noir_def std::slice::append<T: Type>(mut self: Slice<T>, other: Slice<T>) -> Slice<T> := {
   {
-    let (ζi0: Slice<T>) = other;
+    let ζi0 = other;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: T) = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
       {
         self = (#_slicePushBack returning Slice<T>)(self, elem);
         #_skip

--- a/Lampe/Tests/Monotonicity.lean
+++ b/Lampe/Tests/Monotonicity.lean
@@ -61,8 +61,8 @@ theorem add_one_correct
 -- Finally, we define a slightly more complex function that will rely on the proofs of correctness
 -- for both of the above functions.
 noir_def add_one_to_three_and_n<>(n: Field) → Field := {
-  let (three: Field) = (return_three<> as λ() → Field)();
-  let (added_one: Field) = (add_one<> as λ(Field) → Field)(three);
+  let three = (return_three<> as λ() → Field)();
+  let added_one = (add_one<> as λ(Field) → Field)(three);
   (#_fAdd returning Field)(added_one, n)
 }
 
@@ -188,8 +188,8 @@ theorem default_u8_correct
 -- With both of our trait implementations proved to do the right thing, let's define a function that
 -- uses both trait implementations at once, along with an environment for it and the traits.
 noir_def call_trait_impls_and_add<>(n: Field) → Field := {
-  let (_default_u8: u8) = ((u8 as Default<>)::default<> as λ() → u8)();
-  let (default_field: Field) = ((Field as Default<>)::default<> as λ() → Field)();
+  let _default_u8 = ((u8 as Default<>)::default<> as λ() → u8)();
+  let default_field = ((Field as Default<>)::default<> as λ() → Field)();
   (#_fAdd returning Field)(default_field, n)
 }
 
@@ -215,8 +215,8 @@ theorem call_trait_impls_and_add_correct
 -- that the monotonicity works. We define a function that uses both already-composed environments,
 -- along with its accompanying env.
 noir_def combining_everything<>(n: Field) → Field := {
-  let (added_4: Field) = (add_one_to_three_and_n<> as λ(Field) → Field)(n);
-  let (added_42: Field) = (call_trait_impls_and_add<> as λ(Field) → Field)(n);
+  let added_4 = (add_one_to_three_and_n<> as λ(Field) → Field)(n);
+  let added_42 = (call_trait_impls_and_add<> as λ(Field) → Field)(n);
   (#_fAdd returning Field)(added_4, added_42)
 }
 

--- a/Lampe/Tests/Syntax.lean
+++ b/Lampe/Tests/Syntax.lean
@@ -14,8 +14,8 @@ noir_def basic_fn<>(x: u64) -> u64 := {
 }
 
 noir_def basic_fn_call<>() -> u64 := {
-  let (y: u64) = (basic_fn<> as λ(u64) → u64)(3: u64);
-  let (z: u64) = (basic_fn<> as λ(u64) → u64)(4: u64);
+  let y = (basic_fn<> as λ(u64) → u64)(3: u64);
+  let z = (basic_fn<> as λ(u64) → u64)(4: u64);
   (#_uAdd returning u64)(y, z)
 }
 
@@ -34,8 +34,8 @@ example : Lampe.STHoare p basicFnEnv ⟦⟧ (basic_fn_call.fn.body _ h![] |>.bod
   simp_all; subst_vars; norm_cast
 
 noir_def basic_muts<>(x: Field) -> Field := {
-  let mut (y: Field) = x;
-  let mut (z: Field) = x;
+  let mut y = x;
+  let mut z = x;
   z = z;
   y = z;
   y
@@ -47,7 +47,7 @@ example : Lampe.STHoare p Γ ⟦⟧ (basic_muts.fn.body _ h![] |>.body h![x]) fu
   simp_all
 
 noir_def weird_eq<I: Type>(x: I, y: I) -> Unit := {
-  let (a: I) = (#_fresh returning I)();
+  let a = (#_fresh returning I)();
   (#_fAdd returning I)(x, y);
   (#_assert returning Unit)((#_fEq returning bool)(a, x));
   (#_assert returning Unit)((#_fEq returning bool)(a, y));
@@ -60,7 +60,7 @@ example {x y : Tp.denote p .field} :
   simp_all
 
 noir_def slice_append<I: Type>(x: Slice<I>, y: Slice<I>) → Slice<I> := {
-  let mut (self: Slice<I>) = x;
+  let mut self = x;
   for i in (0 : u32) .. (#_arrayLen returning u32)(y) do {
     self = (#_slicePushBack returning Slice<I>)(self, (#_sliceIndex returning I)(y, i));
   };
@@ -82,7 +82,7 @@ example {selfV that : Tp.denote p (.slice tp)}
     simp_all [Nat.mod_eq_of_lt]
 
 noir_def simple_if<>(x: Field, y: Field) -> Field := {
-  let mut (z: Field) = x;
+  let mut z = x;
   if (#_fEq returning bool)(x, x) then {
     z = y;
   };
@@ -102,7 +102,7 @@ example : STHoare p Γ ⟦⟧ (simple_if.fn.body _ h![] |>.body h![x, y]) fun v 
   simp_all
 
 noir_def simple_if_else<>(x: Field, y: Field) -> Field := {
-  let (z: Field) = if (#_fEq returning bool)(x, x) then { x } else { y };
+  let z = if (#_fEq returning bool)(x, x) then { x } else { y };
   z
 }
 
@@ -119,7 +119,7 @@ example : STHoare p Γ ⟦⟧ (simple_if_else.fn.body _ h![] |>.body h![x, y]) f
   simp_all
 
 noir_def simple_lambda<>(x: Field, y: Field) -> Field := {
-  let (add: λ(Field, Field) -> Field) = fn((a: Field), (b: Field)): Field := (#_fAdd returning Field)(a, b);
+  let add = fn(a: Field, b: Field): Field := (#_fAdd returning Field)(a, b);
   (add as λ(Field, Field) -> Field)(x, y);
 }
 
@@ -202,7 +202,7 @@ noir_struct_def FooStruct<I: Type> {
 }
 
 noir_def make_foo_struct<>(x: u32) -> FooStruct<u32> := {
-  let (y: u32) = (#_uMul returning u32)(x, 10: u32);
+  let y = (#_uMul returning u32)(x, 10: u32);
   (#_makeData returning FooStruct<u32>)(x, y)
 }
 
@@ -217,7 +217,7 @@ example : STHoare p Γ ⟦⟧ (make_tuple.fn.body _ h![] |>.body h![x])
   subst_vars; rfl
 
 noir_def get_second_elem<>() -> u32 := {
-  let (v: FooStruct<u32>) = (make_foo_struct<> as λ(u32) → FooStruct<u32>)(10: u32);
+  let v = (make_foo_struct<> as λ(u32) → FooStruct<u32>)(10: u32);
   v.1
 }
 
@@ -244,7 +244,7 @@ noir_def generic_func<I: Type>(a: I) -> I := {
 }
 
 noir_def call_generic_func<>(a: Field) -> Field := {
-  let (x: Field) = (generic_func<Field> as λ(Field) -> Field)(a);
+  let x = (generic_func<Field> as λ(Field) -> Field)(a);
   x
 }
 
@@ -281,7 +281,7 @@ example : STHoare p ⟨[add_two_fields], []⟩ ⟦⟧
     ring
 
 noir_def simple_tuple<>() -> Field := {
-  let (t: Tuple<Field, bool, Field>) = (#_makeData returning Tuple<Field, bool, Field>)(1: Field, #_true, 3: Field);
+  let t = (#_makeData returning Tuple<Field, bool, Field>)(1: Field, #_true, 3: Field);
   t.2
 }
 
@@ -292,7 +292,7 @@ example : STHoare p Γ ⟦⟧ (simple_tuple.fn.body _ h![] |>.body h![])
   aesop
 
 noir_def simple_slice<>() -> bool := {
-  let (s : Slice<bool>) = (#_mkSlice returning Slice<bool>)(#_true, #_false);
+  let s = (#_mkSlice returning Slice<bool>)(#_true, #_false);
   (#_sliceIndex returning bool)(s, (1: u32))
 }
 
@@ -303,7 +303,7 @@ example : STHoare p Γ ⟦⟧ (simple_slice.fn.body _ h![] |>.body h![])
   simp_all
 
 noir_def simple_array<>() -> Field := {
-  let (arr: Array<Field, 2: u32>) = (#_mkArray returning Array<Field, 2: u32>)(1: Field, 2: Field);
+  let arr = (#_mkArray returning Array<Field, 2: u32>)(1: Field, 2: Field);
   (#_arrayIndex returning Field)(arr, 1: u32)
 }
 
@@ -315,7 +315,7 @@ example : STHoare p Γ ⟦⟧ (simple_array.fn.body _ h![] |>.body h![])
   simp_all; aesop
 
 noir_def use_array<>() -> Field := {
-  let (a: Array<Field, 4: u32>) = (#_mkRepeatedArray returning Array<Field, 4: u32>)((1: Field));
+  let a = (#_mkRepeatedArray returning Array<Field, 4: u32>)((1: Field));
   (#_arrayIndex returning Field)(a, ((2: u32)))
 }
 
@@ -327,7 +327,7 @@ example : STHoare p Γ ⟦⟧ (use_array.fn.body _ h![] |>.body h![])
 
 -- Note that repeated slices are not currently supported in the extractor
 noir_def repeated_slice<>() -> Field := {
-  let (a: Slice<Field>) = (#_mkRepeatedSlice returning Slice<Field>)((4: u32), (1: Field));
+  let a = (#_mkRepeatedSlice returning Slice<Field>)((4: u32), (1: Field));
   (#_sliceIndex returning Field)(a, (0: u32))
 }
 
@@ -338,7 +338,7 @@ example : STHoare p Γ ⟦⟧ (repeated_slice.fn.body _ h![] |>.body h![])
   simp_all
 
 noir_def simple_tuple_access<>() → Field := {
-  let (t: Tuple<Field, bool, Field>) =
+  let t =
     (#_makeData returning Tuple<Field, bool, Field>)(1: Field, #_true, 3: Field);
   t.2
 }
@@ -350,7 +350,7 @@ example : STHoare p Γ ⟦⟧ (simple_tuple_access.fn.body _ h![] |>.body h![])
   aesop
 
 noir_def simple_slice_of_values<>() → bool := {
-  let (s: Slice<bool>) = (#_mkSlice returning Slice<bool>)(#_true, #_false);
+  let s = (#_mkSlice returning Slice<bool>)(#_true, #_false);
   (#_sliceIndex returning bool)(s, 1: u32)
 }
 
@@ -361,11 +361,10 @@ example : STHoare p Γ ⟦⟧ (simple_slice_of_values.fn.body _ h![] |>.body h![
   aesop
 
 noir_def tuple_lens<>() → Field := {
-  let mut (p: Tuple<Tuple<Field, Field>, Field>) =
-    (#_makeData returning Tuple<Tuple<Field, Field>, Field>)(
-      (#_makeData returning Tuple<Field, Field>)(1: Field, 2: Field),
-      3: Field
-    );
+  let mut p = (#_makeData returning Tuple<Tuple<Field, Field>, Field>)(
+    (#_makeData returning Tuple<Field, Field>)(1: Field, 2: Field),
+    3: Field
+  );
 
   (p.1: Field) = 5: Field;
   ((p.0: Tuple<Field, Field>).1: Field) = 10: Field;
@@ -386,7 +385,7 @@ noir_struct_def Pair<E: Type> {
 }
 
 noir_def struct_lens<>() → Field := {
-  let mut (p: Tuple<Pair<Field>, Field>) = (#_makeData returning Tuple<Pair<Field>, Field>)(
+  let mut p = (#_makeData returning Tuple<Pair<Field>, Field>)(
     (#_makeData returning Pair<Field>)(1: Field, 2: Field),
     3: Field
   );
@@ -404,7 +403,7 @@ example : STHoare p Γ ⟦⟧ (struct_lens.fn.body _ h![] |>.body h![])
   rfl
 
 noir_def array_lens<>() → Field := {
-  let mut (a: Tuple<Array<Field, 2: u32>, Field>) = (#_makeData returning Tuple<Array<Field, 2: u32>, Field>)(
+  let mut a = (#_makeData returning Tuple<Array<Field, 2: u32>, Field>)(
     (#_mkArray returning Array<Field, 2: u32>)(1: Field, 2: Field),
     3: Field
   );
@@ -421,7 +420,7 @@ example : STHoare p Γ ⟦⟧ (array_lens.fn.body _ h![] |>.body h![])
   aesop
 
 noir_def slice_lens<>() → Field := {
-  let mut (a: Tuple<Slice<Field>, Field>) = (#_makeData returning Tuple<Slice<Field>, Field>)(
+  let mut a = (#_makeData returning Tuple<Slice<Field>, Field>)(
     (#_mkSlice returning Slice<Field>)(1: Field, 2: Field),
     3: Field
   );
@@ -438,7 +437,7 @@ example : STHoare p Γ ⟦⟧ (slice_lens.fn.body _ h![] |>.body h![])
   aesop
 
 noir_def deref_lens<>() → Field := {
-  let (r: &Field) = (#_ref returning &Tuple<Field>)((#_makeData returning Tuple<Field>)(5: Field));
+  let r = (#_ref returning &Tuple<Field>)((#_makeData returning Tuple<Field>)(5: Field));
 
   ((*r: Tuple<Field>).0: Field) = 10: Field;
 
@@ -465,7 +464,7 @@ noir_def call_function<>(f: λ() → Field) → Field := {
 }
 
 noir_def simple_hof<>() → Field := {
-  let (func: λ() → Field) = (return_ten<> as λ() → Field);
+  let func = (return_ten<> as λ() → Field);
 
   (call_function<> as λ(λ() → Field) → Field)(func)
 }
@@ -519,7 +518,7 @@ example : STHoare p aliasTestEnv ⟦⟧ (alias_test.call h![] h![⟨[1, 2, 3], b
   aesop
 
 noir_def const_test<N: u8>(x: Field) → Field := {
-  let mut (res: Field) = x;
+  let mut res = x;
 
   for _ in (0: u8) .. uConst!(N: u8) do {
     res = (#_fMul returning Field)(res, 2: Field);
@@ -545,7 +544,7 @@ example : STHoare p constTestEnv ⟦⟧ (const_test.call h![3] h![2])
     norm_num
 
 noir_def tuple_pattern<>(x: Field) → Field := {
-  let (mut (x: Field), (y: Field)) = (#_makeData returning Tuple<Field, Field>)(x, x);
+  let (mut x, y) = (#_makeData returning Tuple<Field, Field>)(x, x);
   x = y;
   x
 }
@@ -560,7 +559,7 @@ example : STHoare p tuplePatternEnv ⟦⟧ (tuple_pattern.call h![] h![x])
   apply_assumption
 
 noir_def test_lam<>(x: Field) -> Field := {
-  let (f: λ(Field) → Field) = (fn((x: Field)): Field := x);
+  let f = fn(x: Field): Field := x;
   (f as λ(Field) → Field)(x)
 }
 
@@ -601,22 +600,22 @@ noir_struct_def «asdf::Other»<> {
 }
 
 noir_def «asdf::colon_test»<>() -> Field := {
-  let (a: Field) = (5: Field);
-  let (b: Field) = (10: Field);
+  let a = (5: Field);
+  let b = (10: Field);
   (#_fAdd returning Field)(a, b)
 }
 
 noir_def «asdf::inner::colon_test_inner»<>() -> @FField<> := {
-  let (a: @FField<>) = (5: Field);
-  let (b: @FField<>) = (10: Field);
-  let (c: «asdf::Other»<>) = (#_makeData returning «asdf::Other»<>)((#_fAdd returning Field)(a, b));
+  let a = (5: Field);
+  let b = (10: Field);
+  let c = (#_makeData returning «asdf::Other»<>)((#_fAdd returning Field)(a, b));
   c.0
 }
 
 noir_def test_blocks<>() -> u32 := {
-  let (s: Field) = (2: Field);
-  let (x: Field) = {
-    let (y: Field) = (9: Field);
+  let s = (2: Field);
+  let x = {
+    let y = (9: Field);
     (2: u32)
   };
   (3: u32)

--- a/Lampe/Tests/UnitReturn.lean
+++ b/Lampe/Tests/UnitReturn.lean
@@ -3,11 +3,11 @@ import Lampe
 open Lampe
 
 noir_def foo<>() → Unit := {
-  let (a: Field) = 3: Field;
+  let a = 3: Field;
   #_skip
 }
 
 noir_def bar<>() → Unit := {
-  let mut (a: Field) = 3: Field;
+  let mut a = 3: Field;
   #_skip
 }

--- a/src/lean/emit/writer.rs
+++ b/src/lean/emit/writer.rs
@@ -405,15 +405,15 @@ impl Writer<'_> {
     /// Directly writes the contents of the lambda parameter into the builder.
     pub fn write_lambda_parameter(&mut self, param: &(Pattern, Type)) {
         self.write_pattern(&param.0);
+        self.append_to_line(": ");
+        self.write_type_value(&param.1, false);
     }
 
     /// Directly writes the contents of the pattern into the builder.
     pub fn write_pattern(&mut self, pattern: &Pattern) {
         match pattern {
             Pattern::Identifier(ident) => {
-                self.append_to_line("(");
-                self.write_identifier(ident, true);
-                self.append_to_line(")");
+                self.write_identifier(ident, false);
             }
             Pattern::Mutable(ident) => {
                 self.append_to_line("mut ");

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Array/CheckShuffle.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Array/CheckShuffle.lean
@@ -17,16 +17,16 @@ noir_def std::array::check_shuffle::__get_index<N: u32>(indices: Array<u32, N: u
 }
 
 noir_def std::array::check_shuffle::check_shuffle<T: Type, N: u32>(lhs: Array<T, N: u32>, rhs: Array<T, N: u32>) -> Unit := {
-  let (shuffle_indices: Array<u32, N: u32>) = (std::array::check_shuffle::__get_shuffle_indices<T, N: u32> as λ(Array<T, N: u32>, Array<T, N: u32>) -> Array<u32, N: u32>)(lhs, rhs);
+  let shuffle_indices = (std::array::check_shuffle::__get_shuffle_indices<T, N: u32> as λ(Array<T, N: u32>, Array<T, N: u32>) -> Array<u32, N: u32>)(lhs, rhs);
   for i in (0: u32) .. uConst!(N: u32) do {
-    let (idx: u32) = (std::array::check_shuffle::__get_index<N: u32> as λ(Array<u32, N: u32>, u32) -> u32)(shuffle_indices, i);
+    let idx = (std::array::check_shuffle::__get_index<N: u32> as λ(Array<u32, N: u32>, u32) -> u32)(shuffle_indices, i);
     (#_assert returning Unit)((#_uEq returning bool)((#_arrayIndex returning u32)(shuffle_indices, (#_cast returning u32)(idx)), i));
     #_skip
   };
   for i in (0: u32) .. uConst!(N: u32) do {
-    let (idx: u32) = (#_arrayIndex returning u32)(shuffle_indices, (#_cast returning u32)(i));
-    let (expected: T) = (#_arrayIndex returning T)(rhs, (#_cast returning u32)(idx));
-    let (result: T) = (#_arrayIndex returning T)(lhs, (#_cast returning u32)(i));
+    let idx = (#_arrayIndex returning u32)(shuffle_indices, (#_cast returning u32)(i));
+    let expected = (#_arrayIndex returning T)(rhs, (#_cast returning u32)(idx));
+    let result = (#_arrayIndex returning T)(lhs, (#_cast returning u32)(i));
     (#_assert returning Unit)(((T as Eq<>)::eq<> as λ(T, T) -> bool)(expected, result));
     #_skip
   };
@@ -40,36 +40,36 @@ noir_trait_impl[impl_23]<> std::cmp::Eq<> for std::array::check_shuffle::test::C
 }
 
 noir_def std::array::check_shuffle::test::test_shuffle<>() -> Unit := {
-  let (lhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
-  let (rhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((2: Field), (0: Field), (3: Field), (1: Field), (4: Field));
+  let lhs = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
+  let rhs = (#_mkArray returning Array<Field, 5: u32>)((2: Field), (0: Field), (3: Field), (1: Field), (4: Field));
   (std::array::check_shuffle::check_shuffle<Field, 5: u32> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> Unit)(lhs, rhs);
   #_skip
 }
 
 noir_def std::array::check_shuffle::test::test_shuffle_identity<>() -> Unit := {
-  let (lhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
-  let (rhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
+  let lhs = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
+  let rhs = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
   (std::array::check_shuffle::check_shuffle<Field, 5: u32> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> Unit)(lhs, rhs);
   #_skip
 }
 
 noir_def std::array::check_shuffle::test::test_shuffle_fail<>() -> Unit := {
-  let (lhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
-  let (rhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (5: Field));
+  let lhs = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
+  let rhs = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (5: Field));
   (std::array::check_shuffle::check_shuffle<Field, 5: u32> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> Unit)(lhs, rhs);
   #_skip
 }
 
 noir_def std::array::check_shuffle::test::test_shuffle_duplicates<>() -> Unit := {
-  let (lhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
-  let (rhs: Array<Field, 5: u32>) = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (3: Field));
+  let lhs = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (4: Field));
+  let rhs = (#_mkArray returning Array<Field, 5: u32>)((0: Field), (1: Field), (2: Field), (3: Field), (3: Field));
   (std::array::check_shuffle::check_shuffle<Field, 5: u32> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> Unit)(lhs, rhs);
   #_skip
 }
 
 noir_def std::array::check_shuffle::test::test_shuffle_compound_struct<>() -> Unit := {
-  let (lhs: Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>) = (#_mkArray returning Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>)((#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (0: Field), (12345: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (-100: Field), (54321: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_true, (5: Field), (18446744073709551615: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_true, (9814: Field), (17221745184140693811: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (341: Field), (0: u64)));
-  let (rhs: Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>) = (#_mkArray returning Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>)((#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (341: Field), (0: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (0: Field), (12345: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (-100: Field), (54321: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_true, (9814: Field), (17221745184140693811: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_true, (5: Field), (18446744073709551615: u64)));
+  let lhs = (#_mkArray returning Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>)((#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (0: Field), (12345: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (-100: Field), (54321: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_true, (5: Field), (18446744073709551615: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_true, (9814: Field), (17221745184140693811: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (341: Field), (0: u64)));
+  let rhs = (#_mkArray returning Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>)((#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (341: Field), (0: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (0: Field), (12345: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_false, (-100: Field), (54321: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_true, (9814: Field), (17221745184140693811: u64)), (#_makeData returning std::array::check_shuffle::test::CompoundStruct<>)(#_true, (5: Field), (18446744073709551615: u64)));
   (std::array::check_shuffle::check_shuffle<std::array::check_shuffle::test::CompoundStruct<>, 5: u32> as λ(Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>, Array<std::array::check_shuffle::test::CompoundStruct<>, 5: u32>) -> Unit)(lhs, rhs);
   #_skip
 }

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Array/Mod.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Array/Mod.lean
@@ -9,8 +9,8 @@ namespace «std-1.0.0-beta.11»
 namespace Extracted
 
 noir_def std::array::map<T: Type, N: u32, U: Type, Env: Type>(self: Array<T, N: u32>, f: λ(T) -> U) -> Array<U, N: u32> := {
-  let (uninitialized: U) = (#_zeroed returning U)();
-  let mut (ret: Array<U, N: u32>) = (#_mkRepeatedArray returning Array<U, N: u32>)(uninitialized);
+  let uninitialized = (#_zeroed returning U)();
+  let mut ret = (#_mkRepeatedArray returning Array<U, N: u32>)(uninitialized);
   for i in (0: u32) .. (#_arrayLen returning u32)(self) do {
     (ret[i]: U) = (f as λ(T) -> U)((#_arrayIndex returning T)(self, (#_cast returning u32)(i)));
     #_skip
@@ -19,8 +19,8 @@ noir_def std::array::map<T: Type, N: u32, U: Type, Env: Type>(self: Array<T, N: 
 }
 
 noir_def std::array::mapi<T: Type, N: u32, U: Type, Env: Type>(self: Array<T, N: u32>, f: λ(u32, T) -> U) -> Array<U, N: u32> := {
-  let (uninitialized: U) = (#_zeroed returning U)();
-  let mut (ret: Array<U, N: u32>) = (#_mkRepeatedArray returning Array<U, N: u32>)(uninitialized);
+  let uninitialized = (#_zeroed returning U)();
+  let mut ret = (#_mkRepeatedArray returning Array<U, N: u32>)(uninitialized);
   for i in (0: u32) .. (#_arrayLen returning u32)(self) do {
     (ret[i]: U) = (f as λ(u32, T) -> U)(i, (#_arrayIndex returning T)(self, (#_cast returning u32)(i)));
     #_skip
@@ -46,9 +46,9 @@ noir_def std::array::for_eachi<T: Type, N: u32, Env: Type>(self: Array<T, N: u32
 
 noir_def std::array::fold<T: Type, N: u32, U: Type, Env: Type>(self: Array<T, N: u32>, mut accumulator: U, f: λ(U, T) -> U) -> U := {
   {
-    let (ζi0: Array<T, N: u32>) = self;
+    let ζi0 = self;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: T) = (#_arrayIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_arrayIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
       {
         accumulator = (f as λ(U, T) -> U)(accumulator, elem);
         #_skip
@@ -60,7 +60,7 @@ noir_def std::array::fold<T: Type, N: u32, U: Type, Env: Type>(self: Array<T, N:
 }
 
 noir_def std::array::reduce<T: Type, N: u32, Env: Type>(self: Array<T, N: u32>, f: λ(T, T) -> T) -> T := {
-  let mut (accumulator: T) = (#_arrayIndex returning T)(self, (0: u32));
+  let mut accumulator = (#_arrayIndex returning T)(self, (0: u32));
   for i in (1: u32) .. (#_arrayLen returning u32)(self) do {
     accumulator = (f as λ(T, T) -> T)(accumulator, (#_arrayIndex returning T)(self, (#_cast returning u32)(i)));
     #_skip
@@ -69,11 +69,11 @@ noir_def std::array::reduce<T: Type, N: u32, Env: Type>(self: Array<T, N: u32>, 
 }
 
 noir_def std::array::all<T: Type, N: u32, Env: Type>(self: Array<T, N: u32>, predicate: λ(T) -> bool) -> bool := {
-  let mut (ret: bool) = #_true;
+  let mut ret = #_true;
   {
-    let (ζi0: Array<T, N: u32>) = self;
+    let ζi0 = self;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: T) = (#_arrayIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_arrayIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
       {
         ret = (#_bAnd returning bool)(ret, (predicate as λ(T) -> bool)(elem));
         #_skip
@@ -85,11 +85,11 @@ noir_def std::array::all<T: Type, N: u32, Env: Type>(self: Array<T, N: u32>, pre
 }
 
 noir_def std::array::any<T: Type, N: u32, Env: Type>(self: Array<T, N: u32>, predicate: λ(T) -> bool) -> bool := {
-  let mut (ret: bool) = #_false;
+  let mut ret = #_false;
   {
-    let (ζi0: Array<T, N: u32>) = self;
+    let ζi0 = self;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: T) = (#_arrayIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_arrayIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
       {
         ret = (#_bOr returning bool)(ret, (predicate as λ(T) -> bool)(elem));
         #_skip
@@ -101,13 +101,13 @@ noir_def std::array::any<T: Type, N: u32, Env: Type>(self: Array<T, N: u32>, pre
 }
 
 noir_def std::array::concat<T: Type, N: u32, M: u32>(self: Array<T, N: u32>, array2: Array<T, M: u32>) -> Array<T, (N + M): u32> := {
-  let mut (result: Array<T, (N + M): u32>) = (#_mkRepeatedArray returning Array<T, (N + M): u32>)((#_zeroed returning T)());
+  let mut result = (#_mkRepeatedArray returning Array<T, (N + M): u32>)((#_zeroed returning T)());
   for i in (0: u32) .. uConst!(N: u32) do {
     (result[i]: T) = (#_arrayIndex returning T)(self, (#_cast returning u32)(i));
     #_skip
   };
   for i in (0: u32) .. uConst!(M: u32) do {
-    let (i_3606: Unit) = (#_uAdd returning u32)(i, uConst!(N: u32));
+    let i_3606 = (#_uAdd returning u32)(i, uConst!(N: u32));
     (result[i_3606]: T) = (#_arrayIndex returning T)(array2, (#_cast returning u32)(i));
     #_skip
   };
@@ -115,11 +115,11 @@ noir_def std::array::concat<T: Type, N: u32, M: u32>(self: Array<T, N: u32>, arr
 }
 
 noir_def std::array::sort<T: Type, N: u32>(self: Array<T, N: u32>) -> Array<T, N: u32> := {
-  (std::array::sort_via<T, N: u32, Unit> as λ(Array<T, N: u32>, λ(T, T) -> bool) -> Array<T, N: u32>)(self, (fn((a: T), (b: T)): bool := ((T as Ord<>)::cmp<> as λ(T, T) -> bool)(a, b)))
+  (std::array::sort_via<T, N: u32, Unit> as λ(Array<T, N: u32>, λ(T, T) -> bool) -> Array<T, N: u32>)(self, (fn(a: T, b: T): bool := ((T as Ord<>)::cmp<> as λ(T, T) -> bool)(a, b)))
 }
 
 noir_def std::array::sort_via<T: Type, N: u32, Env: Type>(self: Array<T, N: u32>, ordering: λ(T, T) -> bool) -> Array<T, N: u32> := {
-  let (sorted: Array<T, N: u32>) = {
+  let sorted = {
     (std::array::quicksort::quicksort<T, N: u32, Env> as λ(Array<T, N: u32>, λ(T, T) -> bool) -> Array<T, N: u32>)(self, (ordering as λ(T, T) -> bool))
   };
   if (#_bNot returning bool)((#_isUnconstrained returning bool)()) then {
@@ -140,7 +140,7 @@ noir_trait_impl[impl_24]<N: u32> std::convert::From<String<N: u32> > for Array<u
 }
 
 noir_def std::array::test::map_empty<>() -> Unit := {
-  (#_assert returning Unit)(((Array<Field, 0: u32> as Eq<>)::eq<> as λ(Array<Field, 0: u32>, Array<Field, 0: u32>) -> bool)((std::array::map<Field, 0: u32, Unit> as λ(Array<Field, 0: u32>, λ(Field) -> Field) -> Array<Field, 0: u32>)((#_mkArray returning Array<Field, 0: u32>)(), (fn((x: Field)): Field := (#_fAdd returning Field)(x, (1: Field)))), (#_mkArray returning Array<Field, 0: u32>)()));
+  (#_assert returning Unit)(((Array<Field, 0: u32> as Eq<>)::eq<> as λ(Array<Field, 0: u32>, Array<Field, 0: u32>) -> bool)((std::array::map<Field, 0: u32, Unit> as λ(Array<Field, 0: u32>, λ(Field) -> Field) -> Array<Field, 0: u32>)((#_mkArray returning Array<Field, 0: u32>)(), (fn(x: Field): Field := (#_fAdd returning Field)(x, (1: Field)))), (#_mkArray returning Array<Field, 0: u32>)()));
   #_skip
 }
 
@@ -153,83 +153,83 @@ noir_def std::array::test::sort_u32<>(a: u32, b: u32) -> bool := {
 }
 
 noir_def std::array::test::test_sort<>() -> Unit := {
-  let mut (arr: Array<u32, 7: u32>) = (#_mkArray returning Array<u32, 7: u32>)((3: u32), (6: u32), (8: u32), (10: u32), (1: u32), (2: u32), (1: u32));
-  let (sorted: Array<u32, 7: u32>) = (std::array::sort<u32, 7: u32> as λ(Array<u32, 7: u32>) -> Array<u32, 7: u32>)(arr);
-  let (expected: Array<u32, 7: u32>) = (#_mkArray returning Array<u32, 7: u32>)((1: u32), (1: u32), (2: u32), (3: u32), (6: u32), (8: u32), (10: u32));
+  let mut arr = (#_mkArray returning Array<u32, 7: u32>)((3: u32), (6: u32), (8: u32), (10: u32), (1: u32), (2: u32), (1: u32));
+  let sorted = (std::array::sort<u32, 7: u32> as λ(Array<u32, 7: u32>) -> Array<u32, 7: u32>)(arr);
+  let expected = (#_mkArray returning Array<u32, 7: u32>)((1: u32), (1: u32), (2: u32), (3: u32), (6: u32), (8: u32), (10: u32));
   (#_assert returning Unit)(((Array<u32, 7: u32> as Eq<>)::eq<> as λ(Array<u32, 7: u32>, Array<u32, 7: u32>) -> bool)(sorted, expected));
   #_skip
 }
 
 noir_def std::array::test::test_sort_100_values<>() -> Unit := {
-  let mut (arr: Array<u32, 100: u32>) = (#_mkArray returning Array<u32, 100: u32>)((42: u32), (123: u32), (87: u32), (93: u32), (48: u32), (80: u32), (50: u32), (5: u32), (104: u32), (84: u32), (70: u32), (47: u32), (119: u32), (66: u32), (71: u32), (121: u32), (3: u32), (29: u32), (42: u32), (118: u32), (2: u32), (54: u32), (89: u32), (44: u32), (81: u32), (0: u32), (26: u32), (106: u32), (68: u32), (96: u32), (84: u32), (48: u32), (95: u32), (54: u32), (45: u32), (32: u32), (89: u32), (100: u32), (109: u32), (19: u32), (37: u32), (41: u32), (19: u32), (98: u32), (53: u32), (114: u32), (107: u32), (66: u32), (6: u32), (74: u32), (13: u32), (19: u32), (105: u32), (64: u32), (123: u32), (28: u32), (44: u32), (50: u32), (89: u32), (58: u32), (123: u32), (126: u32), (21: u32), (43: u32), (86: u32), (35: u32), (21: u32), (62: u32), (82: u32), (0: u32), (108: u32), (120: u32), (72: u32), (72: u32), (62: u32), (80: u32), (12: u32), (71: u32), (70: u32), (86: u32), (116: u32), (73: u32), (38: u32), (15: u32), (127: u32), (81: u32), (30: u32), (8: u32), (125: u32), (28: u32), (26: u32), (69: u32), (114: u32), (63: u32), (27: u32), (28: u32), (61: u32), (42: u32), (13: u32), (32: u32));
-  let (sorted: Array<u32, 100: u32>) = (std::array::sort<u32, 100: u32> as λ(Array<u32, 100: u32>) -> Array<u32, 100: u32>)(arr);
-  let (expected: Array<u32, 100: u32>) = (#_mkArray returning Array<u32, 100: u32>)((0: u32), (0: u32), (2: u32), (3: u32), (5: u32), (6: u32), (8: u32), (12: u32), (13: u32), (13: u32), (15: u32), (19: u32), (19: u32), (19: u32), (21: u32), (21: u32), (26: u32), (26: u32), (27: u32), (28: u32), (28: u32), (28: u32), (29: u32), (30: u32), (32: u32), (32: u32), (35: u32), (37: u32), (38: u32), (41: u32), (42: u32), (42: u32), (42: u32), (43: u32), (44: u32), (44: u32), (45: u32), (47: u32), (48: u32), (48: u32), (50: u32), (50: u32), (53: u32), (54: u32), (54: u32), (58: u32), (61: u32), (62: u32), (62: u32), (63: u32), (64: u32), (66: u32), (66: u32), (68: u32), (69: u32), (70: u32), (70: u32), (71: u32), (71: u32), (72: u32), (72: u32), (73: u32), (74: u32), (80: u32), (80: u32), (81: u32), (81: u32), (82: u32), (84: u32), (84: u32), (86: u32), (86: u32), (87: u32), (89: u32), (89: u32), (89: u32), (93: u32), (95: u32), (96: u32), (98: u32), (100: u32), (104: u32), (105: u32), (106: u32), (107: u32), (108: u32), (109: u32), (114: u32), (114: u32), (116: u32), (118: u32), (119: u32), (120: u32), (121: u32), (123: u32), (123: u32), (123: u32), (125: u32), (126: u32), (127: u32));
+  let mut arr = (#_mkArray returning Array<u32, 100: u32>)((42: u32), (123: u32), (87: u32), (93: u32), (48: u32), (80: u32), (50: u32), (5: u32), (104: u32), (84: u32), (70: u32), (47: u32), (119: u32), (66: u32), (71: u32), (121: u32), (3: u32), (29: u32), (42: u32), (118: u32), (2: u32), (54: u32), (89: u32), (44: u32), (81: u32), (0: u32), (26: u32), (106: u32), (68: u32), (96: u32), (84: u32), (48: u32), (95: u32), (54: u32), (45: u32), (32: u32), (89: u32), (100: u32), (109: u32), (19: u32), (37: u32), (41: u32), (19: u32), (98: u32), (53: u32), (114: u32), (107: u32), (66: u32), (6: u32), (74: u32), (13: u32), (19: u32), (105: u32), (64: u32), (123: u32), (28: u32), (44: u32), (50: u32), (89: u32), (58: u32), (123: u32), (126: u32), (21: u32), (43: u32), (86: u32), (35: u32), (21: u32), (62: u32), (82: u32), (0: u32), (108: u32), (120: u32), (72: u32), (72: u32), (62: u32), (80: u32), (12: u32), (71: u32), (70: u32), (86: u32), (116: u32), (73: u32), (38: u32), (15: u32), (127: u32), (81: u32), (30: u32), (8: u32), (125: u32), (28: u32), (26: u32), (69: u32), (114: u32), (63: u32), (27: u32), (28: u32), (61: u32), (42: u32), (13: u32), (32: u32));
+  let sorted = (std::array::sort<u32, 100: u32> as λ(Array<u32, 100: u32>) -> Array<u32, 100: u32>)(arr);
+  let expected = (#_mkArray returning Array<u32, 100: u32>)((0: u32), (0: u32), (2: u32), (3: u32), (5: u32), (6: u32), (8: u32), (12: u32), (13: u32), (13: u32), (15: u32), (19: u32), (19: u32), (19: u32), (21: u32), (21: u32), (26: u32), (26: u32), (27: u32), (28: u32), (28: u32), (28: u32), (29: u32), (30: u32), (32: u32), (32: u32), (35: u32), (37: u32), (38: u32), (41: u32), (42: u32), (42: u32), (42: u32), (43: u32), (44: u32), (44: u32), (45: u32), (47: u32), (48: u32), (48: u32), (50: u32), (50: u32), (53: u32), (54: u32), (54: u32), (58: u32), (61: u32), (62: u32), (62: u32), (63: u32), (64: u32), (66: u32), (66: u32), (68: u32), (69: u32), (70: u32), (70: u32), (71: u32), (71: u32), (72: u32), (72: u32), (73: u32), (74: u32), (80: u32), (80: u32), (81: u32), (81: u32), (82: u32), (84: u32), (84: u32), (86: u32), (86: u32), (87: u32), (89: u32), (89: u32), (89: u32), (93: u32), (95: u32), (96: u32), (98: u32), (100: u32), (104: u32), (105: u32), (106: u32), (107: u32), (108: u32), (109: u32), (114: u32), (114: u32), (116: u32), (118: u32), (119: u32), (120: u32), (121: u32), (123: u32), (123: u32), (123: u32), (125: u32), (126: u32), (127: u32));
   (#_assert returning Unit)(((Array<u32, 100: u32> as Eq<>)::eq<> as λ(Array<u32, 100: u32>, Array<u32, 100: u32>) -> bool)(sorted, expected));
   #_skip
 }
 
 noir_def std::array::test::test_sort_100_values_comptime<>() -> Unit := {
-  let (sorted: Array<u32, 100: u32>) = (std::array::sort<u32, 100: u32> as λ(Array<u32, 100: u32>) -> Array<u32, 100: u32>)((arr_with_100_values<> as λ() -> Array<u32, 100: u32>)());
-  (#_assert returning Unit)(((Array<u32, 100: u32> as Eq<>)::eq<> as λ(Array<u32, 100: u32>, Array<u32, 100: u32>) -> bool)(sorted, (expected_with_100_values<> as λ() -> Array<u32, 100: u32>)()));
+  let sorted = (std::array::sort<u32, 100: u32> as λ(Array<u32, 100: u32>) -> Array<u32, 100: u32>)((std::array::test::arr_with_100_values<> as λ() -> Array<u32, 100: u32>)());
+  (#_assert returning Unit)(((Array<u32, 100: u32> as Eq<>)::eq<> as λ(Array<u32, 100: u32>, Array<u32, 100: u32>) -> bool)(sorted, (std::array::test::expected_with_100_values<> as λ() -> Array<u32, 100: u32>)()));
   #_skip
 }
 
 noir_def std::array::test::test_sort_via<>() -> Unit := {
-  let mut (arr: Array<u32, 7: u32>) = (#_mkArray returning Array<u32, 7: u32>)((3: u32), (6: u32), (8: u32), (10: u32), (1: u32), (2: u32), (1: u32));
-  let (sorted: Array<u32, 7: u32>) = (std::array::sort_via<u32, 7: u32, Unit> as λ(Array<u32, 7: u32>, λ(u32, u32) -> bool) -> Array<u32, 7: u32>)(arr, (std::array::test::sort_u32<> as λ(u32, u32) -> bool));
-  let (expected: Array<u32, 7: u32>) = (#_mkArray returning Array<u32, 7: u32>)((1: u32), (1: u32), (2: u32), (3: u32), (6: u32), (8: u32), (10: u32));
+  let mut arr = (#_mkArray returning Array<u32, 7: u32>)((3: u32), (6: u32), (8: u32), (10: u32), (1: u32), (2: u32), (1: u32));
+  let sorted = (std::array::sort_via<u32, 7: u32, Unit> as λ(Array<u32, 7: u32>, λ(u32, u32) -> bool) -> Array<u32, 7: u32>)(arr, (std::array::test::sort_u32<> as λ(u32, u32) -> bool));
+  let expected = (#_mkArray returning Array<u32, 7: u32>)((1: u32), (1: u32), (2: u32), (3: u32), (6: u32), (8: u32), (10: u32));
   (#_assert returning Unit)(((Array<u32, 7: u32> as Eq<>)::eq<> as λ(Array<u32, 7: u32>, Array<u32, 7: u32>) -> bool)(sorted, expected));
   #_skip
 }
 
 noir_def std::array::test::test_sort_via_100_values<>() -> Unit := {
-  let mut (arr: Array<u32, 100: u32>) = (#_mkArray returning Array<u32, 100: u32>)((42: u32), (123: u32), (87: u32), (93: u32), (48: u32), (80: u32), (50: u32), (5: u32), (104: u32), (84: u32), (70: u32), (47: u32), (119: u32), (66: u32), (71: u32), (121: u32), (3: u32), (29: u32), (42: u32), (118: u32), (2: u32), (54: u32), (89: u32), (44: u32), (81: u32), (0: u32), (26: u32), (106: u32), (68: u32), (96: u32), (84: u32), (48: u32), (95: u32), (54: u32), (45: u32), (32: u32), (89: u32), (100: u32), (109: u32), (19: u32), (37: u32), (41: u32), (19: u32), (98: u32), (53: u32), (114: u32), (107: u32), (66: u32), (6: u32), (74: u32), (13: u32), (19: u32), (105: u32), (64: u32), (123: u32), (28: u32), (44: u32), (50: u32), (89: u32), (58: u32), (123: u32), (126: u32), (21: u32), (43: u32), (86: u32), (35: u32), (21: u32), (62: u32), (82: u32), (0: u32), (108: u32), (120: u32), (72: u32), (72: u32), (62: u32), (80: u32), (12: u32), (71: u32), (70: u32), (86: u32), (116: u32), (73: u32), (38: u32), (15: u32), (127: u32), (81: u32), (30: u32), (8: u32), (125: u32), (28: u32), (26: u32), (69: u32), (114: u32), (63: u32), (27: u32), (28: u32), (61: u32), (42: u32), (13: u32), (32: u32));
-  let (sorted: Array<u32, 100: u32>) = (std::array::sort_via<u32, 100: u32, Unit> as λ(Array<u32, 100: u32>, λ(u32, u32) -> bool) -> Array<u32, 100: u32>)(arr, (std::array::test::sort_u32<> as λ(u32, u32) -> bool));
-  let (expected: Array<u32, 100: u32>) = (#_mkArray returning Array<u32, 100: u32>)((0: u32), (0: u32), (2: u32), (3: u32), (5: u32), (6: u32), (8: u32), (12: u32), (13: u32), (13: u32), (15: u32), (19: u32), (19: u32), (19: u32), (21: u32), (21: u32), (26: u32), (26: u32), (27: u32), (28: u32), (28: u32), (28: u32), (29: u32), (30: u32), (32: u32), (32: u32), (35: u32), (37: u32), (38: u32), (41: u32), (42: u32), (42: u32), (42: u32), (43: u32), (44: u32), (44: u32), (45: u32), (47: u32), (48: u32), (48: u32), (50: u32), (50: u32), (53: u32), (54: u32), (54: u32), (58: u32), (61: u32), (62: u32), (62: u32), (63: u32), (64: u32), (66: u32), (66: u32), (68: u32), (69: u32), (70: u32), (70: u32), (71: u32), (71: u32), (72: u32), (72: u32), (73: u32), (74: u32), (80: u32), (80: u32), (81: u32), (81: u32), (82: u32), (84: u32), (84: u32), (86: u32), (86: u32), (87: u32), (89: u32), (89: u32), (89: u32), (93: u32), (95: u32), (96: u32), (98: u32), (100: u32), (104: u32), (105: u32), (106: u32), (107: u32), (108: u32), (109: u32), (114: u32), (114: u32), (116: u32), (118: u32), (119: u32), (120: u32), (121: u32), (123: u32), (123: u32), (123: u32), (125: u32), (126: u32), (127: u32));
+  let mut arr = (#_mkArray returning Array<u32, 100: u32>)((42: u32), (123: u32), (87: u32), (93: u32), (48: u32), (80: u32), (50: u32), (5: u32), (104: u32), (84: u32), (70: u32), (47: u32), (119: u32), (66: u32), (71: u32), (121: u32), (3: u32), (29: u32), (42: u32), (118: u32), (2: u32), (54: u32), (89: u32), (44: u32), (81: u32), (0: u32), (26: u32), (106: u32), (68: u32), (96: u32), (84: u32), (48: u32), (95: u32), (54: u32), (45: u32), (32: u32), (89: u32), (100: u32), (109: u32), (19: u32), (37: u32), (41: u32), (19: u32), (98: u32), (53: u32), (114: u32), (107: u32), (66: u32), (6: u32), (74: u32), (13: u32), (19: u32), (105: u32), (64: u32), (123: u32), (28: u32), (44: u32), (50: u32), (89: u32), (58: u32), (123: u32), (126: u32), (21: u32), (43: u32), (86: u32), (35: u32), (21: u32), (62: u32), (82: u32), (0: u32), (108: u32), (120: u32), (72: u32), (72: u32), (62: u32), (80: u32), (12: u32), (71: u32), (70: u32), (86: u32), (116: u32), (73: u32), (38: u32), (15: u32), (127: u32), (81: u32), (30: u32), (8: u32), (125: u32), (28: u32), (26: u32), (69: u32), (114: u32), (63: u32), (27: u32), (28: u32), (61: u32), (42: u32), (13: u32), (32: u32));
+  let sorted = (std::array::sort_via<u32, 100: u32, Unit> as λ(Array<u32, 100: u32>, λ(u32, u32) -> bool) -> Array<u32, 100: u32>)(arr, (std::array::test::sort_u32<> as λ(u32, u32) -> bool));
+  let expected = (#_mkArray returning Array<u32, 100: u32>)((0: u32), (0: u32), (2: u32), (3: u32), (5: u32), (6: u32), (8: u32), (12: u32), (13: u32), (13: u32), (15: u32), (19: u32), (19: u32), (19: u32), (21: u32), (21: u32), (26: u32), (26: u32), (27: u32), (28: u32), (28: u32), (28: u32), (29: u32), (30: u32), (32: u32), (32: u32), (35: u32), (37: u32), (38: u32), (41: u32), (42: u32), (42: u32), (42: u32), (43: u32), (44: u32), (44: u32), (45: u32), (47: u32), (48: u32), (48: u32), (50: u32), (50: u32), (53: u32), (54: u32), (54: u32), (58: u32), (61: u32), (62: u32), (62: u32), (63: u32), (64: u32), (66: u32), (66: u32), (68: u32), (69: u32), (70: u32), (70: u32), (71: u32), (71: u32), (72: u32), (72: u32), (73: u32), (74: u32), (80: u32), (80: u32), (81: u32), (81: u32), (82: u32), (84: u32), (84: u32), (86: u32), (86: u32), (87: u32), (89: u32), (89: u32), (89: u32), (93: u32), (95: u32), (96: u32), (98: u32), (100: u32), (104: u32), (105: u32), (106: u32), (107: u32), (108: u32), (109: u32), (114: u32), (114: u32), (116: u32), (118: u32), (119: u32), (120: u32), (121: u32), (123: u32), (123: u32), (123: u32), (125: u32), (126: u32), (127: u32));
   (#_assert returning Unit)(((Array<u32, 100: u32> as Eq<>)::eq<> as λ(Array<u32, 100: u32>, Array<u32, 100: u32>) -> bool)(sorted, expected));
   #_skip
 }
 
 noir_def std::array::test::mapi_empty<>() -> Unit := {
-  (#_assert returning Unit)(((Array<u32, 0: u32> as Eq<>)::eq<> as λ(Array<u32, 0: u32>, Array<u32, 0: u32>) -> bool)((std::array::mapi<u32, 0: u32, Unit> as λ(Array<u32, 0: u32>, λ(u32, u32) -> u32) -> Array<u32, 0: u32>)((#_mkArray returning Array<u32, 0: u32>)(), (fn((i: u32), (x: u32)): u32 := (#_uAdd returning u32)((#_uMul returning u32)(i, x), (1: u32)))), (#_mkArray returning Array<u32, 0: u32>)()));
+  (#_assert returning Unit)(((Array<u32, 0: u32> as Eq<>)::eq<> as λ(Array<u32, 0: u32>, Array<u32, 0: u32>) -> bool)((std::array::mapi<u32, 0: u32, Unit> as λ(Array<u32, 0: u32>, λ(u32, u32) -> u32) -> Array<u32, 0: u32>)((#_mkArray returning Array<u32, 0: u32>)(), (fn(i: u32, x: u32): u32 := (#_uAdd returning u32)((#_uMul returning u32)(i, x), (1: u32)))), (#_mkArray returning Array<u32, 0: u32>)()));
   #_skip
 }
 
 noir_def std::array::test::for_each_empty<>() -> Unit := {
-  let (empty_array: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
-  (std::array::for_each<Field, 0: u32, Unit> as λ(Array<Field, 0: u32>, λ(Field) -> Unit) -> Unit)(empty_array, (fn((_x: Field)): Unit := (#_assert returning Unit)(#_false)));
+  let empty_array = (#_mkArray returning Array<Field, 0: u32>)();
+  (std::array::for_each<Field, 0: u32, Unit> as λ(Array<Field, 0: u32>, λ(Field) -> Unit) -> Unit)(empty_array, (fn(_x: Field): Unit := (#_assert returning Unit)(#_false)));
   #_skip
 }
 
 noir_def std::array::test::for_eachi_empty<>() -> Unit := {
-  let (empty_array: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
-  (std::array::for_eachi<Field, 0: u32, Unit> as λ(Array<Field, 0: u32>, λ(u32, Field) -> Unit) -> Unit)(empty_array, (fn((_i: u32), (_x: Field)): Unit := (#_assert returning Unit)(#_false)));
+  let empty_array = (#_mkArray returning Array<Field, 0: u32>)();
+  (std::array::for_eachi<Field, 0: u32, Unit> as λ(Array<Field, 0: u32>, λ(u32, Field) -> Unit) -> Unit)(empty_array, (fn(_i: u32, _x: Field): Unit := (#_assert returning Unit)(#_false)));
   #_skip
 }
 
 noir_def std::array::test::map_example<>() -> Unit := {
-  let (a: Array<Field, 3: u32>) = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
-  let (b: Array<Field, 3: u32>) = (std::array::map<Field, 3: u32, Unit> as λ(Array<Field, 3: u32>, λ(Field) -> Field) -> Array<Field, 3: u32>)(a, (fn((a: Field)): Field := (#_fMul returning Field)(a, (2: Field))));
+  let a = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
+  let b = (std::array::map<Field, 3: u32, Unit> as λ(Array<Field, 3: u32>, λ(Field) -> Field) -> Array<Field, 3: u32>)(a, (fn(a: Field): Field := (#_fMul returning Field)(a, (2: Field))));
   (#_assert returning Unit)(((Array<Field, 3: u32> as Eq<>)::eq<> as λ(Array<Field, 3: u32>, Array<Field, 3: u32>) -> bool)(b, (#_mkArray returning Array<Field, 3: u32>)((2: Field), (4: Field), (6: Field))));
   #_skip
 }
 
 noir_def std::array::test::mapi_example<>() -> Unit := {
-  let (a: Array<u32, 3: u32>) = (#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32));
-  let (b: Array<u32, 3: u32>) = (std::array::mapi<u32, 3: u32, Unit> as λ(Array<u32, 3: u32>, λ(u32, u32) -> u32) -> Array<u32, 3: u32>)(a, (fn((i: u32), (a: u32)): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(a, (2: u32)))));
+  let a = (#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32));
+  let b = (std::array::mapi<u32, 3: u32, Unit> as λ(Array<u32, 3: u32>, λ(u32, u32) -> u32) -> Array<u32, 3: u32>)(a, (fn(i: u32, a: u32): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(a, (2: u32)))));
   (#_assert returning Unit)(((Array<u32, 3: u32> as Eq<>)::eq<> as λ(Array<u32, 3: u32>, Array<u32, 3: u32>) -> bool)(b, (#_mkArray returning Array<u32, 3: u32>)((2: u32), (5: u32), (8: u32))));
   #_skip
 }
 
 noir_def std::array::test::for_each_example<>() -> Unit := {
-  let (a: Array<Field, 3: u32>) = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
-  let mut (b: Array<Field, 3: u32>) = (#_mkArray returning Array<Field, 3: u32>)((0: Field), (0: Field), (0: Field));
-  let (b_ref: & Array<Field, 3: u32>) = (#_ref returning & Array<Field, 3: u32>)(b);
-  let mut (i: u32) = (0: u32);
-  let (i_ref: & u32) = (#_ref returning & u32)(i);
-  (std::array::for_each<Field, 3: u32, Tuple<& u32, & Array<Field, 3: u32> > > as λ(Array<Field, 3: u32>, λ(Field) -> Unit) -> Unit)(a, (fn((x: Field)): Unit := {
+  let a = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
+  let mut b = (#_mkArray returning Array<Field, 3: u32>)((0: Field), (0: Field), (0: Field));
+  let b_ref = (#_ref returning & Array<Field, 3: u32>)(b);
+  let mut i = (0: u32);
+  let i_ref = (#_ref returning & u32)(i);
+  (std::array::for_each<Field, 3: u32, Tuple<& u32, & Array<Field, 3: u32> > > as λ(Array<Field, 3: u32>, λ(Field) -> Unit) -> Unit)(a, (fn(x: Field): Unit := {
     {
-      let (i_2925: Unit) = (#_readRef returning u32)(i_ref);
+      let i_2925 = (#_readRef returning u32)(i_ref);
       ((*b_ref: Array<Field, 3: u32>)[i_2925]: Field) = (#_fMul returning Field)(x, (2: Field));
       #_skip
     };
@@ -242,10 +242,10 @@ noir_def std::array::test::for_each_example<>() -> Unit := {
 }
 
 noir_def std::array::test::for_eachi_example<>() -> Unit := {
-  let (a: Array<u32, 3: u32>) = (#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32));
-  let mut (b: Array<u32, 3: u32>) = (#_mkArray returning Array<u32, 3: u32>)((0: u32), (0: u32), (0: u32));
-  let (b_ref: & Array<u32, 3: u32>) = (#_ref returning & Array<u32, 3: u32>)(b);
-  (std::array::for_eachi<u32, 3: u32, Tuple<& Array<u32, 3: u32> > > as λ(Array<u32, 3: u32>, λ(u32, u32) -> Unit) -> Unit)(a, (fn((i: u32), (a: u32)): Unit := {
+  let a = (#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32));
+  let mut b = (#_mkArray returning Array<u32, 3: u32>)((0: u32), (0: u32), (0: u32));
+  let b_ref = (#_ref returning & Array<u32, 3: u32>)(b);
+  (std::array::for_eachi<u32, 3: u32, Tuple<& Array<u32, 3: u32> > > as λ(Array<u32, 3: u32>, λ(u32, u32) -> Unit) -> Unit)(a, (fn(i: u32, a: u32): Unit := {
     ((*b_ref: Array<u32, 3: u32>)[i]: u32) = (#_uAdd returning u32)(i, (#_uMul returning u32)(a, (2: u32)));
     #_skip
   }));
@@ -254,33 +254,33 @@ noir_def std::array::test::for_eachi_example<>() -> Unit := {
 }
 
 noir_def std::array::test::concat<>() -> Unit := {
-  let (arr1: Array<Field, 4: u32>) = (#_mkArray returning Array<Field, 4: u32>)((1: Field), (2: Field), (3: Field), (4: Field));
-  let (arr2: Array<Field, 6: u32>) = (#_mkArray returning Array<Field, 6: u32>)((6: Field), (7: Field), (8: Field), (9: Field), (10: Field), (11: Field));
-  let (concatenated_arr: Array<Field, (4 + 6): u32>) = (std::array::concat<Field, 4: u32, 6: u32> as λ(Array<Field, 4: u32>, Array<Field, 6: u32>) -> Array<Field, (4 + 6): u32>)(arr1, arr2);
+  let arr1 = (#_mkArray returning Array<Field, 4: u32>)((1: Field), (2: Field), (3: Field), (4: Field));
+  let arr2 = (#_mkArray returning Array<Field, 6: u32>)((6: Field), (7: Field), (8: Field), (9: Field), (10: Field), (11: Field));
+  let concatenated_arr = (std::array::concat<Field, 4: u32, 6: u32> as λ(Array<Field, 4: u32>, Array<Field, 6: u32>) -> Array<Field, (4 + 6): u32>)(arr1, arr2);
   (#_assert returning Unit)(((Array<Field, (4 + 6): u32> as Eq<>)::eq<> as λ(Array<Field, (4 + 6): u32>, Array<Field, 10: u32>) -> bool)(concatenated_arr, (#_mkArray returning Array<Field, 10: u32>)((1: Field), (2: Field), (3: Field), (4: Field), (6: Field), (7: Field), (8: Field), (9: Field), (10: Field), (11: Field))));
   #_skip
 }
 
 noir_def std::array::test::concat_zero_length_with_something<>() -> Unit := {
-  let (arr1: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
-  let (arr2: Array<Field, 1: u32>) = (#_mkArray returning Array<Field, 1: u32>)((1: Field));
-  let (concatenated_arr: Array<Field, (0 + 1): u32>) = (std::array::concat<Field, 0: u32, 1: u32> as λ(Array<Field, 0: u32>, Array<Field, 1: u32>) -> Array<Field, (0 + 1): u32>)(arr1, arr2);
+  let arr1 = (#_mkArray returning Array<Field, 0: u32>)();
+  let arr2 = (#_mkArray returning Array<Field, 1: u32>)((1: Field));
+  let concatenated_arr = (std::array::concat<Field, 0: u32, 1: u32> as λ(Array<Field, 0: u32>, Array<Field, 1: u32>) -> Array<Field, (0 + 1): u32>)(arr1, arr2);
   (#_assert returning Unit)(((Array<Field, (0 + 1): u32> as Eq<>)::eq<> as λ(Array<Field, (0 + 1): u32>, Array<Field, 1: u32>) -> bool)(concatenated_arr, (#_mkArray returning Array<Field, 1: u32>)((1: Field))));
   #_skip
 }
 
 noir_def std::array::test::concat_something_with_zero_length<>() -> Unit := {
-  let (arr1: Array<Field, 1: u32>) = (#_mkArray returning Array<Field, 1: u32>)((1: Field));
-  let (arr2: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
-  let (concatenated_arr: Array<Field, (1 + 0): u32>) = (std::array::concat<Field, 1: u32, 0: u32> as λ(Array<Field, 1: u32>, Array<Field, 0: u32>) -> Array<Field, (1 + 0): u32>)(arr1, arr2);
+  let arr1 = (#_mkArray returning Array<Field, 1: u32>)((1: Field));
+  let arr2 = (#_mkArray returning Array<Field, 0: u32>)();
+  let concatenated_arr = (std::array::concat<Field, 1: u32, 0: u32> as λ(Array<Field, 1: u32>, Array<Field, 0: u32>) -> Array<Field, (1 + 0): u32>)(arr1, arr2);
   (#_assert returning Unit)(((Array<Field, (1 + 0): u32> as Eq<>)::eq<> as λ(Array<Field, (1 + 0): u32>, Array<Field, 1: u32>) -> bool)(concatenated_arr, (#_mkArray returning Array<Field, 1: u32>)((1: Field))));
   #_skip
 }
 
 noir_def std::array::test::concat_zero_lengths<>() -> Unit := {
-  let (arr1: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
-  let (arr2: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
-  let (concatenated_arr: Array<Field, (0 + 0): u32>) = (std::array::concat<Field, 0: u32> as λ(Array<Field, 0: u32>, Array<Field, 0: u32>) -> Array<Field, (0 + 0): u32>)(arr1, arr2);
+  let arr1 = (#_mkArray returning Array<Field, 0: u32>)();
+  let arr2 = (#_mkArray returning Array<Field, 0: u32>)();
+  let concatenated_arr = (std::array::concat<Field, 0: u32> as λ(Array<Field, 0: u32>, Array<Field, 0: u32>) -> Array<Field, (0 + 0): u32>)(arr1, arr2);
   (#_assert returning Unit)(((Array<Field, (0 + 0): u32> as Eq<>)::eq<> as λ(Array<Field, (0 + 0): u32>, Array<Field, 0: u32>) -> bool)(concatenated_arr, (#_mkArray returning Array<Field, 0: u32>)()));
   #_skip
 }

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Cmp.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Cmp.lean
@@ -88,7 +88,7 @@ noir_trait_impl[impl_90]<> std::cmp::Eq<> for bool where [] := {
 
 noir_trait_impl[impl_91]<N: u32, T: Type> std::cmp::Eq<> for Array<T, N: u32> where [T: std::cmp::Eq<>] := {
   noir_def eq<>(self: Array<T, N: u32>, other: Array<T, N: u32>) -> bool := {
-    let mut (result: bool) = #_true;
+    let mut result = #_true;
     for i in (0: u32) .. (#_arrayLen returning u32)(self) do {
       result = (#_bAnd returning bool)(result, ((T as std::cmp::Eq<>)::eq<> as λ(T, T) -> bool)((#_arrayIndex returning T)(self, (#_cast returning u32)(i)), (#_arrayIndex returning T)(other, (#_cast returning u32)(i))));
       #_skip
@@ -99,7 +99,7 @@ noir_trait_impl[impl_91]<N: u32, T: Type> std::cmp::Eq<> for Array<T, N: u32> wh
 
 noir_trait_impl[impl_92]<T: Type> std::cmp::Eq<> for Slice<T> where [T: std::cmp::Eq<>] := {
   noir_def eq<>(self: Slice<T>, other: Slice<T>) -> bool := {
-    let mut (result: bool) = (#_uEq returning bool)((#_arrayLen returning u32)(self), (#_arrayLen returning u32)(other));
+    let mut result = (#_uEq returning bool)((#_arrayLen returning u32)(self), (#_arrayLen returning u32)(other));
     if result then {
       for i in (0: u32) .. (#_arrayLen returning u32)(self) do {
         result = (#_bAnd returning bool)(result, ((T as std::cmp::Eq<>)::eq<> as λ(T, T) -> bool)((#_sliceIndex returning T)(self, (#_cast returning u32)(i)), (#_sliceIndex returning T)(other, (#_cast returning u32)(i))));
@@ -113,8 +113,8 @@ noir_trait_impl[impl_92]<T: Type> std::cmp::Eq<> for Slice<T> where [T: std::cmp
 
 noir_trait_impl[impl_93]<N: u32> std::cmp::Eq<> for String<N: u32> where [] := {
   noir_def eq<>(self: String<N: u32>, other: String<N: u32>) -> bool := {
-    let (self_bytes: Array<u8, N: u32>) = (#_strAsBytes returning Array<u8, N: u32>)(self);
-    let (other_bytes: Array<u8, N: u32>) = (#_strAsBytes returning Array<u8, N: u32>)(other);
+    let self_bytes = (#_strAsBytes returning Array<u8, N: u32>)(self);
+    let other_bytes = (#_strAsBytes returning Array<u8, N: u32>)(other);
     ((Array<u8, N: u32> as Eq<>)::eq<> as λ(Array<u8, N: u32>, Array<u8, N: u32>) -> bool)(self_bytes, other_bytes)
   };
 }
@@ -293,7 +293,7 @@ noir_trait_impl[impl_109]<> std::cmp::Ord<> for bool where [] := {
 
 noir_trait_impl[impl_110]<N: u32, T: Type> std::cmp::Ord<> for Array<T, N: u32> where [T: std::cmp::Ord<>] := {
   noir_def cmp<>(self: Array<T, N: u32>, other: Array<T, N: u32>) -> std::cmp::Ordering<> := {
-    let mut (result: std::cmp::Ordering<>) = (std::cmp::Ordering::equal<> as λ() -> std::cmp::Ordering<>)();
+    let mut result = (std::cmp::Ordering::equal<> as λ() -> std::cmp::Ordering<>)();
     for i in (0: u32) .. (#_arrayLen returning u32)(self) do {
       if ((std::cmp::Ordering<> as Eq<>)::eq<> as λ(std::cmp::Ordering<>, std::cmp::Ordering<>) -> bool)(result, (std::cmp::Ordering::equal<> as λ() -> std::cmp::Ordering<>)()) then {
         result = ((T as std::cmp::Ord<>)::cmp<> as λ(T, T) -> std::cmp::Ordering<>)((#_arrayIndex returning T)(self, (#_cast returning u32)(i)), (#_arrayIndex returning T)(other, (#_cast returning u32)(i)));
@@ -306,7 +306,7 @@ noir_trait_impl[impl_110]<N: u32, T: Type> std::cmp::Ord<> for Array<T, N: u32> 
 
 noir_trait_impl[impl_111]<T: Type> std::cmp::Ord<> for Slice<T> where [T: std::cmp::Ord<>] := {
   noir_def cmp<>(self: Slice<T>, other: Slice<T>) -> std::cmp::Ordering<> := {
-    let mut (result: std::cmp::Ordering<>) = ((u32 as std::cmp::Ord<>)::cmp<> as λ(u32, u32) -> std::cmp::Ordering<>)((#_arrayLen returning u32)(self), (#_arrayLen returning u32)(other));
+    let mut result = ((u32 as std::cmp::Ord<>)::cmp<> as λ(u32, u32) -> std::cmp::Ordering<>)((#_arrayLen returning u32)(self), (#_arrayLen returning u32)(other));
     for i in (0: u32) .. (#_arrayLen returning u32)(self) do {
       if ((std::cmp::Ordering<> as Eq<>)::eq<> as λ(std::cmp::Ordering<>, std::cmp::Ordering<>) -> bool)(result, (std::cmp::Ordering::equal<> as λ() -> std::cmp::Ordering<>)()) then {
         result = ((T as std::cmp::Ord<>)::cmp<> as λ(T, T) -> std::cmp::Ordering<>)((#_sliceIndex returning T)(self, (#_cast returning u32)(i)), (#_sliceIndex returning T)(other, (#_cast returning u32)(i)));
@@ -319,7 +319,7 @@ noir_trait_impl[impl_111]<T: Type> std::cmp::Ord<> for Slice<T> where [T: std::c
 
 noir_trait_impl[impl_112]<A: Type, B: Type> std::cmp::Ord<> for Tuple<A, B> where [A: std::cmp::Ord<>, B: std::cmp::Ord<>] := {
   noir_def cmp<>(self: Tuple<A, B>, other: Tuple<A, B>) -> std::cmp::Ordering<> := {
-    let (result: std::cmp::Ordering<>) = ((A as std::cmp::Ord<>)::cmp<> as λ(A, A) -> std::cmp::Ordering<>)(self.0, other.0);
+    let result = ((A as std::cmp::Ord<>)::cmp<> as λ(A, A) -> std::cmp::Ordering<>)(self.0, other.0);
     if ((std::cmp::Ordering<> as Eq<>)::eq<> as λ(std::cmp::Ordering<>, std::cmp::Ordering<>) -> bool)(result, (std::cmp::Ordering::equal<> as λ() -> std::cmp::Ordering<>)()) then {
       result
     } else {
@@ -330,7 +330,7 @@ noir_trait_impl[impl_112]<A: Type, B: Type> std::cmp::Ord<> for Tuple<A, B> wher
 
 noir_trait_impl[impl_113]<A: Type, B: Type, C: Type> std::cmp::Ord<> for Tuple<A, B, C> where [A: std::cmp::Ord<>, B: std::cmp::Ord<>, C: std::cmp::Ord<>] := {
   noir_def cmp<>(self: Tuple<A, B, C>, other: Tuple<A, B, C>) -> std::cmp::Ordering<> := {
-    let mut (result: std::cmp::Ordering<>) = ((A as std::cmp::Ord<>)::cmp<> as λ(A, A) -> std::cmp::Ordering<>)(self.0, other.0);
+    let mut result = ((A as std::cmp::Ord<>)::cmp<> as λ(A, A) -> std::cmp::Ordering<>)(self.0, other.0);
     if ((std::cmp::Ordering<> as Eq<>)::eq<> as λ(std::cmp::Ordering<>, std::cmp::Ordering<>) -> bool)(result, (std::cmp::Ordering::equal<> as λ() -> std::cmp::Ordering<>)()) then {
       result = ((B as std::cmp::Ord<>)::cmp<> as λ(B, B) -> std::cmp::Ordering<>)(self.1, other.1);
       #_skip
@@ -345,7 +345,7 @@ noir_trait_impl[impl_113]<A: Type, B: Type, C: Type> std::cmp::Ord<> for Tuple<A
 
 noir_trait_impl[impl_114]<A: Type, B: Type, C: Type, D: Type> std::cmp::Ord<> for Tuple<A, B, C, D> where [A: std::cmp::Ord<>, B: std::cmp::Ord<>, C: std::cmp::Ord<>, D: std::cmp::Ord<>] := {
   noir_def cmp<>(self: Tuple<A, B, C, D>, other: Tuple<A, B, C, D>) -> std::cmp::Ordering<> := {
-    let mut (result: std::cmp::Ordering<>) = ((A as std::cmp::Ord<>)::cmp<> as λ(A, A) -> std::cmp::Ordering<>)(self.0, other.0);
+    let mut result = ((A as std::cmp::Ord<>)::cmp<> as λ(A, A) -> std::cmp::Ordering<>)(self.0, other.0);
     if ((std::cmp::Ordering<> as Eq<>)::eq<> as λ(std::cmp::Ordering<>, std::cmp::Ordering<>) -> bool)(result, (std::cmp::Ordering::equal<> as λ() -> std::cmp::Ordering<>)()) then {
       result = ((B as std::cmp::Ord<>)::cmp<> as λ(B, B) -> std::cmp::Ordering<>)(self.1, other.1);
       #_skip
@@ -364,7 +364,7 @@ noir_trait_impl[impl_114]<A: Type, B: Type, C: Type, D: Type> std::cmp::Ord<> fo
 
 noir_trait_impl[impl_115]<A: Type, B: Type, C: Type, D: Type, E: Type> std::cmp::Ord<> for Tuple<A, B, C, D, E> where [A: std::cmp::Ord<>, B: std::cmp::Ord<>, C: std::cmp::Ord<>, D: std::cmp::Ord<>, E: std::cmp::Ord<>] := {
   noir_def cmp<>(self: Tuple<A, B, C, D, E>, other: Tuple<A, B, C, D, E>) -> std::cmp::Ordering<> := {
-    let mut (result: std::cmp::Ordering<>) = ((A as std::cmp::Ord<>)::cmp<> as λ(A, A) -> std::cmp::Ordering<>)(self.0, other.0);
+    let mut result = ((A as std::cmp::Ord<>)::cmp<> as λ(A, A) -> std::cmp::Ordering<>)(self.0, other.0);
     if ((std::cmp::Ordering<> as Eq<>)::eq<> as λ(std::cmp::Ordering<>, std::cmp::Ordering<>) -> bool)(result, (std::cmp::Ordering::equal<> as λ() -> std::cmp::Ordering<>)()) then {
       result = ((B as std::cmp::Ord<>)::cmp<> as λ(B, B) -> std::cmp::Ordering<>)(self.1, other.1);
       #_skip
@@ -418,8 +418,8 @@ noir_def std::cmp::cmp_tests::sanity_check_max<>() -> Unit := {
 }
 
 noir_def std::cmp::cmp_tests::correctly_handles_unequal_length_slices<>() -> Unit := {
-  let (slice_1: Slice<Field>) = (#_mkSlice returning Slice<Field>)((0: Field), (1: Field), (2: Field), (3: Field));
-  let (slice_2: Slice<Field>) = (#_mkSlice returning Slice<Field>)((0: Field), (1: Field), (2: Field));
+  let slice_1 = (#_mkSlice returning Slice<Field>)((0: Field), (1: Field), (2: Field), (3: Field));
+  let slice_2 = (#_mkSlice returning Slice<Field>)((0: Field), (1: Field), (2: Field));
   (#_assert returning Unit)((#_bNot returning bool)(((Slice<Field> as std::cmp::Eq<>)::eq<> as λ(Slice<Field>, Slice<Field>) -> bool)(slice_1, slice_2)));
   #_skip
 }

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/BoundedVec.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/BoundedVec.lean
@@ -9,7 +9,7 @@ namespace «std-1.0.0-beta.11»
 namespace Extracted
 
 noir_def std::collections::bounded_vec::BoundedVec::new<T: Type, MaxLen: u32>() -> std::collections::bounded_vec::BoundedVec<T, MaxLen: u32> := {
-  let (zeroed: T) = (#_zeroed returning T)();
+  let zeroed = (#_zeroed returning T)();
   (#_makeData returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)((#_mkRepeatedArray returning Array<T, MaxLen: u32>)(zeroed), (0: u32))
 }
 
@@ -35,7 +35,7 @@ noir_def std::collections::bounded_vec::BoundedVec::set_unchecked<T: Type, MaxLe
 noir_def std::collections::bounded_vec::BoundedVec::push<T: Type, MaxLen: u32>(self: & std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, elem: T) -> Unit := {
   (#_assert returning Unit)((#_uLt returning bool)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, uConst!(MaxLen: u32)));
   {
-    let (i_3517: Unit) = (#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1;
+    let i_3517 = (#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1;
     (((*self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>).0: Array<T, MaxLen: u32>)[i_3517]: T) = elem;
     #_skip
   };
@@ -56,10 +56,10 @@ noir_def std::collections::bounded_vec::BoundedVec::storage<T: Type, MaxLen: u32
 }
 
 noir_def std::collections::bounded_vec::BoundedVec::extend_from_array<T: Type, MaxLen: u32, Len: u32>(self: & std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, array: Array<T, Len: u32>) -> Unit := {
-  let (new_len: u32) = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, (#_arrayLen returning u32)(array));
+  let new_len = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, (#_arrayLen returning u32)(array));
   (#_assert returning Unit)((#_uLeq returning bool)(new_len, uConst!(MaxLen: u32)));
   for i in (0: u32) .. (#_arrayLen returning u32)(array) do {
-    let (i_3525: Unit) = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, i);
+    let i_3525 = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, i);
     (((*self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>).0: Array<T, MaxLen: u32>)[i_3525]: T) = (#_arrayIndex returning T)(array, (#_cast returning u32)(i));
     #_skip
   };
@@ -68,10 +68,10 @@ noir_def std::collections::bounded_vec::BoundedVec::extend_from_array<T: Type, M
 }
 
 noir_def std::collections::bounded_vec::BoundedVec::extend_from_slice<T: Type, MaxLen: u32>(self: & std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, slice: Slice<T>) -> Unit := {
-  let (new_len: u32) = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, (#_arrayLen returning u32)(slice));
+  let new_len = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, (#_arrayLen returning u32)(slice));
   (#_assert returning Unit)((#_uLeq returning bool)(new_len, uConst!(MaxLen: u32)));
   for i in (0: u32) .. (#_arrayLen returning u32)(slice) do {
-    let (i_3529: Unit) = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, i);
+    let i_3529 = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, i);
     (((*self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>).0: Array<T, MaxLen: u32>)[i_3529]: T) = (#_sliceIndex returning T)(slice, (#_cast returning u32)(i));
     #_skip
   };
@@ -80,22 +80,22 @@ noir_def std::collections::bounded_vec::BoundedVec::extend_from_slice<T: Type, M
 }
 
 noir_def std::collections::bounded_vec::BoundedVec::extend_from_bounded_vec<T: Type, MaxLen: u32, Len: u32>(self: & std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, vec: std::collections::bounded_vec::BoundedVec<T, Len: u32>) -> Unit := {
-  let (append_len: u32) = (std::collections::bounded_vec::BoundedVec::len<T, Len: u32> as λ(std::collections::bounded_vec::BoundedVec<T, Len: u32>) -> u32)(vec);
-  let (new_len: u32) = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, append_len);
+  let append_len = (std::collections::bounded_vec::BoundedVec::len<T, Len: u32> as λ(std::collections::bounded_vec::BoundedVec<T, Len: u32>) -> u32)(vec);
+  let new_len = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, append_len);
   (#_assert returning Unit)((#_uLeq returning bool)(new_len, uConst!(MaxLen: u32)));
   if (#_isUnconstrained returning bool)() then {
     for i in (0: u32) .. append_len do {
-      let (i_3535: Unit) = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, i);
+      let i_3535 = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, i);
       (((*self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>).0: Array<T, MaxLen: u32>)[i_3535]: T) = (std::collections::bounded_vec::BoundedVec::get_unchecked<T, Len: u32> as λ(std::collections::bounded_vec::BoundedVec<T, Len: u32>, u32) -> T)(vec, i);
       #_skip
     };
     #_skip
   } else {
-    let mut (exceeded_len: bool) = #_false;
+    let mut exceeded_len = #_false;
     for i in (0: u32) .. uConst!(Len: u32) do {
       exceeded_len = (#_bOr returning bool)(exceeded_len, (#_uEq returning bool)(i, append_len));
       if (#_bNot returning bool)(exceeded_len) then {
-        let (i_3538: Unit) = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, i);
+        let i_3538 = (#_uAdd returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, i);
         (((*self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>).0: Array<T, MaxLen: u32>)[i_3538]: T) = (std::collections::bounded_vec::BoundedVec::get_unchecked<T, Len: u32> as λ(std::collections::bounded_vec::BoundedVec<T, Len: u32>, u32) -> T)(vec, i);
         #_skip
       }
@@ -108,7 +108,7 @@ noir_def std::collections::bounded_vec::BoundedVec::extend_from_bounded_vec<T: T
 
 noir_def std::collections::bounded_vec::BoundedVec::from_array<T: Type, MaxLen: u32, Len: u32>(array: Array<T, Len: u32>) -> std::collections::bounded_vec::BoundedVec<T, MaxLen: u32> := {
   (#_staticAssert returning Unit)((#_uLeq returning bool)(uConst!(Len: u32), uConst!(MaxLen: u32)), "from array out of bounds");
-  let mut (vec: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<T, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)();
+  let mut vec = (std::collections::bounded_vec::BoundedVec::new<T, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)();
   (std::collections::bounded_vec::BoundedVec::extend_from_array<T, MaxLen: u32, Len: u32> as λ(& std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, Array<T, Len: u32>) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(vec), array);
   vec
 }
@@ -116,9 +116,9 @@ noir_def std::collections::bounded_vec::BoundedVec::from_array<T: Type, MaxLen: 
 noir_def std::collections::bounded_vec::BoundedVec::pop<T: Type, MaxLen: u32>(self: & std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> T := {
   (#_assert returning Unit)((#_uGt returning bool)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, (0: u32)));
   ((*self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>).1: u32) = (#_uSub returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1, (1: u32));
-  let (elem: T) = (#_arrayIndex returning T)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).0, (#_cast returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1));
+  let elem = (#_arrayIndex returning T)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).0, (#_cast returning u32)((#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1));
   {
-    let (i_3544: Unit) = (#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1;
+    let i_3544 = (#_readRef returning std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>)(self).1;
     (((*self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>).0: Array<T, MaxLen: u32>)[i_3544]: T) = (#_zeroed returning T)();
     #_skip
   };
@@ -126,7 +126,7 @@ noir_def std::collections::bounded_vec::BoundedVec::pop<T: Type, MaxLen: u32>(se
 }
 
 noir_def std::collections::bounded_vec::BoundedVec::any<T: Type, MaxLen: u32, Env: Type>(self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, predicate: λ(T) -> bool) -> bool := {
-  let mut (ret: bool) = #_false;
+  let mut ret = #_false;
   if (#_isUnconstrained returning bool)() then {
     for i in (0: u32) .. self.1 do {
       ret = (#_bOr returning bool)(ret, (predicate as λ(T) -> bool)((#_arrayIndex returning T)(self.0, (#_cast returning u32)(i))));
@@ -134,7 +134,7 @@ noir_def std::collections::bounded_vec::BoundedVec::any<T: Type, MaxLen: u32, En
     };
     #_skip
   } else {
-    let mut (exceeded_len: bool) = #_false;
+    let mut exceeded_len = #_false;
     for i in (0: u32) .. uConst!(MaxLen: u32) do {
       exceeded_len = (#_bOr returning bool)(exceeded_len, (#_uEq returning bool)(i, self.1));
       if (#_bNot returning bool)(exceeded_len) then {
@@ -148,7 +148,7 @@ noir_def std::collections::bounded_vec::BoundedVec::any<T: Type, MaxLen: u32, En
 }
 
 noir_def std::collections::bounded_vec::BoundedVec::map<T: Type, MaxLen: u32, U: Type, Env: Type>(self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, f: λ(T) -> U) -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32> := {
-  let mut (ret: std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<U, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
+  let mut ret = (std::collections::bounded_vec::BoundedVec::new<U, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
   (ret.1: u32) = (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self);
   if (#_isUnconstrained returning bool)() then {
     for i in (0: u32) .. (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self) do {
@@ -169,7 +169,7 @@ noir_def std::collections::bounded_vec::BoundedVec::map<T: Type, MaxLen: u32, U:
 }
 
 noir_def std::collections::bounded_vec::BoundedVec::mapi<T: Type, MaxLen: u32, U: Type, Env: Type>(self: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, f: λ(u32, T) -> U) -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32> := {
-  let mut (ret: std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<U, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
+  let mut ret = (std::collections::bounded_vec::BoundedVec::new<U, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
   (ret.1: u32) = (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self);
   if (#_isUnconstrained returning bool)() then {
     for i in (0: u32) .. (std::collections::bounded_vec::BoundedVec::len<T, MaxLen: u32> as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>) -> u32)(self) do {
@@ -227,7 +227,7 @@ noir_def std::collections::bounded_vec::BoundedVec::for_eachi<T: Type, MaxLen: u
 
 noir_def std::collections::bounded_vec::BoundedVec::from_parts<T: Type, MaxLen: u32>(mut array: Array<T, MaxLen: u32>, len: u32) -> std::collections::bounded_vec::BoundedVec<T, MaxLen: u32> := {
   (#_assert returning Unit)((#_uLeq returning bool)(len, uConst!(MaxLen: u32)));
-  let (zeroed: T) = (#_zeroed returning T)();
+  let zeroed = (#_zeroed returning T)();
   if (#_isUnconstrained returning bool)() then {
     for i in len .. uConst!(MaxLen: u32) do {
       (array[i]: T) = zeroed;
@@ -268,13 +268,13 @@ noir_trait_impl[impl_33]<Len: u32, T: Type, MaxLen: u32> std::convert::From<Arra
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::get::panics_when_reading_elements_past_end_of_vec<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<Field, 5: u32>) = (std::collections::bounded_vec::BoundedVec::new<Field, 5: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 5: u32>)();
-  let (_: Field) = (std::collections::bounded_vec::BoundedVec::get<Field, 5: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32) -> Field)(vec, (0: u32));
+  let vec = (std::collections::bounded_vec::BoundedVec::new<Field, 5: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 5: u32>)();
+  let _ = (std::collections::bounded_vec::BoundedVec::get<Field, 5: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32) -> Field)(vec, (0: u32));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::set::set_updates_values_properly<>() -> Unit := {
-  let mut (vec: std::collections::bounded_vec::BoundedVec<Field, 5: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 5: u32> as λ(Array<Field, 5: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 5: u32>)((#_mkArray returning Array<Field, 5: u32>)((0: Field), (0: Field), (0: Field), (0: Field), (0: Field)));
+  let mut vec = (std::collections::bounded_vec::BoundedVec::from_array<Field, 5: u32> as λ(Array<Field, 5: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 5: u32>)((#_mkArray returning Array<Field, 5: u32>)((0: Field), (0: Field), (0: Field), (0: Field), (0: Field)));
   (std::collections::bounded_vec::BoundedVec::set<Field, 5: u32> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (0: u32), (42: Field));
   (#_assert returning Unit)(((Array<Field, 5: u32> as Eq<>)::eq<> as λ(Array<Field, 5: u32>, Array<Field, 5: u32>) -> bool)(vec.0, (#_mkArray returning Array<Field, 5: u32>)((42: Field), (0: Field), (0: Field), (0: Field), (0: Field))));
   (std::collections::bounded_vec::BoundedVec::set<Field, 5: u32> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (1: u32), (43: Field));
@@ -289,102 +289,102 @@ noir_def std::collections::bounded_vec::bounded_vec_tests::set::set_updates_valu
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::set::panics_when_writing_elements_past_end_of_vec<>() -> Unit := {
-  let mut (vec: std::collections::bounded_vec::BoundedVec<Field, 5: u32>) = (std::collections::bounded_vec::BoundedVec::new<Field, 5: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 5: u32>)();
+  let mut vec = (std::collections::bounded_vec::BoundedVec::new<Field, 5: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 5: u32>)();
   (std::collections::bounded_vec::BoundedVec::set<Field, 5: u32> as λ(& std::collections::bounded_vec::BoundedVec<Field, 5: u32>, u32, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 5: u32>)(vec), (0: u32), (42: Field));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::any::returns_false_if_predicate_not_satisfied<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<bool, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<bool, 4: u32> as λ(Array<bool, 4: u32>) -> std::collections::bounded_vec::BoundedVec<bool, 4: u32>)((#_mkArray returning Array<bool, 4: u32>)(#_false, #_false, #_false, #_false));
-  let (result: bool) = (std::collections::bounded_vec::BoundedVec::any<bool, 4: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<bool, 4: u32>, λ(bool) -> bool) -> bool)(vec, (fn((value: bool)): bool := value));
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<bool, 4: u32> as λ(Array<bool, 4: u32>) -> std::collections::bounded_vec::BoundedVec<bool, 4: u32>)((#_mkArray returning Array<bool, 4: u32>)(#_false, #_false, #_false, #_false));
+  let result = (std::collections::bounded_vec::BoundedVec::any<bool, 4: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<bool, 4: u32>, λ(bool) -> bool) -> bool)(vec, (fn(value: bool): bool := value));
   (#_assert returning Unit)((#_bNot returning bool)(result));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::any::returns_true_if_predicate_satisfied<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<bool, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<bool, 4: u32> as λ(Array<bool, 4: u32>) -> std::collections::bounded_vec::BoundedVec<bool, 4: u32>)((#_mkArray returning Array<bool, 4: u32>)(#_false, #_false, #_true, #_true));
-  let (result: bool) = (std::collections::bounded_vec::BoundedVec::any<bool, 4: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<bool, 4: u32>, λ(bool) -> bool) -> bool)(vec, (fn((value: bool)): bool := value));
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<bool, 4: u32> as λ(Array<bool, 4: u32>) -> std::collections::bounded_vec::BoundedVec<bool, 4: u32>)((#_mkArray returning Array<bool, 4: u32>)(#_false, #_false, #_true, #_true));
+  let result = (std::collections::bounded_vec::BoundedVec::any<bool, 4: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<bool, 4: u32>, λ(bool) -> bool) -> bool)(vec, (fn(value: bool): bool := value));
   (#_assert returning Unit)(result);
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::any::returns_false_on_empty_boundedvec<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<bool, 0: u32>) = (std::collections::bounded_vec::BoundedVec::new<bool, 0: u32> as λ() -> std::collections::bounded_vec::BoundedVec<bool, 0: u32>)();
-  let (result: bool) = (std::collections::bounded_vec::BoundedVec::any<bool, 0: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<bool, 0: u32>, λ(bool) -> bool) -> bool)(vec, (fn((value: bool)): bool := value));
+  let vec = (std::collections::bounded_vec::BoundedVec::new<bool, 0: u32> as λ() -> std::collections::bounded_vec::BoundedVec<bool, 0: u32>)();
+  let result = (std::collections::bounded_vec::BoundedVec::any<bool, 0: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<bool, 0: u32>, λ(bool) -> bool) -> bool)(vec, (fn(value: bool): bool := value));
   (#_assert returning Unit)((#_bNot returning bool)(result));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::map::applies_function_correctly<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::map<u32, 4: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn((value: u32)): u32 := (#_uMul returning u32)(value, (2: u32))));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (4: u32), (6: u32), (8: u32)));
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+  let result = (std::collections::bounded_vec::BoundedVec::map<u32, 4: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn(value: u32): u32 := (#_uMul returning u32)(value, (2: u32))));
+  let expected = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (4: u32), (6: u32), (8: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::map::applies_function_that_changes_return_type<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::map<u32, 4: u32, Field, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn((value: u32)): Field := (#_cast returning Field)((#_uMul returning u32)(value, (2: u32)))));
-  let (expected: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (4: Field), (6: Field), (8: Field)));
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+  let result = (std::collections::bounded_vec::BoundedVec::map<u32, 4: u32, Field, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn(value: u32): Field := (#_cast returning Field)((#_uMul returning u32)(value, (2: u32)))));
+  let expected = (std::collections::bounded_vec::BoundedVec::from_array<Field, 4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (4: Field), (6: Field), (8: Field)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<Field, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<Field, 4: u32>, std::collections::bounded_vec::BoundedVec<Field, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::map::does_not_apply_function_past_len<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::map<u32, 3: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn((value: u32)): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
+  let result = (std::collections::bounded_vec::BoundedVec::map<u32, 3: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn(value: u32): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
     (5: u32)
   } else {
     value
   }));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
+  let expected = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 3: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, std::collections::bounded_vec::BoundedVec<u32, 3: u32>) -> bool)(result, expected));
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::get_unchecked<u32, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, u32) -> u32)(result, (2: u32)), (0: u32)));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::mapi::applies_function_correctly<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::mapi<u32, 4: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn((i: u32), (value: u32)): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32)))));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (5: u32), (8: u32), (11: u32)));
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+  let result = (std::collections::bounded_vec::BoundedVec::mapi<u32, 4: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn(i: u32, value: u32): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32)))));
+  let expected = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (5: u32), (8: u32), (11: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::mapi::applies_function_that_changes_return_type<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::mapi<u32, 4: u32, Field, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn((i: u32), (value: u32)): Field := (#_cast returning Field)((#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32))))));
-  let (expected: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (5: Field), (8: Field), (11: Field)));
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+  let result = (std::collections::bounded_vec::BoundedVec::mapi<u32, 4: u32, Field, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn(i: u32, value: u32): Field := (#_cast returning Field)((#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32))))));
+  let expected = (std::collections::bounded_vec::BoundedVec::from_array<Field, 4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (5: Field), (8: Field), (11: Field)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<Field, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<Field, 4: u32>, std::collections::bounded_vec::BoundedVec<Field, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::mapi::does_not_apply_function_past_len<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::mapi<u32, 3: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn((_: u32), (value: u32)): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
+  let result = (std::collections::bounded_vec::BoundedVec::mapi<u32, 3: u32, Unit> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn(_: u32, value: u32): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
     (5: u32)
   } else {
     value
   }));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
+  let expected = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 3: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, std::collections::bounded_vec::BoundedVec<u32, 3: u32>) -> bool)(result, expected));
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::get_unchecked<u32, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, u32) -> u32)(result, (2: u32)), (0: u32)));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::for_each::for_each_map<T: Type, U: Type, Env: Type, MaxLen: u32>(input: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, f: λ(T) -> U) -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32> := {
-  let mut (output: std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<U, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
-  let (output_ref: & std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (#_ref returning & std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)(output);
-  (std::collections::bounded_vec::BoundedVec::for_each<T, MaxLen: u32, Tuple<& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, λ(T) -> U> > as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, λ(T) -> Unit) -> Unit)(input, (fn((x: T)): Unit := (std::collections::bounded_vec::BoundedVec::push<U, MaxLen: u32> as λ(& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, U) -> Unit)(output_ref, (f as λ(T) -> U)(x))));
+  let mut output = (std::collections::bounded_vec::BoundedVec::new<U, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
+  let output_ref = (#_ref returning & std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)(output);
+  (std::collections::bounded_vec::BoundedVec::for_each<T, MaxLen: u32, Tuple<& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, λ(T) -> U> > as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, λ(T) -> Unit) -> Unit)(input, (fn(x: T): Unit := (std::collections::bounded_vec::BoundedVec::push<U, MaxLen: u32> as λ(& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, U) -> Unit)(output_ref, (f as λ(T) -> U)(x))));
   output
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::for_each::smoke_test<>() -> Unit := {
-  let mut (acc: u32) = (0: u32);
-  let (acc_ref: & u32) = (#_ref returning & u32)(acc);
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32> as λ(Array<u32, 3: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32)));
-  (std::collections::bounded_vec::BoundedVec::for_each<u32, 3: u32, Tuple<& u32> > as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32) -> Unit) -> Unit)(vec, (fn((value: u32)): Unit := {
+  let mut acc = (0: u32);
+  let acc_ref = (#_ref returning & u32)(acc);
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32> as λ(Array<u32, 3: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32)));
+  (std::collections::bounded_vec::BoundedVec::for_each<u32, 3: u32, Tuple<& u32> > as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32) -> Unit) -> Unit)(vec, (fn(value: u32): Unit := {
     (*acc_ref: u32) = (#_uAdd returning u32)((#_readRef returning u32)(acc_ref), value);
     #_skip
   }));
@@ -393,46 +393,46 @@ noir_def std::collections::bounded_vec::bounded_vec_tests::for_each::smoke_test<
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::for_each::applies_function_correctly<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::bounded_vec_tests::for_each::for_each_map<u32, Unit, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn((value: u32)): u32 := (#_uMul returning u32)(value, (2: u32))));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (4: u32), (6: u32), (8: u32)));
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+  let result = (std::collections::bounded_vec::bounded_vec_tests::for_each::for_each_map<u32, Unit, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn(value: u32): u32 := (#_uMul returning u32)(value, (2: u32))));
+  let expected = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (4: u32), (6: u32), (8: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::for_each::applies_function_that_changes_return_type<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::bounded_vec_tests::for_each::for_each_map<u32, Field, Unit, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn((value: u32)): Field := (#_cast returning Field)((#_uMul returning u32)(value, (2: u32)))));
-  let (expected: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (4: Field), (6: Field), (8: Field)));
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+  let result = (std::collections::bounded_vec::bounded_vec_tests::for_each::for_each_map<u32, Field, Unit, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn(value: u32): Field := (#_cast returning Field)((#_uMul returning u32)(value, (2: u32)))));
+  let expected = (std::collections::bounded_vec::BoundedVec::from_array<Field, 4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (4: Field), (6: Field), (8: Field)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<Field, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<Field, 4: u32>, std::collections::bounded_vec::BoundedVec<Field, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::for_each::does_not_apply_function_past_len<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::bounded_vec_tests::for_each::for_each_map<u32, Unit, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn((value: u32)): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
+  let result = (std::collections::bounded_vec::bounded_vec_tests::for_each::for_each_map<u32, Unit, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn(value: u32): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
     (5: u32)
   } else {
     value
   }));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
+  let expected = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 3: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, std::collections::bounded_vec::BoundedVec<u32, 3: u32>) -> bool)(result, expected));
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::get_unchecked<u32, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, u32) -> u32)(result, (2: u32)), (0: u32)));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi<T: Type, U: Type, Env: Type, MaxLen: u32>(input: std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, f: λ(u32, T) -> U) -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32> := {
-  let mut (output: std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (std::collections::bounded_vec::BoundedVec::new<U, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
-  let (output_ref: & std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>) = (#_ref returning & std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)(output);
-  (std::collections::bounded_vec::BoundedVec::for_eachi<T, MaxLen: u32, Tuple<& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, λ(u32, T) -> U> > as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, λ(u32, T) -> Unit) -> Unit)(input, (fn((i: u32), (x: T)): Unit := (std::collections::bounded_vec::BoundedVec::push<U, MaxLen: u32> as λ(& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, U) -> Unit)(output_ref, (f as λ(u32, T) -> U)(i, x))));
+  let mut output = (std::collections::bounded_vec::BoundedVec::new<U, MaxLen: u32> as λ() -> std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)();
+  let output_ref = (#_ref returning & std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>)(output);
+  (std::collections::bounded_vec::BoundedVec::for_eachi<T, MaxLen: u32, Tuple<& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, λ(u32, T) -> U> > as λ(std::collections::bounded_vec::BoundedVec<T, MaxLen: u32>, λ(u32, T) -> Unit) -> Unit)(input, (fn(i: u32, x: T): Unit := (std::collections::bounded_vec::BoundedVec::push<U, MaxLen: u32> as λ(& std::collections::bounded_vec::BoundedVec<U, MaxLen: u32>, U) -> Unit)(output_ref, (f as λ(u32, T) -> U)(i, x))));
   output
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::for_eachi::smoke_test<>() -> Unit := {
-  let mut (acc: u32) = (0: u32);
-  let (acc_ref: & u32) = (#_ref returning & u32)(acc);
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32> as λ(Array<u32, 3: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32)));
-  (std::collections::bounded_vec::BoundedVec::for_eachi<u32, 3: u32, Tuple<& u32> > as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32, u32) -> Unit) -> Unit)(vec, (fn((i: u32), (value: u32)): Unit := {
+  let mut acc = (0: u32);
+  let acc_ref = (#_ref returning & u32)(acc);
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32> as λ(Array<u32, 3: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 3: u32>)((1: u32), (2: u32), (3: u32)));
+  (std::collections::bounded_vec::BoundedVec::for_eachi<u32, 3: u32, Tuple<& u32> > as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32, u32) -> Unit) -> Unit)(vec, (fn(i: u32, value: u32): Unit := {
     (*acc_ref: u32) = (#_uAdd returning u32)((#_readRef returning u32)(acc_ref), (#_uMul returning u32)(i, value));
     #_skip
   }));
@@ -441,37 +441,37 @@ noir_def std::collections::bounded_vec::bounded_vec_tests::for_eachi::smoke_test
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::for_eachi::applies_function_correctly<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi<u32, Unit, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn((i: u32), (value: u32)): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32)))));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (5: u32), (8: u32), (11: u32)));
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+  let result = (std::collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi<u32, Unit, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)(vec, (fn(i: u32, value: u32): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32)))));
+  let expected = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((2: u32), (5: u32), (8: u32), (11: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::for_eachi::applies_function_that_changes_return_type<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi<u32, Field, Unit, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn((i: u32), (value: u32)): Field := (#_cast returning Field)((#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32))))));
-  let (expected: std::collections::bounded_vec::BoundedVec<Field, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (5: Field), (8: Field), (11: Field)));
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 4: u32> as λ(Array<u32, 4: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (4: u32)));
+  let result = (std::collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi<u32, Field, Unit, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, λ(u32, u32) -> Field) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)(vec, (fn(i: u32, value: u32): Field := (#_cast returning Field)((#_uAdd returning u32)(i, (#_uMul returning u32)(value, (2: u32))))));
+  let expected = (std::collections::bounded_vec::BoundedVec::from_array<Field, 4: u32> as λ(Array<Field, 4: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 4: u32>)((#_mkArray returning Array<Field, 4: u32>)((2: Field), (5: Field), (8: Field), (11: Field)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<Field, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<Field, 4: u32>, std::collections::bounded_vec::BoundedVec<Field, 4: u32>) -> bool)(result, expected));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::for_eachi::does_not_apply_function_past_len<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
-  let (result: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi<u32, Unit, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn((_: u32), (value: u32)): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
+  let vec = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((0: u32), (1: u32)));
+  let result = (std::collections::bounded_vec::bounded_vec_tests::for_eachi::for_eachi_mapi<u32, Unit, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, λ(u32, u32) -> u32) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)(vec, (fn(_: u32, value: u32): u32 := if (#_uEq returning bool)(value, (0: u32)) then {
     (5: u32)
   } else {
     value
   }));
-  let (expected: std::collections::bounded_vec::BoundedVec<u32, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
+  let expected = (std::collections::bounded_vec::BoundedVec::from_array<u32, 3: u32, 2: u32> as λ(Array<u32, 2: u32>) -> std::collections::bounded_vec::BoundedVec<u32, 3: u32>)((#_mkArray returning Array<u32, 2: u32>)((5: u32), (1: u32)));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 3: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, std::collections::bounded_vec::BoundedVec<u32, 3: u32>) -> bool)(result, expected));
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::get_unchecked<u32, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 3: u32>, u32) -> u32)(result, (2: u32)), (0: u32)));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::from_array::empty<>() -> Unit := {
-  let (empty_array: Array<Field, 0: u32>) = (#_mkArray returning Array<Field, 0: u32>)();
-  let (bounded_vec: std::collections::bounded_vec::BoundedVec<Field, 0: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 0: u32> as λ(Array<Field, 0: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 0: u32>)((#_mkArray returning Array<Field, 0: u32>)());
+  let empty_array = (#_mkArray returning Array<Field, 0: u32>)();
+  let bounded_vec = (std::collections::bounded_vec::BoundedVec::from_array<Field, 0: u32> as λ(Array<Field, 0: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 0: u32>)((#_mkArray returning Array<Field, 0: u32>)());
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::max_len<Field, 0: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 0: u32>) -> u32)(bounded_vec), (0: u32)));
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<Field, 0: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 0: u32>) -> u32)(bounded_vec), (0: u32)));
   (#_assert returning Unit)(((Array<Field, 0: u32> as Eq<>)::eq<> as λ(Array<Field, 0: u32>, Array<Field, 0: u32>) -> bool)((std::collections::bounded_vec::BoundedVec::storage<Field, 0: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 0: u32>) -> Array<Field, 0: u32>)(bounded_vec), empty_array));
@@ -479,8 +479,8 @@ noir_def std::collections::bounded_vec::bounded_vec_tests::from_array::empty<>()
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::from_array::equal_len<>() -> Unit := {
-  let (array: Array<Field, 3: u32>) = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
-  let (bounded_vec: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 3: u32> as λ(Array<Field, 3: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)(array);
+  let array = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
+  let bounded_vec = (std::collections::bounded_vec::BoundedVec::from_array<Field, 3: u32> as λ(Array<Field, 3: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)(array);
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::max_len<Field, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 3: u32>) -> u32)(bounded_vec), (3: u32)));
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<Field, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 3: u32>) -> u32)(bounded_vec), (3: u32)));
   (#_assert returning Unit)(((Array<Field, 3: u32> as Eq<>)::eq<> as λ(Array<Field, 3: u32>, Array<Field, 3: u32>) -> bool)((std::collections::bounded_vec::BoundedVec::storage<Field, 3: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 3: u32>) -> Array<Field, 3: u32>)(bounded_vec), array));
@@ -488,8 +488,8 @@ noir_def std::collections::bounded_vec::bounded_vec_tests::from_array::equal_len
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::from_array::max_len_greater_then_array_len<>() -> Unit := {
-  let (array: Array<Field, 3: u32>) = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
-  let (bounded_vec: std::collections::bounded_vec::BoundedVec<Field, 10: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 10: u32, 3: u32> as λ(Array<Field, 3: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 10: u32>)(array);
+  let array = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
+  let bounded_vec = (std::collections::bounded_vec::BoundedVec::from_array<Field, 10: u32, 3: u32> as λ(Array<Field, 3: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 10: u32>)(array);
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::max_len<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>) -> u32)(bounded_vec), (10: u32)));
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>) -> u32)(bounded_vec), (3: u32)));
   (#_assert returning Unit)((#_fEq returning bool)((std::collections::bounded_vec::BoundedVec::get<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>, u32) -> Field)(bounded_vec, (0: u32)), (1: Field)));
@@ -499,13 +499,13 @@ noir_def std::collections::bounded_vec::bounded_vec_tests::from_array::max_len_g
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::from_array::max_len_lower_then_array_len<>() -> Unit := {
-  let (_: std::collections::bounded_vec::BoundedVec<Field, 2: u32>) = (std::collections::bounded_vec::BoundedVec::from_array<Field, 2: u32, 3: u32> as λ(Array<Field, 3: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 2: u32>)((#_mkRepeatedArray returning Array<Field, 3: u32>)((0: Field)));
+  let _ = (std::collections::bounded_vec::BoundedVec::from_array<Field, 2: u32, 3: u32> as λ(Array<Field, 3: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 2: u32>)((#_mkRepeatedArray returning Array<Field, 3: u32>)((0: Field)));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::trait_from::simple<>() -> Unit := {
-  let (array: Array<Field, 2: u32>) = (#_mkArray returning Array<Field, 2: u32>)((1: Field), (2: Field));
-  let (bounded_vec: std::collections::bounded_vec::BoundedVec<Field, 10: u32>) = ((std::collections::bounded_vec::BoundedVec<Field, 10: u32> as std::convert::From<Array<Field, 2: u32> >)::«from»<> as λ(Array<Field, 2: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 10: u32>)(array);
+  let array = (#_mkArray returning Array<Field, 2: u32>)((1: Field), (2: Field));
+  let bounded_vec = ((std::collections::bounded_vec::BoundedVec<Field, 10: u32> as std::convert::From<Array<Field, 2: u32> >)::«from»<> as λ(Array<Field, 2: u32>) -> std::collections::bounded_vec::BoundedVec<Field, 10: u32>)(array);
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::max_len<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>) -> u32)(bounded_vec), (10: u32)));
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>) -> u32)(bounded_vec), (2: u32)));
   (#_assert returning Unit)((#_fEq returning bool)((std::collections::bounded_vec::BoundedVec::get<Field, 10: u32> as λ(std::collections::bounded_vec::BoundedVec<Field, 10: u32>, u32) -> Field)(bounded_vec, (0: u32)), (1: Field)));
@@ -514,15 +514,15 @@ noir_def std::collections::bounded_vec::bounded_vec_tests::trait_from::simple<>(
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::trait_eq::empty_equality<>() -> Unit := {
-  let mut (bounded_vec1: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::new<Field, 3: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
-  let mut (bounded_vec2: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::new<Field, 3: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
+  let mut bounded_vec1 = (std::collections::bounded_vec::BoundedVec::new<Field, 3: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
+  let mut bounded_vec2 = (std::collections::bounded_vec::BoundedVec::new<Field, 3: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<Field, 3: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<Field, 3: u32>, std::collections::bounded_vec::BoundedVec<Field, 3: u32>) -> bool)(bounded_vec1, bounded_vec2));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::trait_eq::inequality<>() -> Unit := {
-  let mut (bounded_vec1: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::new<Field, 3: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
-  let mut (bounded_vec2: std::collections::bounded_vec::BoundedVec<Field, 3: u32>) = (std::collections::bounded_vec::BoundedVec::new<Field, 3: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
+  let mut bounded_vec1 = (std::collections::bounded_vec::BoundedVec::new<Field, 3: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
+  let mut bounded_vec2 = (std::collections::bounded_vec::BoundedVec::new<Field, 3: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Field, 3: u32>)();
   (std::collections::bounded_vec::BoundedVec::push<Field, 3: u32> as λ(& std::collections::bounded_vec::BoundedVec<Field, 3: u32>, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 3: u32>)(bounded_vec1), (1: Field));
   (std::collections::bounded_vec::BoundedVec::push<Field, 3: u32> as λ(& std::collections::bounded_vec::BoundedVec<Field, 3: u32>, Field) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Field, 3: u32>)(bounded_vec2), (2: Field));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<Field, 3: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<Field, 3: u32>, std::collections::bounded_vec::BoundedVec<Field, 3: u32>) -> bool)(bounded_vec1, bounded_vec2));
@@ -530,19 +530,19 @@ noir_def std::collections::bounded_vec::bounded_vec_tests::trait_eq::inequality<
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::from_parts::from_parts<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (0: u32)), (3: u32));
+  let vec = (std::collections::bounded_vec::BoundedVec::from_parts<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (0: u32)), (3: u32));
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<u32, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> u32)(vec), (3: u32)));
-  let (vec1: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (1: u32)), (3: u32));
-  let (vec2: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (2: u32)), (3: u32));
+  let vec1 = (std::collections::bounded_vec::BoundedVec::from_parts<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (1: u32)), (3: u32));
+  let vec2 = (std::collections::bounded_vec::BoundedVec::from_parts<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (2: u32)), (3: u32));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> bool)(vec1, vec2));
   #_skip
 }
 
 noir_def std::collections::bounded_vec::bounded_vec_tests::from_parts::from_parts_unchecked<>() -> Unit := {
-  let (vec: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts_unchecked<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (0: u32)), (3: u32));
+  let vec = (std::collections::bounded_vec::BoundedVec::from_parts_unchecked<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (0: u32)), (3: u32));
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<u32, 4: u32> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> u32)(vec), (3: u32)));
-  let (vec1: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts_unchecked<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (1: u32)), (3: u32));
-  let (vec2: std::collections::bounded_vec::BoundedVec<u32, 4: u32>) = (std::collections::bounded_vec::BoundedVec::from_parts_unchecked<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (2: u32)), (3: u32));
+  let vec1 = (std::collections::bounded_vec::BoundedVec::from_parts_unchecked<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (1: u32)), (3: u32));
+  let vec2 = (std::collections::bounded_vec::BoundedVec::from_parts_unchecked<u32, 4: u32> as λ(Array<u32, 4: u32>, u32) -> std::collections::bounded_vec::BoundedVec<u32, 4: u32>)((#_mkArray returning Array<u32, 4: u32>)((1: u32), (2: u32), (3: u32), (2: u32)), (3: u32));
   (#_assert returning Unit)(((std::collections::bounded_vec::BoundedVec<u32, 4: u32> as Eq<>)::eq<> as λ(std::collections::bounded_vec::BoundedVec<u32, 4: u32>, std::collections::bounded_vec::BoundedVec<u32, 4: u32>) -> bool)(vec1, vec2));
   #_skip
 }

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/Map.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/Map.lean
@@ -46,8 +46,8 @@ noir_def std::collections::map::Slot::mark_deleted<K: Type, V: Type>(self: & std
 }
 
 noir_def std::collections::map::HashMap::with_hasher<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type>(_build_hasher: B) -> std::collections::map::HashMap<K, V, N: u32, B> := {
-  let (_table: Array<std::collections::map::Slot<K, V>, N: u32>) = (#_mkRepeatedArray returning Array<std::collections::map::Slot<K, V>, N: u32>)(((std::collections::map::Slot<K, V> as std::default::Default<>)::default<> as λ() -> std::collections::map::Slot<K, V>)());
-  let (_len: u32) = (0: u32);
+  let _table = (#_mkRepeatedArray returning Array<std::collections::map::Slot<K, V>, N: u32>)(((std::collections::map::Slot<K, V> as std::default::Default<>)::default<> as λ() -> std::collections::map::Slot<K, V>)());
+  let _len = (0: u32);
   (#_makeData returning std::collections::map::HashMap<K, V, N: u32, B>)(_table, _len, _build_hasher)
 }
 
@@ -66,14 +66,14 @@ noir_def std::collections::map::HashMap::is_empty<K: Type, V: Type, N: u32, B: T
 }
 
 noir_def std::collections::map::HashMap::entries<K: Type, V: Type, N: u32, B: Type>(self: std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32> := {
-  let mut (entries: std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) = (std::collections::bounded_vec::BoundedVec::new<Tuple<K, V>, N: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)();
+  let mut entries = (std::collections::bounded_vec::BoundedVec::new<Tuple<K, V>, N: u32> as λ() -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)();
   {
-    let (ζi0: Array<std::collections::map::Slot<K, V>, N: u32>) = self.0;
+    let ζi0 = self.0;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
+      let slot = (#_arrayIndex returning std::collections::map::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
       {
         if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-          let (key_value: Tuple<K, V>) = (std::option::Option::unwrap_unchecked<Tuple<K, V> > as λ(std::option::Option<Tuple<K, V> >) -> Tuple<K, V>)((std::collections::map::Slot::key_value<K, V> as λ(std::collections::map::Slot<K, V>) -> std::option::Option<Tuple<K, V> >)(slot));
+          let key_value = (std::option::Option::unwrap_unchecked<Tuple<K, V> > as λ(std::option::Option<Tuple<K, V> >) -> Tuple<K, V>)((std::collections::map::Slot::key_value<K, V> as λ(std::collections::map::Slot<K, V>) -> std::option::Option<Tuple<K, V> >)(slot));
           (std::collections::bounded_vec::BoundedVec::push<Tuple<K, V>, N: u32> as λ(& std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>, Tuple<K, V>) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)(entries), key_value);
           #_skip
         }
@@ -81,22 +81,22 @@ noir_def std::collections::map::HashMap::entries<K: Type, V: Type, N: u32, B: Ty
     };
     #_skip
   };
-  let (self_len: u32) = self.1;
-  let (entries_len: u32) = (std::collections::bounded_vec::BoundedVec::len<Tuple<K, V>, N: u32> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) -> u32)(entries);
-  let (msg: FmtString<82: u32, Tuple<u32, u32> >) = (#_mkFormatString returning FmtString<82: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{entries_len}{}.", self_len, entries_len);
+  let self_len = self.1;
+  let entries_len = (std::collections::bounded_vec::BoundedVec::len<Tuple<K, V>, N: u32> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) -> u32)(entries);
+  let msg = (#_mkFormatString returning FmtString<82: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{entries_len}{}.", self_len, entries_len);
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<Tuple<K, V>, N: u32> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) -> u32)(entries), self.1));
   entries
 }
 
 noir_def std::collections::map::HashMap::keys<K: Type, V: Type, N: u32, B: Type>(self: std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<K, N: u32> := {
-  let mut (keys: std::collections::bounded_vec::BoundedVec<K, N: u32>) = (std::collections::bounded_vec::BoundedVec::new<K, N: u32> as λ() -> std::collections::bounded_vec::BoundedVec<K, N: u32>)();
+  let mut keys = (std::collections::bounded_vec::BoundedVec::new<K, N: u32> as λ() -> std::collections::bounded_vec::BoundedVec<K, N: u32>)();
   {
-    let (ζi0: Array<std::collections::map::Slot<K, V>, N: u32>) = self.0;
+    let ζi0 = self.0;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
+      let slot = (#_arrayIndex returning std::collections::map::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
       {
         if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-          let ((key: K), (_: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+          let (key, _) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
           (std::collections::bounded_vec::BoundedVec::push<K, N: u32> as λ(& std::collections::bounded_vec::BoundedVec<K, N: u32>, K) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<K, N: u32>)(keys), key);
           #_skip
         }
@@ -104,22 +104,22 @@ noir_def std::collections::map::HashMap::keys<K: Type, V: Type, N: u32, B: Type>
     };
     #_skip
   };
-  let (self_len: u32) = self.1;
-  let (keys_len: u32) = (std::collections::bounded_vec::BoundedVec::len<K, N: u32> as λ(std::collections::bounded_vec::BoundedVec<K, N: u32>) -> u32)(keys);
-  let (msg: FmtString<79: u32, Tuple<u32, u32> >) = (#_mkFormatString returning FmtString<79: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{keys_len}{}.", self_len, keys_len);
+  let self_len = self.1;
+  let keys_len = (std::collections::bounded_vec::BoundedVec::len<K, N: u32> as λ(std::collections::bounded_vec::BoundedVec<K, N: u32>) -> u32)(keys);
+  let msg = (#_mkFormatString returning FmtString<79: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{keys_len}{}.", self_len, keys_len);
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<K, N: u32> as λ(std::collections::bounded_vec::BoundedVec<K, N: u32>) -> u32)(keys), self.1));
   keys
 }
 
 noir_def std::collections::map::HashMap::values<K: Type, V: Type, N: u32, B: Type>(self: std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<V, N: u32> := {
-  let mut (values: std::collections::bounded_vec::BoundedVec<V, N: u32>) = (std::collections::bounded_vec::BoundedVec::new<V, N: u32> as λ() -> std::collections::bounded_vec::BoundedVec<V, N: u32>)();
+  let mut values = (std::collections::bounded_vec::BoundedVec::new<V, N: u32> as λ() -> std::collections::bounded_vec::BoundedVec<V, N: u32>)();
   {
-    let (ζi0: Array<std::collections::map::Slot<K, V>, N: u32>) = self.0;
+    let ζi0 = self.0;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
+      let slot = (#_arrayIndex returning std::collections::map::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
       {
         if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-          let ((_: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+          let (_, value) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
           (std::collections::bounded_vec::BoundedVec::push<V, N: u32> as λ(& std::collections::bounded_vec::BoundedVec<V, N: u32>, V) -> Unit)((#_ref returning & std::collections::bounded_vec::BoundedVec<V, N: u32>)(values), value);
           #_skip
         }
@@ -127,20 +127,20 @@ noir_def std::collections::map::HashMap::values<K: Type, V: Type, N: u32, B: Typ
     };
     #_skip
   };
-  let (self_len: u32) = self.1;
-  let (values_len: u32) = (std::collections::bounded_vec::BoundedVec::len<V, N: u32> as λ(std::collections::bounded_vec::BoundedVec<V, N: u32>) -> u32)(values);
-  let (msg: FmtString<81: u32, Tuple<u32, u32> >) = (#_mkFormatString returning FmtString<81: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{values_len}{}.", self_len, values_len);
+  let self_len = self.1;
+  let values_len = (std::collections::bounded_vec::BoundedVec::len<V, N: u32> as λ(std::collections::bounded_vec::BoundedVec<V, N: u32>) -> u32)(values);
+  let msg = (#_mkFormatString returning FmtString<81: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{values_len}{}.", self_len, values_len);
   (#_assert returning Unit)((#_uEq returning bool)((std::collections::bounded_vec::BoundedVec::len<V, N: u32> as λ(std::collections::bounded_vec::BoundedVec<V, N: u32>) -> u32)(values), self.1));
   values
 }
 
 noir_def std::collections::map::HashMap::iter_mut<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type>(self: & std::collections::map::HashMap<K, V, N: u32, B>, f: λ(K, V) -> Tuple<K, V>) -> Unit := {
-  let mut (entries: std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) = (std::collections::map::HashMap::entries<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self));
-  let mut (new_map: std::collections::map::HashMap<K, V, N: u32, B>) = (std::collections::map::HashMap::with_hasher<K, V, N: u32, B> as λ(B) -> std::collections::map::HashMap<K, V, N: u32, B>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).2);
+  let mut entries = (std::collections::map::HashMap::entries<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self));
+  let mut new_map = (std::collections::map::HashMap::with_hasher<K, V, N: u32, B> as λ(B) -> std::collections::map::HashMap<K, V, N: u32, B>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).2);
   for i in (0: u32) .. uConst!(N: u32) do {
     if (#_uLt returning bool)(i, (#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).1) then {
-      let (entry: Tuple<K, V>) = (std::collections::bounded_vec::BoundedVec::get_unchecked<Tuple<K, V>, N: u32> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>, u32) -> Tuple<K, V>)(entries, i);
-      let ((key: K), (value: V)) = (f as λ(K, V) -> Tuple<K, V>)(entry.0, entry.1);
+      let entry = (std::collections::bounded_vec::BoundedVec::get_unchecked<Tuple<K, V>, N: u32> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>, u32) -> Tuple<K, V>)(entries, i);
+      let (key, value) = (f as λ(K, V) -> Tuple<K, V>)(entry.0, entry.1);
       (std::collections::map::HashMap::insert<K, V, N: u32, B> as λ(& std::collections::map::HashMap<K, V, N: u32, B>, K, V) -> Unit)((#_ref returning & std::collections::map::HashMap<K, V, N: u32, B>)(new_map), key, value);
       #_skip
     }
@@ -151,12 +151,12 @@ noir_def std::collections::map::HashMap::iter_mut<K: Type, V: Type, N: u32, B: T
 }
 
 noir_def std::collections::map::HashMap::iter_keys_mut<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type>(self: & std::collections::map::HashMap<K, V, N: u32, B>, f: λ(K) -> K) -> Unit := {
-  let mut (entries: std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>) = (std::collections::map::HashMap::entries<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self));
-  let mut (new_map: std::collections::map::HashMap<K, V, N: u32, B>) = (std::collections::map::HashMap::with_hasher<K, V, N: u32, B> as λ(B) -> std::collections::map::HashMap<K, V, N: u32, B>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).2);
+  let mut entries = (std::collections::map::HashMap::entries<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self));
+  let mut new_map = (std::collections::map::HashMap::with_hasher<K, V, N: u32, B> as λ(B) -> std::collections::map::HashMap<K, V, N: u32, B>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).2);
   for i in (0: u32) .. uConst!(N: u32) do {
     if (#_uLt returning bool)(i, (#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).1) then {
-      let (entry: Tuple<K, V>) = (std::collections::bounded_vec::BoundedVec::get_unchecked<Tuple<K, V>, N: u32> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>, u32) -> Tuple<K, V>)(entries, i);
-      let ((key: K), (value: V)) = (#_makeData returning Tuple<K, V>)((f as λ(K) -> K)(entry.0), entry.1);
+      let entry = (std::collections::bounded_vec::BoundedVec::get_unchecked<Tuple<K, V>, N: u32> as λ(std::collections::bounded_vec::BoundedVec<Tuple<K, V>, N: u32>, u32) -> Tuple<K, V>)(entries, i);
+      let (key, value) = (#_makeData returning Tuple<K, V>)((f as λ(K) -> K)(entry.0), entry.1);
       (std::collections::map::HashMap::insert<K, V, N: u32, B> as λ(& std::collections::map::HashMap<K, V, N: u32, B>, K, V) -> Unit)((#_ref returning & std::collections::map::HashMap<K, V, N: u32, B>)(new_map), key, value);
       #_skip
     }
@@ -168,9 +168,9 @@ noir_def std::collections::map::HashMap::iter_keys_mut<K: Type, V: Type, N: u32,
 
 noir_def std::collections::map::HashMap::iter_values_mut<K: Type, V: Type, N: u32, B: Type>(self: & std::collections::map::HashMap<K, V, N: u32, B>, f: λ(V) -> V) -> Unit := {
   for i in (0: u32) .. uConst!(N: u32) do {
-    let mut (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).0, (#_cast returning u32)(i));
+    let mut slot = (#_arrayIndex returning std::collections::map::Slot<K, V>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).0, (#_cast returning u32)(i));
     if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-      let ((key: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+      let (key, value) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
       (std::collections::map::Slot::set<K, V> as λ(& std::collections::map::Slot<K, V>, K, V) -> Unit)((#_ref returning & std::collections::map::Slot<K, V>)(slot), key, (f as λ(V) -> V)(value));
       (((*self: std::collections::map::HashMap<K, V, N: u32, B>).0: Array<std::collections::map::Slot<K, V>, N: u32>)[i]: std::collections::map::Slot<K, V>) = slot;
       #_skip
@@ -181,9 +181,9 @@ noir_def std::collections::map::HashMap::iter_values_mut<K: Type, V: Type, N: u3
 
 noir_def std::collections::map::HashMap::retain<K: Type, V: Type, N: u32, B: Type>(self: & std::collections::map::HashMap<K, V, N: u32, B>, f: λ(K, V) -> bool) -> Unit := {
   for index in (0: u32) .. uConst!(N: u32) do {
-    let mut (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).0, (#_cast returning u32)(index));
+    let mut slot = (#_arrayIndex returning std::collections::map::Slot<K, V>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).0, (#_cast returning u32)(index));
     if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-      let ((key: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+      let (key, value) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
       if (#_bNot returning bool)((f as λ(K, V) -> bool)(key, value)) then {
         (std::collections::map::Slot::mark_deleted<K, V> as λ(& std::collections::map::Slot<K, V>) -> Unit)((#_ref returning & std::collections::map::Slot<K, V>)(slot));
         ((*self: std::collections::map::HashMap<K, V, N: u32, B>).1: u32) = (#_uSub returning u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).1, (1: u32));
@@ -204,15 +204,15 @@ noir_def std::collections::map::HashMap::capacity<K: Type, V: Type, N: u32, B: T
 }
 
 noir_def std::collections::map::HashMap::get<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type>(self: std::collections::map::HashMap<K, V, N: u32, B>, key: K) -> std::option::Option<V> := {
-  let mut (result: std::option::Option<V>) = (std::option::Option::none<V> as λ() -> std::option::Option<V>)();
-  let (hash: u32) = (std::collections::map::HashMap::hash<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> u32)(self, key);
-  let mut (should_break: bool) = #_false;
+  let mut result = (std::option::Option::none<V> as λ() -> std::option::Option<V>)();
+  let hash = (std::collections::map::HashMap::hash<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> u32)(self, key);
+  let mut should_break = #_false;
   for attempt in (0: u32) .. uConst!(N: u32) do {
     if (#_bNot returning bool)(should_break) then {
-      let (index: u32) = (std::collections::map::HashMap::quadratic_probe<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, u32, u32) -> u32)(self, hash, (#_cast returning u32)(attempt));
-      let (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)(self.0, (#_cast returning u32)(index));
+      let index = (std::collections::map::HashMap::quadratic_probe<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, u32, u32) -> u32)(self, hash, (#_cast returning u32)(attempt));
+      let slot = (#_arrayIndex returning std::collections::map::Slot<K, V>)(self.0, (#_cast returning u32)(index));
       if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-        let ((current_key: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+        let (current_key, value) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
         if ((K as Eq<>)::eq<> as λ(K, K) -> bool)(current_key, key) then {
           result = (std::option::Option::some<V> as λ(V) -> std::option::Option<V>)(value);
           should_break = #_true;
@@ -226,19 +226,19 @@ noir_def std::collections::map::HashMap::get<K: Type, V: Type, N: u32, B: Type, 
 
 noir_def std::collections::map::HashMap::insert<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type>(self: & std::collections::map::HashMap<K, V, N: u32, B>, key: K, value: V) -> Unit := {
   (std::collections::map::HashMap::assert_load_factor<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> Unit)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self));
-  let (hash: u32) = (std::collections::map::HashMap::hash<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), key);
-  let mut (should_break: bool) = #_false;
+  let hash = (std::collections::map::HashMap::hash<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), key);
+  let mut should_break = #_false;
   for attempt in (0: u32) .. uConst!(N: u32) do {
     if (#_bNot returning bool)(should_break) then {
-      let (index: u32) = (std::collections::map::HashMap::quadratic_probe<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, u32, u32) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), hash, (#_cast returning u32)(attempt));
-      let mut (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).0, (#_cast returning u32)(index));
-      let mut (insert: bool) = #_false;
+      let index = (std::collections::map::HashMap::quadratic_probe<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, u32, u32) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), hash, (#_cast returning u32)(attempt));
+      let mut slot = (#_arrayIndex returning std::collections::map::Slot<K, V>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).0, (#_cast returning u32)(index));
+      let mut insert = #_false;
       if (std::collections::map::Slot::is_available<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
         insert = #_true;
         ((*self: std::collections::map::HashMap<K, V, N: u32, B>).1: u32) = (#_uAdd returning u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).1, (1: u32));
         #_skip
       } else {
-        let ((current_key: K), (_: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+        let (current_key, _) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
         if ((K as Eq<>)::eq<> as λ(K, K) -> bool)(current_key, key) then {
           insert = #_true;
           #_skip
@@ -256,14 +256,14 @@ noir_def std::collections::map::HashMap::insert<K: Type, V: Type, N: u32, B: Typ
 }
 
 noir_def std::collections::map::HashMap::remove<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type>(self: & std::collections::map::HashMap<K, V, N: u32, B>, key: K) -> Unit := {
-  let (hash: u32) = (std::collections::map::HashMap::hash<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), key);
-  let mut (should_break: bool) = #_false;
+  let hash = (std::collections::map::HashMap::hash<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), key);
+  let mut should_break = #_false;
   for attempt in (0: u32) .. uConst!(N: u32) do {
     if (#_bNot returning bool)(should_break) then {
-      let (index: u32) = (std::collections::map::HashMap::quadratic_probe<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, u32, u32) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), hash, (#_cast returning u32)(attempt));
-      let mut (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).0, (#_cast returning u32)(index));
+      let index = (std::collections::map::HashMap::quadratic_probe<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, u32, u32) -> u32)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self), hash, (#_cast returning u32)(attempt));
+      let mut slot = (#_arrayIndex returning std::collections::map::Slot<K, V>)((#_readRef returning std::collections::map::HashMap<K, V, N: u32, B>)(self).0, (#_cast returning u32)(index));
       if (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot) then {
-        let ((current_key: K), (_: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+        let (current_key, _) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
         if ((K as Eq<>)::eq<> as λ(K, K) -> bool)(current_key, key) then {
           (std::collections::map::Slot::mark_deleted<K, V> as λ(& std::collections::map::Slot<K, V>) -> Unit)((#_ref returning & std::collections::map::Slot<K, V>)(slot));
           (((*self: std::collections::map::HashMap<K, V, N: u32, B>).0: Array<std::collections::map::Slot<K, V>, N: u32>)[index]: std::collections::map::Slot<K, V>) = slot;
@@ -278,7 +278,7 @@ noir_def std::collections::map::HashMap::remove<K: Type, V: Type, N: u32, B: Typ
 }
 
 noir_def std::collections::map::HashMap::hash<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type>(self: std::collections::map::HashMap<K, V, N: u32, B>, key: K) -> u32 := {
-  let mut (hasher: B_as_BuildHasher_H) = ((B as std::hash::BuildHasher<>)::build_hasher<> as λ(B) -> B_as_BuildHasher_H)(self.2);
+  let mut hasher = ((B as std::hash::BuildHasher<>)::build_hasher<> as λ(B) -> B_as_BuildHasher_H)(self.2);
   ((K as std::hash::Hash<>)::hash<B_as_BuildHasher_H> as λ(K, & B_as_BuildHasher_H) -> Unit)(key, (#_ref returning & B_as_BuildHasher_H)(hasher));
   (#_cast returning u32)(((B_as_BuildHasher_H as std::hash::Hasher<>)::finish<> as λ(B_as_BuildHasher_H) -> Field)(hasher))
 }
@@ -288,31 +288,31 @@ noir_def std::collections::map::HashMap::quadratic_probe<K: Type, V: Type, N: u3
 }
 
 noir_def std::collections::map::HashMap::assert_load_factor<K: Type, V: Type, N: u32, B: Type>(self: std::collections::map::HashMap<K, V, N: u32, B>) -> Unit := {
-  let (lhs: u32) = (#_uMul returning u32)(self.1, (MAX_LOAD_FACTOR_DEN0MINATOR<> as λ() -> u32)());
-  let (rhs: u32) = (#_uMul returning u32)((#_arrayLen returning u32)(self.0), (MAX_LOAD_FACTOR_NUMERATOR<> as λ() -> u32)());
-  let (exceeded: bool) = (#_uGeq returning bool)(lhs, rhs);
+  let lhs = (#_uMul returning u32)(self.1, (std::collections::map::MAX_LOAD_FACTOR_DEN0MINATOR<> as λ() -> u32)());
+  let rhs = (#_uMul returning u32)((#_arrayLen returning u32)(self.0), (std::collections::map::MAX_LOAD_FACTOR_NUMERATOR<> as λ() -> u32)());
+  let exceeded = (#_uGeq returning bool)(lhs, rhs);
   (#_assert returning Unit)((#_bNot returning bool)(exceeded));
   #_skip
 }
 
 noir_trait_impl[impl_35]<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type> std::cmp::Eq<> for std::collections::map::HashMap<K, V, N: u32, B> where [K: std::cmp::Eq<>, K: std::hash::Hash<>, V: std::cmp::Eq<>, B: std::hash::BuildHasher<B_as_BuildHasher_H>] := {
   noir_def eq<>(self: std::collections::map::HashMap<K, V, N: u32, B>, other: std::collections::map::HashMap<K, V, N: u32, B>) -> bool := {
-    let mut (equal: bool) = #_false;
+    let mut equal = #_false;
     if (#_uEq returning bool)((std::collections::map::HashMap::len<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> u32)(self), (std::collections::map::HashMap::len<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>) -> u32)(other)) then {
       equal = #_true;
       {
-        let (ζi0: Array<std::collections::map::Slot<K, V>, N: u32>) = self.0;
+        let ζi0 = self.0;
         for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-          let (slot: std::collections::map::Slot<K, V>) = (#_arrayIndex returning std::collections::map::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
+          let slot = (#_arrayIndex returning std::collections::map::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
           {
             if (#_bAnd returning bool)(equal, (std::collections::map::Slot::is_valid<K, V> as λ(std::collections::map::Slot<K, V>) -> bool)(slot)) then {
-              let ((key: K), (value: V)) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
-              let (other_value: std::option::Option<V>) = (std::collections::map::HashMap::get<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> std::option::Option<V>)(other, key);
+              let (key, value) = (std::collections::map::Slot::key_value_unchecked<K, V> as λ(std::collections::map::Slot<K, V>) -> Tuple<K, V>)(slot);
+              let other_value = (std::collections::map::HashMap::get<K, V, N: u32, B> as λ(std::collections::map::HashMap<K, V, N: u32, B>, K) -> std::option::Option<V>)(other, key);
               if (std::option::Option::is_none<V> as λ(std::option::Option<V>) -> bool)(other_value) then {
                 equal = #_false;
                 #_skip
               } else {
-                let (other_value: V) = (std::option::Option::unwrap_unchecked<V> as λ(std::option::Option<V>) -> V)(other_value);
+                let other_value = (std::option::Option::unwrap_unchecked<V> as λ(std::option::Option<V>) -> V)(other_value);
                 if ((V as Eq<>)::eq<> as λ(V, V) -> bool)(value, other_value) then {
                   equal = #_false;
                   #_skip
@@ -330,8 +330,8 @@ noir_trait_impl[impl_35]<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: 
 
 noir_trait_impl[impl_36]<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type> std::default::Default<> for std::collections::map::HashMap<K, V, N: u32, B> where [B: std::hash::BuildHasher<B_as_BuildHasher_H>, B: std::default::Default<>] := {
   noir_def default<>() -> std::collections::map::HashMap<K, V, N: u32, B> := {
-    let (_build_hasher: B) = ((B as std::default::Default<>)::default<> as λ() -> B)();
-    let (map: std::collections::map::HashMap<K, V, N: u32, B>) = (std::collections::map::HashMap::with_hasher<K, V, N: u32, B> as λ(B) -> std::collections::map::HashMap<K, V, N: u32, B>)(_build_hasher);
+    let _build_hasher = ((B as std::default::Default<>)::default<> as λ() -> B)();
+    let map = (std::collections::map::HashMap::with_hasher<K, V, N: u32, B> as λ(B) -> std::collections::map::HashMap<K, V, N: u32, B>)(_build_hasher);
     map
   };
 }

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/Umap.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/Umap.lean
@@ -42,18 +42,18 @@ noir_def std::collections::umap::Slot::mark_deleted<K: Type, V: Type>(self: & st
 }
 
 noir_def std::collections::umap::UHashMap::with_hasher<K: Type, V: Type, B: Type, B_as_BuildHasher_H: Type>(_build_hasher: B) -> std::collections::umap::UHashMap<K, V, B> := {
-  let (_table: Slice<std::collections::umap::Slot<K, V> >) = (#_mkSlice returning Slice<std::collections::umap::Slot<K, V> >)(((std::collections::umap::Slot<K, V> as std::default::Default<>)::default<> as λ() -> std::collections::umap::Slot<K, V>)());
-  let (_len: u32) = (0: u32);
+  let _table = (#_mkSlice returning Slice<std::collections::umap::Slot<K, V> >)(((std::collections::umap::Slot<K, V> as std::default::Default<>)::default<> as λ() -> std::collections::umap::Slot<K, V>)());
+  let _len = (0: u32);
   (#_makeData returning std::collections::umap::UHashMap<K, V, B>)(_table, _len, _build_hasher)
 }
 
 noir_def std::collections::umap::UHashMap::with_hasher_and_capacity<K: Type, V: Type, B: Type, B_as_BuildHasher_H: Type>(_build_hasher: B, capacity: u32) -> std::collections::umap::UHashMap<K, V, B> := {
-  let mut (_table: Slice<std::collections::umap::Slot<K, V> >) = (#_mkSlice returning Slice<std::collections::umap::Slot<K, V> >)();
+  let mut _table = (#_mkSlice returning Slice<std::collections::umap::Slot<K, V> >)();
   for _ in (0: u32) .. capacity do {
     _table = (#_slicePushBack returning Slice<std::collections::umap::Slot<K, V> >)(_table, ((std::collections::umap::Slot<K, V> as std::default::Default<>)::default<> as λ() -> std::collections::umap::Slot<K, V>)());
     #_skip
   };
-  let (_len: u32) = (0: u32);
+  let _len = (0: u32);
   (#_makeData returning std::collections::umap::UHashMap<K, V, B>)(_table, _len, _build_hasher)
 }
 
@@ -74,14 +74,14 @@ noir_def std::collections::umap::UHashMap::is_empty<K: Type, V: Type, B: Type>(s
 }
 
 noir_def std::collections::umap::UHashMap::entries<K: Type, V: Type, B: Type>(self: std::collections::umap::UHashMap<K, V, B>) -> Slice<Tuple<K, V> > := {
-  let mut (entries: Slice<Tuple<K, V> >) = (#_mkSlice returning Slice<Tuple<K, V> >)();
+  let mut entries = (#_mkSlice returning Slice<Tuple<K, V> >)();
   {
-    let (ζi0: Slice<std::collections::umap::Slot<K, V> >) = self.0;
+    let ζi0 = self.0;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (slot: std::collections::umap::Slot<K, V>) = (#_sliceIndex returning std::collections::umap::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
+      let slot = (#_sliceIndex returning std::collections::umap::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
       {
         if (std::collections::umap::Slot::is_valid<K, V> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
-          let (key_value: Tuple<K, V>) = (std::option::Option::unwrap_unchecked<Tuple<K, V> > as λ(std::option::Option<Tuple<K, V> >) -> Tuple<K, V>)((std::collections::umap::Slot::key_value<K, V> as λ(std::collections::umap::Slot<K, V>) -> std::option::Option<Tuple<K, V> >)(slot));
+          let key_value = (std::option::Option::unwrap_unchecked<Tuple<K, V> > as λ(std::option::Option<Tuple<K, V> >) -> Tuple<K, V>)((std::collections::umap::Slot::key_value<K, V> as λ(std::collections::umap::Slot<K, V>) -> std::option::Option<Tuple<K, V> >)(slot));
           entries = (#_slicePushBack returning Slice<Tuple<K, V> >)(entries, key_value);
           #_skip
         }
@@ -89,22 +89,22 @@ noir_def std::collections::umap::UHashMap::entries<K: Type, V: Type, B: Type>(se
     };
     #_skip
   };
-  let (self_len: u32) = self.1;
-  let (entries_len: u32) = (#_arrayLen returning u32)(entries);
-  let (msg: FmtString<82: u32, Tuple<u32, u32> >) = (#_mkFormatString returning FmtString<82: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{entries_len}{}.", self_len, entries_len);
+  let self_len = self.1;
+  let entries_len = (#_arrayLen returning u32)(entries);
+  let msg = (#_mkFormatString returning FmtString<82: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{entries_len}{}.", self_len, entries_len);
   (#_assert returning Unit)((#_uEq returning bool)((#_arrayLen returning u32)(entries), self.1));
   entries
 }
 
 noir_def std::collections::umap::UHashMap::keys<K: Type, V: Type, B: Type>(self: std::collections::umap::UHashMap<K, V, B>) -> Slice<K> := {
-  let mut (keys: Slice<K>) = (#_mkSlice returning Slice<K>)();
+  let mut keys = (#_mkSlice returning Slice<K>)();
   {
-    let (ζi0: Slice<std::collections::umap::Slot<K, V> >) = self.0;
+    let ζi0 = self.0;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (slot: std::collections::umap::Slot<K, V>) = (#_sliceIndex returning std::collections::umap::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
+      let slot = (#_sliceIndex returning std::collections::umap::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
       {
         if (std::collections::umap::Slot::is_valid<K, V> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
-          let ((key: K), (_: V)) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
+          let (key, _) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
           keys = (#_slicePushBack returning Slice<K>)(keys, key);
           #_skip
         }
@@ -112,22 +112,22 @@ noir_def std::collections::umap::UHashMap::keys<K: Type, V: Type, B: Type>(self:
     };
     #_skip
   };
-  let (self_len: u32) = self.1;
-  let (keys_len: u32) = (#_arrayLen returning u32)(keys);
-  let (msg: FmtString<79: u32, Tuple<u32, u32> >) = (#_mkFormatString returning FmtString<79: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{keys_len}{}.", self_len, keys_len);
+  let self_len = self.1;
+  let keys_len = (#_arrayLen returning u32)(keys);
+  let msg = (#_mkFormatString returning FmtString<79: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{keys_len}{}.", self_len, keys_len);
   (#_assert returning Unit)((#_uEq returning bool)((#_arrayLen returning u32)(keys), self.1));
   keys
 }
 
 noir_def std::collections::umap::UHashMap::values<K: Type, V: Type, B: Type>(self: std::collections::umap::UHashMap<K, V, B>) -> Slice<V> := {
-  let mut (values: Slice<V>) = (#_mkSlice returning Slice<V>)();
+  let mut values = (#_mkSlice returning Slice<V>)();
   {
-    let (ζi0: Slice<std::collections::umap::Slot<K, V> >) = self.0;
+    let ζi0 = self.0;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (slot: std::collections::umap::Slot<K, V>) = (#_sliceIndex returning std::collections::umap::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
+      let slot = (#_sliceIndex returning std::collections::umap::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
       {
         if (std::collections::umap::Slot::is_valid<K, V> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
-          let ((_: K), (value: V)) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
+          let (_, value) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
           values = (#_slicePushBack returning Slice<V>)(values, value);
           #_skip
         }
@@ -135,9 +135,9 @@ noir_def std::collections::umap::UHashMap::values<K: Type, V: Type, B: Type>(sel
     };
     #_skip
   };
-  let (self_len: u32) = self.1;
-  let (values_len: u32) = (#_arrayLen returning u32)(values);
-  let (msg: FmtString<81: u32, Tuple<u32, u32> >) = (#_mkFormatString returning FmtString<81: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{values_len}{}.", self_len, values_len);
+  let self_len = self.1;
+  let values_len = (#_arrayLen returning u32)(values);
+  let msg = (#_mkFormatString returning FmtString<81: u32, Tuple<u32, u32> >)("Amount of valid elements should have been {}{self_len}{} times, but got {}{values_len}{}.", self_len, values_len);
   (#_assert returning Unit)((#_uEq returning bool)((#_arrayLen returning u32)(values), self.1));
   values
 }
@@ -152,9 +152,9 @@ noir_def std::collections::umap::UHashMap::iter_keys_mut<K: Type, V: Type, B: Ty
 
 noir_def std::collections::umap::UHashMap::iter_values_mut<K: Type, V: Type, B: Type>(self: & std::collections::umap::UHashMap<K, V, B>, f: λ(V) -> V) -> Unit := {
   for i in (0: u32) .. (#_arrayLen returning u32)((#_readRef returning std::collections::umap::UHashMap<K, V, B>)(self).0) do {
-    let mut (slot: std::collections::umap::Slot<K, V>) = (#_sliceIndex returning std::collections::umap::Slot<K, V>)((#_readRef returning std::collections::umap::UHashMap<K, V, B>)(self).0, (#_cast returning u32)(i));
+    let mut slot = (#_sliceIndex returning std::collections::umap::Slot<K, V>)((#_readRef returning std::collections::umap::UHashMap<K, V, B>)(self).0, (#_cast returning u32)(i));
     if (std::collections::umap::Slot::is_valid<K, V> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
-      let ((key: K), (value: V)) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
+      let (key, value) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
       (std::collections::umap::Slot::set<K, V> as λ(& std::collections::umap::Slot<K, V>, K, V) -> Unit)((#_ref returning & std::collections::umap::Slot<K, V>)(slot), key, (f as λ(V) -> V)(value));
       (((*self: std::collections::umap::UHashMap<K, V, B>).0: Slice<std::collections::umap::Slot<K, V> >)[[i]]: std::collections::umap::Slot<K, V>) = slot;
       #_skip
@@ -165,9 +165,9 @@ noir_def std::collections::umap::UHashMap::iter_values_mut<K: Type, V: Type, B: 
 
 noir_def std::collections::umap::UHashMap::retain<K: Type, V: Type, B: Type>(self: & std::collections::umap::UHashMap<K, V, B>, f: λ(K, V) -> bool) -> Unit := {
   for index in (0: u32) .. (#_arrayLen returning u32)((#_readRef returning std::collections::umap::UHashMap<K, V, B>)(self).0) do {
-    let mut (slot: std::collections::umap::Slot<K, V>) = (#_sliceIndex returning std::collections::umap::Slot<K, V>)((#_readRef returning std::collections::umap::UHashMap<K, V, B>)(self).0, (#_cast returning u32)(index));
+    let mut slot = (#_sliceIndex returning std::collections::umap::Slot<K, V>)((#_readRef returning std::collections::umap::UHashMap<K, V, B>)(self).0, (#_cast returning u32)(index));
     if (std::collections::umap::Slot::is_valid<K, V> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot) then {
-      let ((key: K), (value: V)) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
+      let (key, value) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
       if (#_bNot returning bool)((f as λ(K, V) -> bool)(key, value)) then {
         (std::collections::umap::Slot::mark_deleted<K, V> as λ(& std::collections::umap::Slot<K, V>) -> Unit)((#_ref returning & std::collections::umap::Slot<K, V>)(slot));
         ((*self: std::collections::umap::UHashMap<K, V, B>).1: u32) = (#_uSub returning u32)((#_readRef returning std::collections::umap::UHashMap<K, V, B>)(self).1, (1: u32));
@@ -204,7 +204,7 @@ noir_def std::collections::umap::UHashMap::remove<K: Type, V: Type, B: Type, B_a
 }
 
 noir_def std::collections::umap::UHashMap::hash<K: Type, V: Type, B: Type, B_as_BuildHasher_H: Type>(self: std::collections::umap::UHashMap<K, V, B>, key: K) -> u32 := {
-  let mut (hasher: B_as_BuildHasher_H) = ((B as std::hash::BuildHasher<>)::build_hasher<> as λ(B) -> B_as_BuildHasher_H)(self.2);
+  let mut hasher = ((B as std::hash::BuildHasher<>)::build_hasher<> as λ(B) -> B_as_BuildHasher_H)(self.2);
   ((K as std::hash::Hash<>)::hash<B_as_BuildHasher_H> as λ(K, & B_as_BuildHasher_H) -> Unit)(key, (#_ref returning & B_as_BuildHasher_H)(hasher));
   (#_cast returning u32)(((B_as_BuildHasher_H as std::hash::Hasher<>)::finish<> as λ(B_as_BuildHasher_H) -> Field)(hasher))
 }
@@ -215,24 +215,24 @@ noir_def std::collections::umap::UHashMap::quadratic_probe<K: Type, V: Type, B: 
 
 noir_trait_impl[impl_38]<K: Type, V: Type, B: Type, B_as_BuildHasher_H: Type> std::cmp::Eq<> for std::collections::umap::UHashMap<K, V, B> where [K: std::cmp::Eq<>, K: std::hash::Hash<>, V: std::cmp::Eq<>, B: std::hash::BuildHasher<B_as_BuildHasher_H>] := {
   noir_def eq<>(self: std::collections::umap::UHashMap<K, V, B>, other: std::collections::umap::UHashMap<K, V, B>) -> bool := {
-    let mut (equal: bool) = #_false;
+    let mut equal = #_false;
     if (#_uEq returning bool)((std::collections::umap::UHashMap::len<K, V, B> as λ(std::collections::umap::UHashMap<K, V, B>) -> u32)(self), (std::collections::umap::UHashMap::len<K, V, B> as λ(std::collections::umap::UHashMap<K, V, B>) -> u32)(other)) then {
       equal = #_true;
       {
-        let (ζi0: Slice<std::collections::umap::Slot<K, V> >) = self.0;
+        let ζi0 = self.0;
         for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-          let (slot: std::collections::umap::Slot<K, V>) = (#_sliceIndex returning std::collections::umap::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
+          let slot = (#_sliceIndex returning std::collections::umap::Slot<K, V>)(ζi0, (#_cast returning u32)(ζi1));
           {
             if (#_bAnd returning bool)(equal, (std::collections::umap::Slot::is_valid<K, V> as λ(std::collections::umap::Slot<K, V>) -> bool)(slot)) then {
-              let ((key: K), (value: V)) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
-              let (other_value: std::option::Option<V>) = {
+              let (key, value) = (std::collections::umap::Slot::key_value_unchecked<K, V> as λ(std::collections::umap::Slot<K, V>) -> Tuple<K, V>)(slot);
+              let other_value = {
                 (std::collections::umap::UHashMap::get<K, V, B> as λ(std::collections::umap::UHashMap<K, V, B>, K) -> std::option::Option<V>)(other, key)
               };
               if (std::option::Option::is_none<V> as λ(std::option::Option<V>) -> bool)(other_value) then {
                 equal = #_false;
                 #_skip
               } else {
-                let (other_value: V) = (std::option::Option::unwrap_unchecked<V> as λ(std::option::Option<V>) -> V)(other_value);
+                let other_value = (std::option::Option::unwrap_unchecked<V> as λ(std::option::Option<V>) -> V)(other_value);
                 if ((V as Eq<>)::eq<> as λ(V, V) -> bool)(value, other_value) then {
                   equal = #_false;
                   #_skip

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/Vec.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Collections/Vec.lean
@@ -31,7 +31,7 @@ noir_def std::collections::vec::Vec::push<T: Type>(self: & std::collections::vec
 }
 
 noir_def std::collections::vec::Vec::pop<T: Type>(self: & std::collections::vec::Vec<T>) -> T := {
-  let ((popped_slice: Slice<T>), (last_elem: T)) = (#_slicePopBack returning Tuple<Slice<T>, T>)((#_readRef returning std::collections::vec::Vec<T>)(self).0);
+  let (popped_slice, last_elem) = (#_slicePopBack returning Tuple<Slice<T>, T>)((#_readRef returning std::collections::vec::Vec<T>)(self).0);
   ((*self: std::collections::vec::Vec<T>).0: Slice<T>) = popped_slice;
   last_elem
 }
@@ -42,7 +42,7 @@ noir_def std::collections::vec::Vec::insert<T: Type>(self: & std::collections::v
 }
 
 noir_def std::collections::vec::Vec::remove<T: Type>(self: & std::collections::vec::Vec<T>, index: u32) -> T := {
-  let ((new_slice: Slice<T>), (elem: T)) = (#_sliceRemove returning Tuple<Slice<T>, T>)((#_readRef returning std::collections::vec::Vec<T>)(self).0, index);
+  let (new_slice, elem) = (#_sliceRemove returning Tuple<Slice<T>, T>)((#_readRef returning std::collections::vec::Vec<T>)(self).0, index);
   ((*self: std::collections::vec::Vec<T>).0: Slice<T>) = new_slice;
   elem
 }
@@ -52,7 +52,7 @@ noir_def std::collections::vec::Vec::len<T: Type>(self: std::collections::vec::V
 }
 
 noir_def std::collections::vec::tests::set_updates_values_properly<>() -> Unit := {
-  let mut (vec: std::collections::vec::Vec<Field>) = (#_makeData returning std::collections::vec::Vec<Field>)((#_mkSlice returning Slice<Field>)((0: Field), (0: Field), (0: Field), (0: Field), (0: Field)));
+  let mut vec = (#_makeData returning std::collections::vec::Vec<Field>)((#_mkSlice returning Slice<Field>)((0: Field), (0: Field), (0: Field), (0: Field), (0: Field)));
   (std::collections::vec::Vec::set<Field> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (0: u32), (42: Field));
   (#_assert returning Unit)(((Slice<Field> as Eq<>)::eq<> as λ(Slice<Field>, Slice<Field>) -> bool)(vec.0, (#_mkSlice returning Slice<Field>)((42: Field), (0: Field), (0: Field), (0: Field), (0: Field))));
   (std::collections::vec::Vec::set<Field> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (1: u32), (43: Field));
@@ -67,9 +67,9 @@ noir_def std::collections::vec::tests::set_updates_values_properly<>() -> Unit :
 }
 
 noir_def std::collections::vec::tests::panics_when_writing_elements_past_end_of_vec<>() -> Unit := {
-  let mut (vec: std::collections::vec::Vec<Field>) = (std::collections::vec::Vec::new<Field> as λ() -> std::collections::vec::Vec<Field>)();
+  let mut vec = (std::collections::vec::Vec::new<Field> as λ() -> std::collections::vec::Vec<Field>)();
   (std::collections::vec::Vec::set<Field> as λ(& std::collections::vec::Vec<Field>, u32, Field) -> Unit)((#_ref returning & std::collections::vec::Vec<Field>)(vec), (0: u32), (42: Field));
-  let (_: Field) = (std::collections::vec::Vec::get<Field> as λ(std::collections::vec::Vec<Field>, u32) -> Field)(vec, (0: u32));
+  let _ = (std::collections::vec::Vec::get<Field> as λ(std::collections::vec::Vec<Field>, u32) -> Field)(vec, (0: u32));
   #_skip
 }
 

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/EmbeddedCurveOps.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/EmbeddedCurveOps.lean
@@ -62,21 +62,21 @@ noir_def std::embedded_curve_ops::EmbeddedCurveScalar::new<>(lo: Field, hi: Fiel
 }
 
 noir_def std::embedded_curve_ops::EmbeddedCurveScalar::from_field<>(scalar: Field) -> std::embedded_curve_ops::EmbeddedCurveScalar<> := {
-  let ((a: Field), (b: Field)) = (std::field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)(scalar);
+  let (a, b) = (std::field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)(scalar);
   (#_makeData returning std::embedded_curve_ops::EmbeddedCurveScalar<>)(a, b)
 }
 
 noir_def std::embedded_curve_ops::EmbeddedCurveScalar::from_bytes<>(bytes: Array<u8, 64: u32>, offset: u32) -> std::embedded_curve_ops::EmbeddedCurveScalar<> := {
-  let mut (v: Field) = (1: Field);
-  let mut (lo: Field) = (#_cast returning Field)((0: Field));
-  let mut (hi: Field) = (#_cast returning Field)((0: Field));
+  let mut v = (1: Field);
+  let mut lo = (#_cast returning Field)((0: Field));
+  let mut hi = (#_cast returning Field)((0: Field));
   for i in (0: u32) .. (16: u32) do {
     lo = (#_fAdd returning Field)(lo, (#_fMul returning Field)((#_cast returning Field)((#_arrayIndex returning u8)(bytes, (#_cast returning u32)((#_uSub returning u32)((#_uAdd returning u32)(offset, (31: u32)), i)))), v));
     hi = (#_fAdd returning Field)(hi, (#_fMul returning Field)((#_cast returning Field)((#_arrayIndex returning u8)(bytes, (#_cast returning u32)((#_uSub returning u32)((#_uAdd returning u32)(offset, (15: u32)), i)))), v));
     v = (#_fMul returning Field)(v, (256: Field));
     #_skip
   };
-  let (sig_s: std::embedded_curve_ops::EmbeddedCurveScalar<>) = (#_makeData returning std::embedded_curve_ops::EmbeddedCurveScalar<>)(lo, hi);
+  let sig_s = (#_makeData returning std::embedded_curve_ops::EmbeddedCurveScalar<>)(lo, hi);
   sig_s
 }
 
@@ -112,14 +112,14 @@ noir_def std::embedded_curve_ops::embedded_curve_add<>(point1: std::embedded_cur
       (std::embedded_curve_ops::embedded_curve_add_unsafe<> as λ(std::embedded_curve_ops::EmbeddedCurvePoint<>, std::embedded_curve_ops::EmbeddedCurvePoint<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<>)(point1, point2)
     }
   } else {
-    let (x_coordinates_match: bool) = (#_fEq returning bool)(point1.0, point2.0);
-    let (y_coordinates_match: bool) = (#_fEq returning bool)(point1.1, point2.1);
-    let (double_predicate: bool) = (#_bAnd returning bool)(x_coordinates_match, y_coordinates_match);
-    let (infinity_predicate: bool) = (#_bAnd returning bool)(x_coordinates_match, (#_bNot returning bool)(y_coordinates_match));
-    let (point1_1: std::embedded_curve_ops::EmbeddedCurvePoint<>) = (#_makeData returning std::embedded_curve_ops::EmbeddedCurvePoint<>)((#_fAdd returning Field)(point1.0, (#_cast returning Field)(x_coordinates_match)), point1.1, #_false);
-    let (point2_1: std::embedded_curve_ops::EmbeddedCurvePoint<>) = (#_makeData returning std::embedded_curve_ops::EmbeddedCurvePoint<>)(point2.0, point2.1, #_false);
-    let mut (result: std::embedded_curve_ops::EmbeddedCurvePoint<>) = (std::embedded_curve_ops::embedded_curve_add_unsafe<> as λ(std::embedded_curve_ops::EmbeddedCurvePoint<>, std::embedded_curve_ops::EmbeddedCurvePoint<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<>)(point1_1, point2_1);
-    let (double: std::embedded_curve_ops::EmbeddedCurvePoint<>) = (std::embedded_curve_ops::embedded_curve_add_unsafe<> as λ(std::embedded_curve_ops::EmbeddedCurvePoint<>, std::embedded_curve_ops::EmbeddedCurvePoint<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<>)(point1, point1);
+    let x_coordinates_match = (#_fEq returning bool)(point1.0, point2.0);
+    let y_coordinates_match = (#_fEq returning bool)(point1.1, point2.1);
+    let double_predicate = (#_bAnd returning bool)(x_coordinates_match, y_coordinates_match);
+    let infinity_predicate = (#_bAnd returning bool)(x_coordinates_match, (#_bNot returning bool)(y_coordinates_match));
+    let point1_1 = (#_makeData returning std::embedded_curve_ops::EmbeddedCurvePoint<>)((#_fAdd returning Field)(point1.0, (#_cast returning Field)(x_coordinates_match)), point1.1, #_false);
+    let point2_1 = (#_makeData returning std::embedded_curve_ops::EmbeddedCurvePoint<>)(point2.0, point2.1, #_false);
+    let mut result = (std::embedded_curve_ops::embedded_curve_add_unsafe<> as λ(std::embedded_curve_ops::EmbeddedCurvePoint<>, std::embedded_curve_ops::EmbeddedCurvePoint<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<>)(point1_1, point2_1);
+    let double = (std::embedded_curve_ops::embedded_curve_add_unsafe<> as λ(std::embedded_curve_ops::EmbeddedCurvePoint<>, std::embedded_curve_ops::EmbeddedCurvePoint<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<>)(point1, point1);
     result = if double_predicate then {
       double
     } else {
@@ -133,7 +133,7 @@ noir_def std::embedded_curve_ops::embedded_curve_add<>(point1: std::embedded_cur
       result = point1;
       #_skip
     };
-    let mut (result_is_infinity: bool) = (#_bAnd returning bool)(infinity_predicate, (#_bAnd returning bool)((#_bNot returning bool)(point1.2), (#_bNot returning bool)(point2.2)));
+    let mut result_is_infinity = (#_bAnd returning bool)(infinity_predicate, (#_bAnd returning bool)((#_bNot returning bool)(point1.2), (#_bNot returning bool)(point2.2)));
     (result.2: bool) = (#_bOr returning bool)(result_is_infinity, (#_bAnd returning bool)(point1.2, point2.2));
     result
   }
@@ -143,8 +143,8 @@ noir_def std::embedded_curve_ops::embedded_curve_add_not_nul<>(point1: std::embe
   (#_assert returning Unit)((#_fNeq returning bool)(point1.0, point2.0));
   (#_assert returning Unit)((#_bNot returning bool)(point1.2));
   (#_assert returning Unit)((#_bNot returning bool)(point2.2));
-  let (point1_1: std::embedded_curve_ops::EmbeddedCurvePoint<>) = (#_makeData returning std::embedded_curve_ops::EmbeddedCurvePoint<>)(point1.0, point1.1, #_false);
-  let (point2_1: std::embedded_curve_ops::EmbeddedCurvePoint<>) = (#_makeData returning std::embedded_curve_ops::EmbeddedCurvePoint<>)(point2.0, point2.1, #_false);
+  let point1_1 = (#_makeData returning std::embedded_curve_ops::EmbeddedCurvePoint<>)(point1.0, point1.1, #_false);
+  let point2_1 = (#_makeData returning std::embedded_curve_ops::EmbeddedCurvePoint<>)(point2.0, point2.1, #_false);
   (std::embedded_curve_ops::embedded_curve_add_unsafe<> as λ(std::embedded_curve_ops::EmbeddedCurvePoint<>, std::embedded_curve_ops::EmbeddedCurvePoint<>) -> std::embedded_curve_ops::EmbeddedCurvePoint<>)(point1_1, point2_1)
 }
 

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Field/Bn254.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Field/Bn254.lean
@@ -15,8 +15,8 @@ noir_global_def std::field::bn254::PHI: Field = (6432376461318317704186205748522
 noir_global_def std::field::bn254::TWO_POW_128: Field = (340282366920938463463374607431768211456: Field);
 
 noir_def std::field::bn254::compute_decomposition<>(x: Field) -> Tuple<Field, Field> := {
-  let (low: Field) = (#_cast returning Field)((#_cast returning u128)(x));
-  let (high: Field) = (#_fDiv returning Field)((#_fSub returning Field)(x, low), (TWO_POW_128<> as λ() -> Field)());
+  let low = (#_cast returning Field)((#_cast returning u128)(x));
+  let high = (#_fDiv returning Field)((#_fSub returning Field)(x, low), (std::field::bn254::TWO_POW_128<> as λ() -> Field)());
   (#_makeData returning Tuple<Field, Field>)(low, high)
 }
 
@@ -29,12 +29,12 @@ noir_def std::field::bn254::lte_hint<>(x: Field, y: Field) -> bool := {
 }
 
 noir_def std::field::bn254::assert_gt_limbs<>(a: Tuple<Field, Field>, b: Tuple<Field, Field>) -> Unit := {
-  let ((alo: Field), (ahi: Field)) = a;
-  let ((blo: Field), (bhi: Field)) = b;
+  let (alo, ahi) = a;
+  let (blo, bhi) = b;
   {
-    let (borrow: bool) = (std::field::bn254::lte_hint<> as λ(Field, Field) -> bool)(alo, blo);
-    let (rlo: Field) = (#_fAdd returning Field)((#_fSub returning Field)((#_fSub returning Field)(alo, blo), (1: Field)), (#_fMul returning Field)((#_cast returning Field)(borrow), (TWO_POW_128<> as λ() -> Field)()));
-    let (rhi: Field) = (#_fSub returning Field)((#_fSub returning Field)(ahi, bhi), (#_cast returning Field)(borrow));
+    let borrow = (std::field::bn254::lte_hint<> as λ(Field, Field) -> bool)(alo, blo);
+    let rlo = (#_fAdd returning Field)((#_fSub returning Field)((#_fSub returning Field)(alo, blo), (1: Field)), (#_fMul returning Field)((#_cast returning Field)(borrow), (std::field::bn254::TWO_POW_128<> as λ() -> Field)()));
+    let rhi = (#_fSub returning Field)((#_fSub returning Field)(ahi, bhi), (#_cast returning Field)(borrow));
     (std::field::assert_max_bit_size<128: u32> as λ(Field) -> Unit)(rlo);
     (std::field::assert_max_bit_size<128: u32> as λ(Field) -> Unit)(rhi);
     #_skip
@@ -45,11 +45,11 @@ noir_def std::field::bn254::decompose<>(x: Field) -> Tuple<Field, Field> := {
   if (#_isUnconstrained returning bool)() then {
     (std::field::bn254::compute_decomposition<> as λ(Field) -> Tuple<Field, Field>)(x)
   } else {
-    let ((xlo: Field), (xhi: Field)) = (std::field::bn254::decompose_hint<> as λ(Field) -> Tuple<Field, Field>)(x);
+    let (xlo, xhi) = (std::field::bn254::decompose_hint<> as λ(Field) -> Tuple<Field, Field>)(x);
     (std::field::assert_max_bit_size<128: u32> as λ(Field) -> Unit)(xlo);
     (std::field::assert_max_bit_size<128: u32> as λ(Field) -> Unit)(xhi);
-    (#_assert returning Unit)((#_fEq returning bool)(x, (#_fAdd returning Field)(xlo, (#_fMul returning Field)((TWO_POW_128<> as λ() -> Field)(), xhi))));
-    (std::field::bn254::assert_gt_limbs<> as λ(Tuple<Field, Field>, Tuple<Field, Field>) -> Unit)((#_makeData returning Tuple<Field, Field>)((PLO<> as λ() -> Field)(), (PHI<> as λ() -> Field)()), (#_makeData returning Tuple<Field, Field>)(xlo, xhi));
+    (#_assert returning Unit)((#_fEq returning bool)(x, (#_fAdd returning Field)(xlo, (#_fMul returning Field)((std::field::bn254::TWO_POW_128<> as λ() -> Field)(), xhi))));
+    (std::field::bn254::assert_gt_limbs<> as λ(Tuple<Field, Field>, Tuple<Field, Field>) -> Unit)((#_makeData returning Tuple<Field, Field>)((std::field::bn254::PLO<> as λ() -> Field)(), (std::field::bn254::PHI<> as λ() -> Field)()), (#_makeData returning Tuple<Field, Field>)(xlo, xhi));
     (#_makeData returning Tuple<Field, Field>)(xlo, xhi)
   }
 }
@@ -61,8 +61,8 @@ noir_def std::field::bn254::assert_gt<>(a: Field, b: Field) -> Unit := {
     });
     #_skip
   } else {
-    let (a_limbs: Tuple<Field, Field>) = (std::field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)(a);
-    let (b_limbs: Tuple<Field, Field>) = (std::field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)(b);
+    let a_limbs = (std::field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)(a);
+    let b_limbs = (std::field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)(b);
     (std::field::bn254::assert_gt_limbs<> as λ(Tuple<Field, Field>, Tuple<Field, Field>) -> Unit)(a_limbs, b_limbs)
   }
 }
@@ -93,8 +93,8 @@ noir_def std::field::bn254::lt<>(a: Field, b: Field) -> bool := {
 }
 
 noir_def std::field::bn254::tests::check_decompose<>() -> Unit := {
-  (#_assert returning Unit)(((Tuple<Field, Field> as Eq<>)::eq<> as λ(Tuple<Field, Field>, Tuple<Field, Field>) -> bool)((std::field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)((TWO_POW_128<> as λ() -> Field)()), (#_makeData returning Tuple<Field, Field>)((0: Field), (1: Field))));
-  (#_assert returning Unit)(((Tuple<Field, Field> as Eq<>)::eq<> as λ(Tuple<Field, Field>, Tuple<Field, Field>) -> bool)((std::field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)((#_fAdd returning Field)((TWO_POW_128<> as λ() -> Field)(), (78187493520: Field))), (#_makeData returning Tuple<Field, Field>)((78187493520: Field), (1: Field))));
+  (#_assert returning Unit)(((Tuple<Field, Field> as Eq<>)::eq<> as λ(Tuple<Field, Field>, Tuple<Field, Field>) -> bool)((std::field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)((std::field::bn254::TWO_POW_128<> as λ() -> Field)()), (#_makeData returning Tuple<Field, Field>)((0: Field), (1: Field))));
+  (#_assert returning Unit)(((Tuple<Field, Field> as Eq<>)::eq<> as λ(Tuple<Field, Field>, Tuple<Field, Field>) -> bool)((std::field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)((#_fAdd returning Field)((std::field::bn254::TWO_POW_128<> as λ() -> Field)(), (78187493520: Field))), (#_makeData returning Tuple<Field, Field>)((78187493520: Field), (1: Field))));
   (#_assert returning Unit)(((Tuple<Field, Field> as Eq<>)::eq<> as λ(Tuple<Field, Field>, Tuple<Field, Field>) -> bool)((std::field::bn254::decompose<> as λ(Field) -> Tuple<Field, Field>)((78187493520: Field)), (#_makeData returning Tuple<Field, Field>)((78187493520: Field), (0: Field))));
   #_skip
 }
@@ -111,7 +111,7 @@ noir_def std::field::bn254::tests::check_assert_gt<>() -> Unit := {
   (std::field::bn254::assert_gt<> as λ(Field, Field) -> Unit)((1: Field), (0: Field));
   (std::field::bn254::assert_gt<> as λ(Field, Field) -> Unit)((256: Field), (0: Field));
   (std::field::bn254::assert_gt<> as λ(Field, Field) -> Unit)((#_fSub returning Field)((0: Field), (1: Field)), (#_fSub returning Field)((0: Field), (2: Field)));
-  (std::field::bn254::assert_gt<> as λ(Field, Field) -> Unit)((TWO_POW_128<> as λ() -> Field)(), (0: Field));
+  (std::field::bn254::assert_gt<> as λ(Field, Field) -> Unit)((std::field::bn254::TWO_POW_128<> as λ() -> Field)(), (0: Field));
   (std::field::bn254::assert_gt<> as λ(Field, Field) -> Unit)((#_fSub returning Field)((0: Field), (1: Field)), (0: Field));
   #_skip
 }
@@ -124,7 +124,7 @@ noir_def std::field::bn254::tests::check_gt<>() -> Unit := {
   (#_assert returning Unit)((std::field::bn254::gt<> as λ(Field, Field) -> bool)((1: Field), (0: Field)));
   (#_assert returning Unit)((std::field::bn254::gt<> as λ(Field, Field) -> bool)((256: Field), (0: Field)));
   (#_assert returning Unit)((std::field::bn254::gt<> as λ(Field, Field) -> bool)((#_fSub returning Field)((0: Field), (1: Field)), (#_fSub returning Field)((0: Field), (2: Field))));
-  (#_assert returning Unit)((std::field::bn254::gt<> as λ(Field, Field) -> bool)((TWO_POW_128<> as λ() -> Field)(), (0: Field)));
+  (#_assert returning Unit)((std::field::bn254::gt<> as λ(Field, Field) -> bool)((std::field::bn254::TWO_POW_128<> as λ() -> Field)(), (0: Field)));
   (#_assert returning Unit)((#_bNot returning bool)((std::field::bn254::gt<> as λ(Field, Field) -> bool)((0: Field), (0: Field))));
   (#_assert returning Unit)((#_bNot returning bool)((std::field::bn254::gt<> as λ(Field, Field) -> bool)((0: Field), (256: Field))));
   (#_assert returning Unit)((std::field::bn254::gt<> as λ(Field, Field) -> bool)((#_fSub returning Field)((0: Field), (1: Field)), (#_fSub returning Field)((0: Field), (2: Field))));
@@ -137,19 +137,19 @@ noir_def std::field::bn254::tests::check_gt_unconstrained<>() -> Unit := {
 }
 
 noir_def std::field::bn254::tests::check_plo_phi<>() -> Unit := {
-  (#_assert returning Unit)((#_fEq returning bool)((#_fAdd returning Field)((PLO<> as λ() -> Field)(), (#_fMul returning Field)((PHI<> as λ() -> Field)(), (TWO_POW_128<> as λ() -> Field)())), (0: Field)));
-  let (p_bytes: Slice<u8>) = (#_modulusLeBytes returning Slice<u8>)();
-  let mut (p_low: Field) = (0: Field);
-  let mut (p_high: Field) = (0: Field);
-  let mut (offset: Field) = (1: Field);
+  (#_assert returning Unit)((#_fEq returning bool)((#_fAdd returning Field)((std::field::bn254::PLO<> as λ() -> Field)(), (#_fMul returning Field)((std::field::bn254::PHI<> as λ() -> Field)(), (std::field::bn254::TWO_POW_128<> as λ() -> Field)())), (0: Field)));
+  let p_bytes = (#_modulusLeBytes returning Slice<u8>)();
+  let mut p_low = (0: Field);
+  let mut p_high = (0: Field);
+  let mut offset = (1: Field);
   for i in (0: u32) .. (16: u32) do {
     p_low = (#_fAdd returning Field)(p_low, (#_fMul returning Field)((#_cast returning Field)((#_sliceIndex returning u8)(p_bytes, (#_cast returning u32)(i))), offset));
     p_high = (#_fAdd returning Field)(p_high, (#_fMul returning Field)((#_cast returning Field)((#_sliceIndex returning u8)(p_bytes, (#_cast returning u32)((#_uAdd returning u32)(i, (16: u32))))), offset));
     offset = (#_fMul returning Field)(offset, (256: Field));
     #_skip
   };
-  (#_assert returning Unit)((#_fEq returning bool)(p_low, (PLO<> as λ() -> Field)()));
-  (#_assert returning Unit)((#_fEq returning bool)(p_high, (PHI<> as λ() -> Field)()));
+  (#_assert returning Unit)((#_fEq returning bool)(p_low, (std::field::bn254::PLO<> as λ() -> Field)()));
+  (#_assert returning Unit)((#_fEq returning bool)(p_high, (std::field::bn254::PHI<> as λ() -> Field)()));
   #_skip
 }
 

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Field/Mod.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Field/Mod.lean
@@ -15,11 +15,11 @@ noir_def std::field::assert_max_bit_size<BIT_SIZE: u32>(self: Field) -> Unit := 
 }
 
 noir_def std::field::to_le_bits<N: u32>(self: Field) -> Array<u1, N: u32> := {
-  let (bits: Array<u1, N: u32>) = (#_toLeBits returning Array<u1, N: u32>)(self);
+  let bits = (#_toLeBits returning Array<u1, N: u32>)(self);
   if (#_bNot returning bool)((#_isUnconstrained returning bool)()) then {
-    let (p: Slice<u1>) = (#_modulusLeBits returning Slice<u1>)();
+    let p = (#_modulusLeBits returning Slice<u1>)();
     (#_assert returning Unit)((#_uLeq returning bool)((#_arrayLen returning u32)(bits), (#_arrayLen returning u32)(p)));
-    let mut (ok: bool) = (#_uNeq returning bool)((#_arrayLen returning u32)(bits), (#_arrayLen returning u32)(p));
+    let mut ok = (#_uNeq returning bool)((#_arrayLen returning u32)(bits), (#_arrayLen returning u32)(p));
     for i in (0: u32) .. uConst!(N: u32) do {
       if (#_bNot returning bool)(ok) then {
         if (#_uNeq returning bool)((#_arrayIndex returning u1)(bits, (#_cast returning u32)((#_uSub returning u32)((#_uSub returning u32)(uConst!(N: u32), (1: u32)), i))), (#_sliceIndex returning u1)(p, (#_cast returning u32)((#_uSub returning u32)((#_uSub returning u32)(uConst!(N: u32), (1: u32)), i)))) then {
@@ -36,11 +36,11 @@ noir_def std::field::to_le_bits<N: u32>(self: Field) -> Array<u1, N: u32> := {
 }
 
 noir_def std::field::to_be_bits<N: u32>(self: Field) -> Array<u1, N: u32> := {
-  let (bits: Array<u1, N: u32>) = (#_toBeBits returning Array<u1, N: u32>)(self);
+  let bits = (#_toBeBits returning Array<u1, N: u32>)(self);
   if (#_bNot returning bool)((#_isUnconstrained returning bool)()) then {
-    let (p: Slice<u1>) = (#_modulusBeBits returning Slice<u1>)();
+    let p = (#_modulusBeBits returning Slice<u1>)();
     (#_assert returning Unit)((#_uLeq returning bool)((#_arrayLen returning u32)(bits), (#_arrayLen returning u32)(p)));
-    let mut (ok: bool) = (#_uNeq returning bool)((#_arrayLen returning u32)(bits), (#_arrayLen returning u32)(p));
+    let mut ok = (#_uNeq returning bool)((#_arrayLen returning u32)(bits), (#_arrayLen returning u32)(p));
     for i in (0: u32) .. uConst!(N: u32) do {
       if (#_bNot returning bool)(ok) then {
         if (#_uNeq returning bool)((#_arrayIndex returning u1)(bits, (#_cast returning u32)(i)), (#_sliceIndex returning u1)(p, (#_cast returning u32)(i))) then {
@@ -58,11 +58,11 @@ noir_def std::field::to_be_bits<N: u32>(self: Field) -> Array<u1, N: u32> := {
 
 noir_def std::field::to_le_bytes<N: u32>(self: Field) -> Array<u8, N: u32> := {
   (#_staticAssert returning Unit)((#_uLeq returning bool)(uConst!(N: u32), (#_arrayLen returning u32)((#_modulusLeBytes returning Slice<u8>)())), "N must be less than or equal to modulus_le_bytes().len()");
-  let (bytes: Array<u8, N: u32>) = (std::field::to_le_radix<N: u32> as λ(Field, u32) -> Array<u8, N: u32>)(self, (256: u32));
+  let bytes = (std::field::to_le_radix<N: u32> as λ(Field, u32) -> Array<u8, N: u32>)(self, (256: u32));
   if (#_bNot returning bool)((#_isUnconstrained returning bool)()) then {
-    let (p: Slice<u8>) = (#_modulusLeBytes returning Slice<u8>)();
+    let p = (#_modulusLeBytes returning Slice<u8>)();
     (#_assert returning Unit)((#_uLeq returning bool)((#_arrayLen returning u32)(bytes), (#_arrayLen returning u32)(p)));
-    let mut (ok: bool) = (#_uNeq returning bool)((#_arrayLen returning u32)(bytes), (#_arrayLen returning u32)(p));
+    let mut ok = (#_uNeq returning bool)((#_arrayLen returning u32)(bytes), (#_arrayLen returning u32)(p));
     for i in (0: u32) .. uConst!(N: u32) do {
       if (#_bNot returning bool)(ok) then {
         if (#_uNeq returning bool)((#_arrayIndex returning u8)(bytes, (#_cast returning u32)((#_uSub returning u32)((#_uSub returning u32)(uConst!(N: u32), (1: u32)), i))), (#_sliceIndex returning u8)(p, (#_cast returning u32)((#_uSub returning u32)((#_uSub returning u32)(uConst!(N: u32), (1: u32)), i)))) then {
@@ -80,11 +80,11 @@ noir_def std::field::to_le_bytes<N: u32>(self: Field) -> Array<u8, N: u32> := {
 
 noir_def std::field::to_be_bytes<N: u32>(self: Field) -> Array<u8, N: u32> := {
   (#_staticAssert returning Unit)((#_uLeq returning bool)(uConst!(N: u32), (#_arrayLen returning u32)((#_modulusLeBytes returning Slice<u8>)())), "N must be less than or equal to modulus_le_bytes().len()");
-  let (bytes: Array<u8, N: u32>) = (std::field::to_be_radix<N: u32> as λ(Field, u32) -> Array<u8, N: u32>)(self, (256: u32));
+  let bytes = (std::field::to_be_radix<N: u32> as λ(Field, u32) -> Array<u8, N: u32>)(self, (256: u32));
   if (#_bNot returning bool)((#_isUnconstrained returning bool)()) then {
-    let (p: Slice<u8>) = (#_modulusBeBytes returning Slice<u8>)();
+    let p = (#_modulusBeBytes returning Slice<u8>)();
     (#_assert returning Unit)((#_uLeq returning bool)((#_arrayLen returning u32)(bytes), (#_arrayLen returning u32)(p)));
-    let mut (ok: bool) = (#_uNeq returning bool)((#_arrayLen returning u32)(bytes), (#_arrayLen returning u32)(p));
+    let mut ok = (#_uNeq returning bool)((#_arrayLen returning u32)(bytes), (#_arrayLen returning u32)(p));
     for i in (0: u32) .. uConst!(N: u32) do {
       if (#_bNot returning bool)(ok) then {
         if (#_uNeq returning bool)((#_arrayIndex returning u8)(bytes, (#_cast returning u32)(i)), (#_sliceIndex returning u8)(p, (#_cast returning u32)(i))) then {
@@ -121,8 +121,8 @@ noir_def std::field::to_be_radix<N: u32>(self: Field, radix: u32) -> Array<u8, N
 }
 
 noir_def std::field::pow_32<>(self: Field, exponent: Field) -> Field := {
-  let mut (r: Field) = (1: Field);
-  let (b: Array<u1, 32: u32>) = (std::field::to_le_bits<32: u32> as λ(Field) -> Array<u1, 32: u32>)(exponent);
+  let mut r = (1: Field);
+  let b = (std::field::to_le_bits<32: u32> as λ(Field) -> Array<u1, 32: u32>)(exponent);
   for i in (1: u32) .. (33: u32) do {
     r = (#_fMul returning Field)(r, r);
     r = (#_fAdd returning Field)((#_fMul returning Field)((#_cast returning Field)((#_arrayIndex returning u1)(b, (#_cast returning u32)((#_uSub returning u32)((32: u32), i)))), (#_fMul returning Field)(r, self)), (#_fMul returning Field)((#_fSub returning Field)((1: Field), (#_cast returning Field)((#_arrayIndex returning u1)(b, (#_cast returning u32)((#_uSub returning u32)((32: u32), i))))), r));
@@ -145,8 +145,8 @@ noir_def std::field::lt<>(self: Field, another: Field) -> bool := {
 
 noir_def std::field::from_le_bytes<N: u32>(bytes: Array<u8, N: u32>) -> Field := {
   (#_staticAssert returning Unit)((#_uLeq returning bool)(uConst!(N: u32), (#_arrayLen returning u32)((#_modulusLeBytes returning Slice<u8>)())), "N must be less than or equal to modulus_le_bytes().len()");
-  let mut (v: Field) = (1: Field);
-  let mut (result: Field) = (0: Field);
+  let mut v = (1: Field);
+  let mut result = (0: Field);
   for i in (0: u32) .. uConst!(N: u32) do {
     result = (#_fAdd returning Field)(result, (#_fMul returning Field)((#_cast returning Field)((#_arrayIndex returning u8)(bytes, (#_cast returning u32)(i))), v));
     v = (#_fMul returning Field)(v, (256: Field));
@@ -156,8 +156,8 @@ noir_def std::field::from_le_bytes<N: u32>(bytes: Array<u8, N: u32>) -> Field :=
 }
 
 noir_def std::field::from_be_bytes<N: u32>(bytes: Array<u8, N: u32>) -> Field := {
-  let mut (v: Field) = (1: Field);
-  let mut (result: Field) = (0: Field);
+  let mut v = (1: Field);
+  let mut result = (0: Field);
   for i in (0: u32) .. uConst!(N: u32) do {
     result = (#_fAdd returning Field)(result, (#_fMul returning Field)((#_cast returning Field)((#_arrayIndex returning u8)(bytes, (#_cast returning u32)((#_uSub returning u32)((#_uSub returning u32)(uConst!(N: u32), (1: u32)), i)))), v));
     v = (#_fMul returning Field)(v, (256: Field));
@@ -175,9 +175,9 @@ noir_def std::field::field_less_than<>(x: Field, y: Field) -> bool := {
 }
 
 noir_def std::field::bytes32_to_field<>(bytes32: Array<u8, 32: u32>) -> Field := {
-  let mut (v: Field) = (1: Field);
-  let mut (high: Field) = (#_cast returning Field)((0: Field));
-  let mut (low: Field) = (#_cast returning Field)((0: Field));
+  let mut v = (1: Field);
+  let mut high = (#_cast returning Field)((0: Field));
+  let mut low = (#_cast returning Field)((0: Field));
   for i in (0: u32) .. (16: u32) do {
     high = (#_fAdd returning Field)(high, (#_fMul returning Field)((#_cast returning Field)((#_arrayIndex returning u8)(bytes32, (#_cast returning u32)((#_uSub returning u32)((15: u32), i)))), v));
     low = (#_fAdd returning Field)(low, (#_fMul returning Field)((#_cast returning Field)((#_arrayIndex returning u8)(bytes32, (#_cast returning u32)((#_uSub returning u32)((#_uAdd returning u32)((16: u32), (15: u32)), i)))), v));
@@ -191,15 +191,15 @@ noir_def std::field::lt_fallback<>(x: Field, y: Field) -> bool := {
   if (#_isUnconstrained returning bool)() then {
     (std::field::field_less_than<> as λ(Field, Field) -> bool)(x, y)
   } else {
-    let (x_bytes: Array<u8, 32: u32>) = (std::field::to_le_bytes<32: u32> as λ(Field) -> Array<u8, 32: u32>)(x);
-    let (y_bytes: Array<u8, 32: u32>) = (std::field::to_le_bytes<32: u32> as λ(Field) -> Array<u8, 32: u32>)(y);
-    let mut (x_is_lt: bool) = #_false;
-    let mut (done: bool) = #_false;
+    let x_bytes = (std::field::to_le_bytes<32: u32> as λ(Field) -> Array<u8, 32: u32>)(x);
+    let y_bytes = (std::field::to_le_bytes<32: u32> as λ(Field) -> Array<u8, 32: u32>)(y);
+    let mut x_is_lt = #_false;
+    let mut done = #_false;
     for i in (0: u32) .. (32: u32) do {
       if (#_bNot returning bool)(done) then {
-        let (x_byte: u8) = (#_cast returning u8)((#_arrayIndex returning u8)(x_bytes, (#_cast returning u32)((#_uSub returning u32)((#_uSub returning u32)((32: u32), (1: u32)), i))));
-        let (y_byte: u8) = (#_cast returning u8)((#_arrayIndex returning u8)(y_bytes, (#_cast returning u32)((#_uSub returning u32)((#_uSub returning u32)((32: u32), (1: u32)), i))));
-        let (bytes_match: bool) = (#_uEq returning bool)(x_byte, y_byte);
+        let x_byte = (#_cast returning u8)((#_arrayIndex returning u8)(x_bytes, (#_cast returning u32)((#_uSub returning u32)((#_uSub returning u32)((32: u32), (1: u32)), i))));
+        let y_byte = (#_cast returning u8)((#_arrayIndex returning u8)(y_bytes, (#_cast returning u32)((#_uSub returning u32)((#_uSub returning u32)((32: u32), (1: u32)), i))));
+        let bytes_match = (#_uEq returning bool)(x_byte, y_byte);
         if (#_bNot returning bool)(bytes_match) then {
           x_is_lt = (#_uLt returning bool)(x_byte, y_byte);
           done = #_true;
@@ -212,46 +212,46 @@ noir_def std::field::lt_fallback<>(x: Field, y: Field) -> bool := {
 }
 
 noir_def std::field::tests::test_to_be_bits<>() -> Unit := {
-  let (field: Field) = (2: Field);
-  let (bits: Array<u1, 8: u32>) = (std::field::to_be_bits<8: u32> as λ(Field) -> Array<u1, 8: u32>)(field);
+  let field = (2: Field);
+  let bits = (std::field::to_be_bits<8: u32> as λ(Field) -> Array<u1, 8: u32>)(field);
   (#_assert returning Unit)(((Array<u1, 8: u32> as Eq<>)::eq<> as λ(Array<u1, 8: u32>, Array<u1, 8: u32>) -> bool)(bits, (#_mkArray returning Array<u1, 8: u32>)((0: u1), (0: u1), (0: u1), (0: u1), (0: u1), (0: u1), (1: u1), (0: u1))));
   #_skip
 }
 
 noir_def std::field::tests::test_to_le_bits<>() -> Unit := {
-  let (field: Field) = (2: Field);
-  let (bits: Array<u1, 8: u32>) = (std::field::to_le_bits<8: u32> as λ(Field) -> Array<u1, 8: u32>)(field);
+  let field = (2: Field);
+  let bits = (std::field::to_le_bits<8: u32> as λ(Field) -> Array<u1, 8: u32>)(field);
   (#_assert returning Unit)(((Array<u1, 8: u32> as Eq<>)::eq<> as λ(Array<u1, 8: u32>, Array<u1, 8: u32>) -> bool)(bits, (#_mkArray returning Array<u1, 8: u32>)((0: u1), (1: u1), (0: u1), (0: u1), (0: u1), (0: u1), (0: u1), (0: u1))));
   #_skip
 }
 
 noir_def std::field::tests::test_to_be_bytes<>() -> Unit := {
-  let (field: Field) = (2: Field);
-  let (bytes: Array<u8, 8: u32>) = (std::field::to_be_bytes<8: u32> as λ(Field) -> Array<u8, 8: u32>)(field);
+  let field = (2: Field);
+  let bytes = (std::field::to_be_bytes<8: u32> as λ(Field) -> Array<u8, 8: u32>)(field);
   (#_assert returning Unit)(((Array<u8, 8: u32> as Eq<>)::eq<> as λ(Array<u8, 8: u32>, Array<u8, 8: u32>) -> bool)(bytes, (#_mkArray returning Array<u8, 8: u32>)((0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (2: u8))));
   (#_assert returning Unit)((#_fEq returning bool)((std::field::from_be_bytes<8: u32> as λ(Array<u8, 8: u32>) -> Field)(bytes), field));
   #_skip
 }
 
 noir_def std::field::tests::test_to_le_bytes<>() -> Unit := {
-  let (field: Field) = (2: Field);
-  let (bytes: Array<u8, 8: u32>) = (std::field::to_le_bytes<8: u32> as λ(Field) -> Array<u8, 8: u32>)(field);
+  let field = (2: Field);
+  let bytes = (std::field::to_le_bytes<8: u32> as λ(Field) -> Array<u8, 8: u32>)(field);
   (#_assert returning Unit)(((Array<u8, 8: u32> as Eq<>)::eq<> as λ(Array<u8, 8: u32>, Array<u8, 8: u32>) -> bool)(bytes, (#_mkArray returning Array<u8, 8: u32>)((2: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8))));
   (#_assert returning Unit)((#_fEq returning bool)((std::field::from_le_bytes<8: u32> as λ(Array<u8, 8: u32>) -> Field)(bytes), field));
   #_skip
 }
 
 noir_def std::field::tests::test_to_be_radix<>() -> Unit := {
-  let (field: Field) = (259: Field);
-  let (bytes: Array<u8, 8: u32>) = (std::field::to_be_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (256: u32));
+  let field = (259: Field);
+  let bytes = (std::field::to_be_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (256: u32));
   (#_assert returning Unit)(((Array<u8, 8: u32> as Eq<>)::eq<> as λ(Array<u8, 8: u32>, Array<u8, 8: u32>) -> bool)(bytes, (#_mkArray returning Array<u8, 8: u32>)((0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (1: u8), (3: u8))));
   (#_assert returning Unit)((#_fEq returning bool)((std::field::from_be_bytes<8: u32> as λ(Array<u8, 8: u32>) -> Field)(bytes), field));
   #_skip
 }
 
 noir_def std::field::tests::test_to_le_radix<>() -> Unit := {
-  let (field: Field) = (259: Field);
-  let (bytes: Array<u8, 8: u32>) = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (256: u32));
+  let field = (259: Field);
+  let bytes = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (256: u32));
   (#_assert returning Unit)(((Array<u8, 8: u32> as Eq<>)::eq<> as λ(Array<u8, 8: u32>, Array<u8, 8: u32>) -> bool)(bytes, (#_mkArray returning Array<u8, 8: u32>)((3: u8), (1: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8), (0: u8))));
   (#_assert returning Unit)((#_fEq returning bool)((std::field::from_le_bytes<8: u32> as λ(Array<u8, 8: u32>) -> Field)(bytes), field));
   #_skip
@@ -259,8 +259,8 @@ noir_def std::field::tests::test_to_le_radix<>() -> Unit := {
 
 noir_def std::field::tests::test_to_le_radix_1<>() -> Unit := {
   if (#_bNot returning bool)((#_isUnconstrained returning bool)()) then {
-    let (field: Field) = (2: Field);
-    let (_: Array<u8, 8: u32>) = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (1: u32));
+    let field = (2: Field);
+    let _ = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (1: u32));
     #_skip
   } else {
     (std::panic::panic<Tuple<>, Unit, 28: u32> as λ(FmtString<28: u32, Tuple<> >) -> Unit)((#_mkFormatString returning FmtString<28: u32, Tuple<> >)("radix must be greater than 1"));
@@ -270,8 +270,8 @@ noir_def std::field::tests::test_to_le_radix_1<>() -> Unit := {
 
 noir_def std::field::tests::test_to_le_radix_3<>() -> Unit := {
   if (#_bNot returning bool)((#_isUnconstrained returning bool)()) then {
-    let (field: Field) = (2: Field);
-    let (_: Array<u8, 8: u32>) = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (3: u32));
+    let field = (2: Field);
+    let _ = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (3: u32));
     #_skip
   } else {
     (std::panic::panic<Tuple<>, Unit, 26: u32> as λ(FmtString<26: u32, Tuple<> >) -> Unit)((#_mkFormatString returning FmtString<26: u32, Tuple<> >)("radix must be a power of 2"));
@@ -281,9 +281,9 @@ noir_def std::field::tests::test_to_le_radix_3<>() -> Unit := {
 
 noir_def std::field::tests::test_to_le_radix_brillig_3<>() -> Unit := {
   if (#_isUnconstrained returning bool)() then {
-    let (field: Field) = (1: Field);
-    let (out: Array<u8, 8: u32>) = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (3: u32));
-    let mut (expected: Array<u8, 8: u32>) = (#_mkRepeatedArray returning Array<u8, 8: u32>)((0: u8));
+    let field = (1: Field);
+    let out = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (3: u32));
+    let mut expected = (#_mkRepeatedArray returning Array<u8, 8: u32>)((0: u8));
     (expected[(0: u32)]: u8) = (1: u8);
     (#_assert returning Unit)(((Array<u8, 8: u32> as Eq<>)::eq<> as λ(Array<u8, 8: u32>, Array<u8, 8: u32>) -> bool)(out, expected));
     #_skip
@@ -292,8 +292,8 @@ noir_def std::field::tests::test_to_le_radix_brillig_3<>() -> Unit := {
 
 noir_def std::field::tests::test_to_le_radix_512<>() -> Unit := {
   if (#_bNot returning bool)((#_isUnconstrained returning bool)()) then {
-    let (field: Field) = (2: Field);
-    let (_: Array<u8, 8: u32>) = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (512: u32));
+    let field = (2: Field);
+    let _ = (std::field::to_le_radix<8: u32> as λ(Field, u32) -> Array<u8, 8: u32>)(field, (512: u32));
     #_skip
   } else {
     (std::panic::panic<Tuple<>, Unit, 39: u32> as λ(FmtString<39: u32, Tuple<> >) -> Unit)((#_mkFormatString returning FmtString<39: u32, Tuple<> >)("radix must be less than or equal to 256"))
@@ -305,7 +305,7 @@ noir_def std::field::tests::not_enough_limbs_brillig<>() -> Unit := {
 }
 
 noir_def std::field::tests::not_enough_limbs<>() -> Unit := {
-  let (_: Array<u8, 16: u32>) = (std::field::to_le_bytes<16: u32> as λ(Field) -> Array<u8, 16: u32>)((340282366920938463463374607431768211456: Field));
+  let _ = (std::field::to_le_bytes<16: u32> as λ(Field) -> Array<u8, 16: u32>)((340282366920938463463374607431768211456: Field));
   #_skip
 }
 

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Hash/Mod.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Hash/Mod.lean
@@ -25,12 +25,12 @@ noir_def std::hash::pedersen_commitment<N: u32>(input: Array<Field, N: u32>) -> 
 }
 
 noir_def std::hash::pedersen_commitment_with_separator<N: u32>(input: Array<Field, N: u32>, separator: u32) -> std::embedded_curve_ops::EmbeddedCurvePoint<> := {
-  let mut (points: Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, N: u32>) = (#_mkRepeatedArray returning Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, N: u32>)((#_makeData returning std::embedded_curve_ops::EmbeddedCurveScalar<>)((0: Field), (0: Field)));
+  let mut points = (#_mkRepeatedArray returning Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, N: u32>)((#_makeData returning std::embedded_curve_ops::EmbeddedCurveScalar<>)((0: Field), (0: Field)));
   for i in (0: u32) .. uConst!(N: u32) do {
     (points[i]: std::embedded_curve_ops::EmbeddedCurveScalar<>) = (std::hash::from_field_unsafe<> as λ(Field) -> std::embedded_curve_ops::EmbeddedCurveScalar<>)((#_arrayIndex returning Field)(input, (#_cast returning u32)(i)));
     #_skip
   };
-  let (generators: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>) = (std::hash::derive_generators<N: u32, 24: u32> as λ(Array<u8, 24: u32>, u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>)((#_strAsBytes returning Array<u8, 24: u32>)("DEFAULT_DOMAIN_SEPARATOR"), separator);
+  let generators = (std::hash::derive_generators<N: u32, 24: u32> as λ(Array<u8, 24: u32>, u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>)((#_strAsBytes returning Array<u8, 24: u32>)("DEFAULT_DOMAIN_SEPARATOR"), separator);
   (std::embedded_curve_ops::multi_scalar_mul<N: u32> as λ(Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>, Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, N: u32>) -> std::embedded_curve_ops::EmbeddedCurvePoint<>)(generators, points)
 }
 
@@ -39,16 +39,16 @@ noir_def std::hash::pedersen_hash<N: u32>(input: Array<Field, N: u32>) -> Field 
 }
 
 noir_def std::hash::pedersen_hash_with_separator<N: u32>(input: Array<Field, N: u32>, separator: u32) -> Field := {
-  let mut (scalars: Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, (N + 1): u32>) = (#_mkRepeatedArray returning Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, (N + 1): u32>)((#_makeData returning std::embedded_curve_ops::EmbeddedCurveScalar<>)((0: Field), (0: Field)));
-  let mut (generators: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, (N + 1): u32>) = (#_mkRepeatedArray returning Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, (N + 1): u32>)((std::embedded_curve_ops::EmbeddedCurvePoint::point_at_infinity<> as λ() -> std::embedded_curve_ops::EmbeddedCurvePoint<>)());
-  let (domain_generators: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>) = (std::hash::derive_generators<N: u32, 24: u32> as λ(Array<u8, 24: u32>, u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>)((#_strAsBytes returning Array<u8, 24: u32>)("DEFAULT_DOMAIN_SEPARATOR"), separator);
+  let mut scalars = (#_mkRepeatedArray returning Array<std::embedded_curve_ops::EmbeddedCurveScalar<>, (N + 1): u32>)((#_makeData returning std::embedded_curve_ops::EmbeddedCurveScalar<>)((0: Field), (0: Field)));
+  let mut generators = (#_mkRepeatedArray returning Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, (N + 1): u32>)((std::embedded_curve_ops::EmbeddedCurvePoint::point_at_infinity<> as λ() -> std::embedded_curve_ops::EmbeddedCurvePoint<>)());
+  let domain_generators = (std::hash::derive_generators<N: u32, 24: u32> as λ(Array<u8, 24: u32>, u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, N: u32>)((#_strAsBytes returning Array<u8, 24: u32>)("DEFAULT_DOMAIN_SEPARATOR"), separator);
   for i in (0: u32) .. uConst!(N: u32) do {
     (scalars[i]: std::embedded_curve_ops::EmbeddedCurveScalar<>) = (std::hash::from_field_unsafe<> as λ(Field) -> std::embedded_curve_ops::EmbeddedCurveScalar<>)((#_arrayIndex returning Field)(input, (#_cast returning u32)(i)));
     (generators[i]: std::embedded_curve_ops::EmbeddedCurvePoint<>) = (#_arrayIndex returning std::embedded_curve_ops::EmbeddedCurvePoint<>)(domain_generators, (#_cast returning u32)(i));
     #_skip
   };
   (scalars[uConst!(N: u32)]: std::embedded_curve_ops::EmbeddedCurveScalar<>) = (#_makeData returning std::embedded_curve_ops::EmbeddedCurveScalar<>)((#_cast returning Field)(uConst!(N: u32)), (#_cast returning Field)((0: Field)));
-  let (length_generator: Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>) = (std::hash::derive_generators<1: u32, 20: u32> as λ(Array<u8, 20: u32>, u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>)((#_strAsBytes returning Array<u8, 20: u32>)("pedersen_hash_length"), (0: u32));
+  let length_generator = (std::hash::derive_generators<1: u32, 20: u32> as λ(Array<u8, 20: u32>, u32) -> Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>)((#_strAsBytes returning Array<u8, 20: u32>)("pedersen_hash_length"), (0: u32));
   (generators[uConst!(N: u32)]: std::embedded_curve_ops::EmbeddedCurvePoint<>) = (#_arrayIndex returning std::embedded_curve_ops::EmbeddedCurvePoint<>)(length_generator, (0: u32));
   (#_arrayIndex returning std::embedded_curve_ops::EmbeddedCurvePoint<>)((#_multiScalarMul returning Array<std::embedded_curve_ops::EmbeddedCurvePoint<>, 1: u32>)(generators, scalars), (0: u32)).0
 }
@@ -59,10 +59,10 @@ noir_def std::hash::derive_generators<N: u32, M: u32>(domain_separator_bytes: Ar
 }
 
 noir_def std::hash::from_field_unsafe<>(scalar: Field) -> std::embedded_curve_ops::EmbeddedCurveScalar<> := {
-  let ((xlo: Field), (xhi: Field)) = {
+  let (xlo, xhi) = {
     (std::field::bn254::decompose_hint<> as λ(Field) -> Tuple<Field, Field>)(scalar)
   };
-  (#_assert returning Unit)((#_fEq returning bool)(scalar, (#_fAdd returning Field)(xlo, (#_fMul returning Field)((TWO_POW_128<> as λ() -> Field)(), xhi))));
+  (#_assert returning Unit)((#_fEq returning bool)(scalar, (#_fAdd returning Field)(xlo, (#_fMul returning Field)((std::field::bn254::TWO_POW_128<> as λ() -> Field)(), xhi))));
   (#_makeData returning std::embedded_curve_ops::EmbeddedCurveScalar<>)(xlo, xhi)
 }
 
@@ -170,9 +170,9 @@ noir_trait_impl[impl_16]<> std::hash::Hash<> for Unit where [] := {
 
 noir_trait_impl[impl_17]<N: u32, T: Type> std::hash::Hash<> for Array<T, N: u32> where [T: std::hash::Hash<>] := {
   noir_def hash<H: Type>(self: Array<T, N: u32>, state: & H) -> Unit := {
-    let (ζi0: Array<T, N: u32>) = self;
+    let ζi0 = self;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: T) = (#_arrayIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_arrayIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
       {
         ((T as std::hash::Hash<>)::hash<H> as λ(T, & H) -> Unit)(elem, state);
         #_skip
@@ -186,9 +186,9 @@ noir_trait_impl[impl_18]<T: Type> std::hash::Hash<> for Slice<T> where [T: std::
   noir_def hash<H: Type>(self: Slice<T>, state: & H) -> Unit := {
     ((u32 as std::hash::Hash<>)::hash<H> as λ(u32, & H) -> Unit)((#_arrayLen returning u32)(self), state);
     {
-      let (ζi0: Slice<T>) = self;
+      let ζi0 = self;
       for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-        let (elem: T) = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+        let elem = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
         {
           ((T as std::hash::Hash<>)::hash<H> as λ(T, & H) -> Unit)(elem, state);
           #_skip

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Hash/Poseidon2.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Hash/Poseidon2.lean
@@ -13,13 +13,13 @@ noir_def std::hash::poseidon2::Poseidon2::hash<N: u32>(input: Array<Field, N: u3
 }
 
 noir_def std::hash::poseidon2::Poseidon2::new<>(iv: Field) -> std::hash::poseidon2::Poseidon2<> := {
-  let mut (result: std::hash::poseidon2::Poseidon2<>) = (#_makeData returning std::hash::poseidon2::Poseidon2<>)((#_mkRepeatedArray returning Array<Field, 3: u32>)((0: Field)), (#_mkRepeatedArray returning Array<Field, 4: u32>)((0: Field)), (0: u32), #_false);
-  ((result.1: Array<Field, 4: u32>)[(RATE<> as λ() -> u32)()]: Field) = iv;
+  let mut result = (#_makeData returning std::hash::poseidon2::Poseidon2<>)((#_mkRepeatedArray returning Array<Field, 3: u32>)((0: Field)), (#_mkRepeatedArray returning Array<Field, 4: u32>)((0: Field)), (0: u32), #_false);
+  ((result.1: Array<Field, 4: u32>)[(std::hash::poseidon2::RATE<> as λ() -> u32)()]: Field) = iv;
   result
 }
 
 noir_def std::hash::poseidon2::Poseidon2::perform_duplex<>(self: & std::hash::poseidon2::Poseidon2<>) -> Unit := {
-  for i in (0: u32) .. (RATE<> as λ() -> u32)() do {
+  for i in (0: u32) .. (std::hash::poseidon2::RATE<> as λ() -> u32)() do {
     if (#_uLt returning bool)(i, (#_readRef returning std::hash::poseidon2::Poseidon2<>)(self).2) then {
       (((*self: std::hash::poseidon2::Poseidon2<>).1: Array<Field, 4: u32>)[i]: Field) = (#_fAdd returning Field)((#_arrayIndex returning Field)((#_readRef returning std::hash::poseidon2::Poseidon2<>)(self).1, (#_cast returning u32)(i)), (#_arrayIndex returning Field)((#_readRef returning std::hash::poseidon2::Poseidon2<>)(self).0, (#_cast returning u32)(i)));
       #_skip
@@ -31,14 +31,14 @@ noir_def std::hash::poseidon2::Poseidon2::perform_duplex<>(self: & std::hash::po
 
 noir_def std::hash::poseidon2::Poseidon2::absorb<>(self: & std::hash::poseidon2::Poseidon2<>, input: Field) -> Unit := {
   (#_assert returning Unit)((#_bNot returning bool)((#_readRef returning std::hash::poseidon2::Poseidon2<>)(self).3));
-  if (#_uEq returning bool)((#_readRef returning std::hash::poseidon2::Poseidon2<>)(self).2, (RATE<> as λ() -> u32)()) then {
+  if (#_uEq returning bool)((#_readRef returning std::hash::poseidon2::Poseidon2<>)(self).2, (std::hash::poseidon2::RATE<> as λ() -> u32)()) then {
     (std::hash::poseidon2::Poseidon2::perform_duplex<> as λ(& std::hash::poseidon2::Poseidon2<>) -> Unit)(self);
     (((*self: std::hash::poseidon2::Poseidon2<>).0: Array<Field, 3: u32>)[(0: u32)]: Field) = input;
     ((*self: std::hash::poseidon2::Poseidon2<>).2: u32) = (1: u32);
     #_skip
   } else {
     {
-      let (i_2571: Unit) = (#_readRef returning std::hash::poseidon2::Poseidon2<>)(self).2;
+      let i_2571 = (#_readRef returning std::hash::poseidon2::Poseidon2<>)(self).2;
       (((*self: std::hash::poseidon2::Poseidon2<>).0: Array<Field, 3: u32>)[i_2571]: Field) = input;
       #_skip
     };
@@ -55,9 +55,9 @@ noir_def std::hash::poseidon2::Poseidon2::squeeze<>(self: & std::hash::poseidon2
 }
 
 noir_def std::hash::poseidon2::Poseidon2::hash_internal<N: u32>(input: Array<Field, N: u32>, in_len: u32, is_variable_length: bool) -> Field := {
-  let (two_pow_64: Field) = (18446744073709551616: Field);
-  let (iv: Field) = (#_fMul returning Field)((#_cast returning Field)(in_len), two_pow_64);
-  let mut (sponge: std::hash::poseidon2::Poseidon2<>) = (std::hash::poseidon2::Poseidon2::new<> as λ(Field) -> std::hash::poseidon2::Poseidon2<>)(iv);
+  let two_pow_64 = (18446744073709551616: Field);
+  let iv = (#_fMul returning Field)((#_cast returning Field)(in_len), two_pow_64);
+  let mut sponge = (std::hash::poseidon2::Poseidon2::new<> as λ(Field) -> std::hash::poseidon2::Poseidon2<>)(iv);
   for i in (0: u32) .. (#_arrayLen returning u32)(input) do {
     if (#_uLt returning bool)(i, in_len) then {
       (std::hash::poseidon2::Poseidon2::absorb<> as λ(& std::hash::poseidon2::Poseidon2<>, Field) -> Unit)((#_ref returning & std::hash::poseidon2::Poseidon2<>)(sponge), (#_arrayIndex returning Field)(input, (#_cast returning u32)(i)));
@@ -73,8 +73,8 @@ noir_def std::hash::poseidon2::Poseidon2::hash_internal<N: u32>(input: Array<Fie
 
 noir_trait_impl[impl_0]<> std::hash::Hasher<> for std::hash::poseidon2::Poseidon2Hasher<> where [] := {
   noir_def finish<>(self: std::hash::poseidon2::Poseidon2Hasher<>) -> Field := {
-    let (iv: Field) = (#_fMul returning Field)((#_cast returning Field)((#_arrayLen returning u32)(self.0)), (18446744073709551616: Field));
-    let mut (sponge: std::hash::poseidon2::Poseidon2<>) = (std::hash::poseidon2::Poseidon2::new<> as λ(Field) -> std::hash::poseidon2::Poseidon2<>)(iv);
+    let iv = (#_fMul returning Field)((#_cast returning Field)((#_arrayLen returning u32)(self.0)), (18446744073709551616: Field));
+    let mut sponge = (std::hash::poseidon2::Poseidon2::new<> as λ(Field) -> std::hash::poseidon2::Poseidon2<>)(iv);
     for i in (0: u32) .. (#_arrayLen returning u32)(self.0) do {
       (std::hash::poseidon2::Poseidon2::absorb<> as λ(& std::hash::poseidon2::Poseidon2<>, Field) -> Unit)((#_ref returning & std::hash::poseidon2::Poseidon2<>)(sponge), (#_sliceIndex returning Field)(self.0, (#_cast returning u32)(i)));
       #_skip

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Lib.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Lib.lean
@@ -53,10 +53,10 @@ noir_def std::tests::test_static_assert_custom_message<>() -> Unit := {
 }
 
 noir_def std::tests::test_wrapping_mul<>() -> Unit := {
-  let (zero: u128) = (0: u128);
-  let (one: u128) = (1: u128);
-  let (two_pow_64: u128) = (18446744073709551616: u128);
-  let (u128_max: u128) = (340282366920938463463374607431768211455: u128);
+  let zero = (0: u128);
+  let one = (1: u128);
+  let two_pow_64 = (18446744073709551616: u128);
+  let u128_max = (340282366920938463463374607431768211455: u128);
   (#_assert returning Unit)((#_uEq returning bool)(zero, ((u128 as std::ops::arith::WrappingMul<>)::wrapping_mul<> as λ(u128, u128) -> u128)(zero, one)));
   (#_assert returning Unit)((#_uEq returning bool)(zero, ((u128 as std::ops::arith::WrappingMul<>)::wrapping_mul<> as λ(u128, u128) -> u128)(one, zero)));
   (#_assert returning Unit)((#_uEq returning bool)(one, ((u128 as std::ops::arith::WrappingMul<>)::wrapping_mul<> as λ(u128, u128) -> u128)(one, one)));

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Meta/Mod.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Meta/Mod.lean
@@ -29,11 +29,11 @@ noir_def std::«meta»::tests::concatenate_test<>() -> Unit := {
 }
 
 noir_def std::«meta»::tests::remove_unused_warnings<>() -> Unit := {
-  let (_: std::«meta»::tests::Bar<>) = (#_makeData returning std::«meta»::tests::Bar<>)((1: Field), (#_mkArray returning Array<Field, 2: u32>)((2: Field), (3: Field)));
-  let (_: std::«meta»::tests::MyStruct<>) = (#_makeData returning std::«meta»::tests::MyStruct<>)((1: i32));
-  let (_: std::«meta»::tests::MyOtherStruct<>) = (#_makeData returning std::«meta»::tests::MyOtherStruct<>)((2: u32));
-  let (_: Unit) = (std::meta::tests::derive_do_nothing<> as λ(Unit) -> Unit)((std::panic::panic<Tuple<>, Unit, 0: u32> as λ(FmtString<0: u32, Tuple<> >) -> Unit)((#_mkFormatString returning FmtString<0: u32, Tuple<> >)("")));
-  let (_: Unit) = (std::meta::tests::derive_do_nothing_alt<> as λ(Unit) -> Unit)((std::panic::panic<Tuple<>, Unit, 0: u32> as λ(FmtString<0: u32, Tuple<> >) -> Unit)((#_mkFormatString returning FmtString<0: u32, Tuple<> >)("")));
+  let _ = (#_makeData returning std::«meta»::tests::Bar<>)((1: Field), (#_mkArray returning Array<Field, 2: u32>)((2: Field), (3: Field)));
+  let _ = (#_makeData returning std::«meta»::tests::MyStruct<>)((1: i32));
+  let _ = (#_makeData returning std::«meta»::tests::MyOtherStruct<>)((2: u32));
+  let _ = (std::meta::tests::derive_do_nothing<> as λ(Unit) -> Unit)((std::panic::panic<Tuple<>, Unit, 0: u32> as λ(FmtString<0: u32, Tuple<> >) -> Unit)((#_mkFormatString returning FmtString<0: u32, Tuple<> >)("")));
+  let _ = (std::meta::tests::derive_do_nothing_alt<> as λ(Unit) -> Unit)((std::panic::panic<Tuple<>, Unit, 0: u32> as λ(FmtString<0: u32, Tuple<> >) -> Unit)((#_mkFormatString returning FmtString<0: u32, Tuple<> >)("")));
   if #_false then {
     (std::meta::tests::remove_unused_warnings<> as λ() -> Unit)();
     #_skip

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Ops/Arith.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Ops/Arith.lean
@@ -400,28 +400,28 @@ noir_trait_impl[impl_180]<> std::ops::arith::WrappingAdd<> for u128 where [] := 
 
 noir_trait_impl[impl_181]<> std::ops::arith::WrappingAdd<> for i8 where [] := {
   noir_def wrapping_add<>(self: i8, y: i8) -> i8 := {
-    let (x: u8) = (#_cast returning u8)(self);
+    let x = (#_cast returning u8)(self);
     (#_cast returning i8)(((u8 as std::ops::arith::WrappingAdd<>)::wrapping_add<> as λ(u8, u8) -> u8)(x, (#_cast returning u8)(y)))
   };
 }
 
 noir_trait_impl[impl_182]<> std::ops::arith::WrappingAdd<> for i16 where [] := {
   noir_def wrapping_add<>(self: i16, y: i16) -> i16 := {
-    let (x: u16) = (#_cast returning u16)(self);
+    let x = (#_cast returning u16)(self);
     (#_cast returning i16)(((u16 as std::ops::arith::WrappingAdd<>)::wrapping_add<> as λ(u16, u16) -> u16)(x, (#_cast returning u16)(y)))
   };
 }
 
 noir_trait_impl[impl_183]<> std::ops::arith::WrappingAdd<> for i32 where [] := {
   noir_def wrapping_add<>(self: i32, y: i32) -> i32 := {
-    let (x: u32) = (#_cast returning u32)(self);
+    let x = (#_cast returning u32)(self);
     (#_cast returning i32)(((u32 as std::ops::arith::WrappingAdd<>)::wrapping_add<> as λ(u32, u32) -> u32)(x, (#_cast returning u32)(y)))
   };
 }
 
 noir_trait_impl[impl_184]<> std::ops::arith::WrappingAdd<> for i64 where [] := {
   noir_def wrapping_add<>(self: i64, y: i64) -> i64 := {
-    let (x: u64) = (#_cast returning u64)(self);
+    let x = (#_cast returning u64)(self);
     (#_cast returning i64)(((u64 as std::ops::arith::WrappingAdd<>)::wrapping_add<> as λ(u64, u64) -> u64)(x, (#_cast returning u64)(y)))
   };
 }
@@ -470,28 +470,28 @@ noir_trait_impl[impl_191]<> std::ops::arith::WrappingSub<> for u128 where [] := 
 
 noir_trait_impl[impl_192]<> std::ops::arith::WrappingSub<> for i8 where [] := {
   noir_def wrapping_sub<>(self: i8, y: i8) -> i8 := {
-    let (x: u8) = (#_cast returning u8)(self);
+    let x = (#_cast returning u8)(self);
     (#_cast returning i8)(((u8 as std::ops::arith::WrappingSub<>)::wrapping_sub<> as λ(u8, u8) -> u8)(x, (#_cast returning u8)(y)))
   };
 }
 
 noir_trait_impl[impl_193]<> std::ops::arith::WrappingSub<> for i16 where [] := {
   noir_def wrapping_sub<>(self: i16, y: i16) -> i16 := {
-    let (x: u16) = (#_cast returning u16)(self);
+    let x = (#_cast returning u16)(self);
     (#_cast returning i16)(((u16 as std::ops::arith::WrappingSub<>)::wrapping_sub<> as λ(u16, u16) -> u16)(x, (#_cast returning u16)(y)))
   };
 }
 
 noir_trait_impl[impl_194]<> std::ops::arith::WrappingSub<> for i32 where [] := {
   noir_def wrapping_sub<>(self: i32, y: i32) -> i32 := {
-    let (x: u32) = (#_cast returning u32)(self);
+    let x = (#_cast returning u32)(self);
     (#_cast returning i32)(((u32 as std::ops::arith::WrappingSub<>)::wrapping_sub<> as λ(u32, u32) -> u32)(x, (#_cast returning u32)(y)))
   };
 }
 
 noir_trait_impl[impl_195]<> std::ops::arith::WrappingSub<> for i64 where [] := {
   noir_def wrapping_sub<>(self: i64, y: i64) -> i64 := {
-    let (x: u64) = (#_cast returning u64)(self);
+    let x = (#_cast returning u64)(self);
     (#_cast returning i64)(((u64 as std::ops::arith::WrappingSub<>)::wrapping_sub<> as λ(u64, u64) -> u64)(x, (#_cast returning u64)(y)))
   };
 }
@@ -534,28 +534,28 @@ noir_trait_impl[impl_201]<> std::ops::arith::WrappingMul<> for u64 where [] := {
 
 noir_trait_impl[impl_202]<> std::ops::arith::WrappingMul<> for i8 where [] := {
   noir_def wrapping_mul<>(self: i8, y: i8) -> i8 := {
-    let (x: u8) = (#_cast returning u8)(self);
+    let x = (#_cast returning u8)(self);
     (#_cast returning i8)(((u8 as std::ops::arith::WrappingMul<>)::wrapping_mul<> as λ(u8, u8) -> u8)(x, (#_cast returning u8)(y)))
   };
 }
 
 noir_trait_impl[impl_203]<> std::ops::arith::WrappingMul<> for i16 where [] := {
   noir_def wrapping_mul<>(self: i16, y: i16) -> i16 := {
-    let (x: u16) = (#_cast returning u16)(self);
+    let x = (#_cast returning u16)(self);
     (#_cast returning i16)(((u16 as std::ops::arith::WrappingMul<>)::wrapping_mul<> as λ(u16, u16) -> u16)(x, (#_cast returning u16)(y)))
   };
 }
 
 noir_trait_impl[impl_204]<> std::ops::arith::WrappingMul<> for i32 where [] := {
   noir_def wrapping_mul<>(self: i32, y: i32) -> i32 := {
-    let (x: u32) = (#_cast returning u32)(self);
+    let x = (#_cast returning u32)(self);
     (#_cast returning i32)(((u32 as std::ops::arith::WrappingMul<>)::wrapping_mul<> as λ(u32, u32) -> u32)(x, (#_cast returning u32)(y)))
   };
 }
 
 noir_trait_impl[impl_205]<> std::ops::arith::WrappingMul<> for i64 where [] := {
   noir_def wrapping_mul<>(self: i64, y: i64) -> i64 := {
-    let (x: u64) = (#_cast returning u64)(self);
+    let x = (#_cast returning u64)(self);
     (#_cast returning i64)(((u64 as std::ops::arith::WrappingMul<>)::wrapping_mul<> as λ(u64, u64) -> u64)(x, (#_cast returning u64)(y)))
   };
 }
@@ -591,22 +591,22 @@ noir_def std::ops::arith::split64<>(x: u128) -> Tuple<u64, u64> := {
 }
 
 noir_def std::ops::arith::split_into_64_bit_limbs<>(x: u128) -> Tuple<u64, u64> := {
-  let ((x_lo: u64), (x_hi: u64)) = {
+  let (x_lo, x_hi) = {
     (std::ops::arith::split64<> as λ(u128) -> Tuple<u64, u64>)(x)
   };
-  (#_assert returning Unit)((#_fEq returning bool)((#_cast returning Field)(x), (#_fAdd returning Field)((#_cast returning Field)(x_lo), (#_fMul returning Field)((#_cast returning Field)(x_hi), (#_cast returning Field)((two_pow_64<> as λ() -> u128)())))));
+  (#_assert returning Unit)((#_fEq returning bool)((#_cast returning Field)(x), (#_fAdd returning Field)((#_cast returning Field)(x_lo), (#_fMul returning Field)((#_cast returning Field)(x_hi), (#_cast returning Field)((std::ops::arith::two_pow_64<> as λ() -> u128)())))));
   (#_makeData returning Tuple<u64, u64>)(x_lo, x_hi)
 }
 
 noir_def std::ops::arith::wrapping_mul128_hlp<>(x: u128, y: u128) -> u128 := {
-  let ((x_lo: u64), (x_hi: u64)) = (std::ops::arith::split_into_64_bit_limbs<> as λ(u128) -> Tuple<u64, u64>)(x);
-  let ((y_lo: u64), (y_hi: u64)) = (std::ops::arith::split_into_64_bit_limbs<> as λ(u128) -> Tuple<u64, u64>)(y);
-  let (low: Field) = (#_fMul returning Field)((#_cast returning Field)(x_lo), (#_cast returning Field)(y_lo));
-  let (lo: Field) = (#_cast returning Field)((#_cast returning u64)(low));
-  let (carry: Field) = (#_fDiv returning Field)((#_fSub returning Field)(low, lo), (#_cast returning Field)((two_pow_64<> as λ() -> u128)()));
-  let (high: Field) = (#_fAdd returning Field)((#_fAdd returning Field)((#_fMul returning Field)((#_cast returning Field)(x_lo), (#_cast returning Field)(y_hi)), (#_fMul returning Field)((#_cast returning Field)(x_hi), (#_cast returning Field)(y_lo))), carry);
-  let (hi: Field) = (#_cast returning Field)((#_cast returning u64)(high));
-  (#_cast returning u128)((#_fAdd returning Field)(lo, (#_fMul returning Field)((#_cast returning Field)((two_pow_64<> as λ() -> u128)()), hi)))
+  let (x_lo, x_hi) = (std::ops::arith::split_into_64_bit_limbs<> as λ(u128) -> Tuple<u64, u64>)(x);
+  let (y_lo, y_hi) = (std::ops::arith::split_into_64_bit_limbs<> as λ(u128) -> Tuple<u64, u64>)(y);
+  let low = (#_fMul returning Field)((#_cast returning Field)(x_lo), (#_cast returning Field)(y_lo));
+  let lo = (#_cast returning Field)((#_cast returning u64)(low));
+  let carry = (#_fDiv returning Field)((#_fSub returning Field)(low, lo), (#_cast returning Field)((std::ops::arith::two_pow_64<> as λ() -> u128)()));
+  let high = (#_fAdd returning Field)((#_fAdd returning Field)((#_fMul returning Field)((#_cast returning Field)(x_lo), (#_cast returning Field)(y_hi)), (#_fMul returning Field)((#_cast returning Field)(x_hi), (#_cast returning Field)(y_lo))), carry);
+  let hi = (#_cast returning Field)((#_cast returning u64)(high));
+  (#_cast returning u128)((#_fAdd returning Field)(lo, (#_fMul returning Field)((#_cast returning Field)((std::ops::arith::two_pow_64<> as λ() -> u128)()), hi)))
 }
 
 def Ops.Arith.env : Env := Env.mk

--- a/stdlib/lampe/std-1.0.0-beta.11/Extracted/Slice.lean
+++ b/stdlib/lampe/std-1.0.0-beta.11/Extracted/Slice.lean
@@ -10,9 +10,9 @@ namespace Extracted
 
 noir_def std::slice::append<T: Type>(mut self: Slice<T>, other: Slice<T>) -> Slice<T> := {
   {
-    let (ζi0: Slice<T>) = other;
+    let ζi0 = other;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: T) = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
       {
         self = (#_slicePushBack returning Slice<T>)(self, elem);
         #_skip
@@ -25,7 +25,7 @@ noir_def std::slice::append<T: Type>(mut self: Slice<T>, other: Slice<T>) -> Sli
 
 noir_def std::slice::as_array<T: Type, N: u32>(self: Slice<T>) -> Array<T, N: u32> := {
   (#_assert returning Unit)((#_uEq returning bool)((#_arrayLen returning u32)(self), uConst!(N: u32)));
-  let mut (array: Array<T, N: u32>) = (#_mkRepeatedArray returning Array<T, N: u32>)((#_zeroed returning T)());
+  let mut array = (#_mkRepeatedArray returning Array<T, N: u32>)((#_zeroed returning T)());
   for i in (0: u32) .. uConst!(N: u32) do {
     (array[i]: T) = (#_sliceIndex returning T)(self, (#_cast returning u32)(i));
     #_skip
@@ -34,11 +34,11 @@ noir_def std::slice::as_array<T: Type, N: u32>(self: Slice<T>) -> Array<T, N: u3
 }
 
 noir_def std::slice::map<T: Type, U: Type, Env: Type>(self: Slice<T>, f: λ(T) -> U) -> Slice<U> := {
-  let mut (ret: Slice<U>) = (#_mkSlice returning Slice<U>)();
+  let mut ret = (#_mkSlice returning Slice<U>)();
   {
-    let (ζi0: Slice<T>) = self;
+    let ζi0 = self;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: T) = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
       {
         ret = (#_slicePushBack returning Slice<U>)(ret, (f as λ(T) -> U)(elem));
         #_skip
@@ -50,12 +50,12 @@ noir_def std::slice::map<T: Type, U: Type, Env: Type>(self: Slice<T>, f: λ(T) -
 }
 
 noir_def std::slice::mapi<T: Type, U: Type, Env: Type>(self: Slice<T>, f: λ(u32, T) -> U) -> Slice<U> := {
-  let mut (ret: Slice<U>) = (#_mkSlice returning Slice<U>)();
-  let mut (index: u32) = (0: u32);
+  let mut ret = (#_mkSlice returning Slice<U>)();
+  let mut index = (0: u32);
   {
-    let (ζi0: Slice<T>) = self;
+    let ζi0 = self;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: T) = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
       {
         ret = (#_slicePushBack returning Slice<U>)(ret, (f as λ(u32, T) -> U)(index, elem));
         index = (#_uAdd returning u32)(index, (1: u32));
@@ -68,9 +68,9 @@ noir_def std::slice::mapi<T: Type, U: Type, Env: Type>(self: Slice<T>, f: λ(u32
 }
 
 noir_def std::slice::for_each<T: Type, Env: Type>(self: Slice<T>, f: λ(T) -> Unit) -> Unit := {
-  let (ζi0: Slice<T>) = self;
+  let ζi0 = self;
   for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-    let (elem: T) = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+    let elem = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
     {
       (f as λ(T) -> Unit)(elem);
       #_skip
@@ -80,11 +80,11 @@ noir_def std::slice::for_each<T: Type, Env: Type>(self: Slice<T>, f: λ(T) -> Un
 }
 
 noir_def std::slice::for_eachi<T: Type, Env: Type>(self: Slice<T>, f: λ(u32, T) -> Unit) -> Unit := {
-  let mut (index: u32) = (0: u32);
+  let mut index = (0: u32);
   {
-    let (ζi0: Slice<T>) = self;
+    let ζi0 = self;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: T) = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
       {
         (f as λ(u32, T) -> Unit)(index, elem);
         index = (#_uAdd returning u32)(index, (1: u32));
@@ -97,9 +97,9 @@ noir_def std::slice::for_eachi<T: Type, Env: Type>(self: Slice<T>, f: λ(u32, T)
 
 noir_def std::slice::fold<T: Type, U: Type, Env: Type>(self: Slice<T>, mut accumulator: U, f: λ(U, T) -> U) -> U := {
   {
-    let (ζi0: Slice<T>) = self;
+    let ζi0 = self;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: T) = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
       {
         accumulator = (f as λ(U, T) -> U)(accumulator, elem);
         #_skip
@@ -111,7 +111,7 @@ noir_def std::slice::fold<T: Type, U: Type, Env: Type>(self: Slice<T>, mut accum
 }
 
 noir_def std::slice::reduce<T: Type, Env: Type>(self: Slice<T>, f: λ(T, T) -> T) -> T := {
-  let mut (accumulator: T) = (#_sliceIndex returning T)(self, (0: u32));
+  let mut accumulator = (#_sliceIndex returning T)(self, (0: u32));
   for i in (1: u32) .. (#_arrayLen returning u32)(self) do {
     accumulator = (f as λ(T, T) -> T)(accumulator, (#_sliceIndex returning T)(self, (#_cast returning u32)(i)));
     #_skip
@@ -120,11 +120,11 @@ noir_def std::slice::reduce<T: Type, Env: Type>(self: Slice<T>, f: λ(T, T) -> T
 }
 
 noir_def std::slice::filter<T: Type, Env: Type>(self: Slice<T>, predicate: λ(T) -> bool) -> Slice<T> := {
-  let mut (ret: Slice<T>) = (#_mkSlice returning Slice<T>)();
+  let mut ret = (#_mkSlice returning Slice<T>)();
   {
-    let (ζi0: Slice<T>) = self;
+    let ζi0 = self;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: T) = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
       {
         if (predicate as λ(T) -> bool)(elem) then {
           ret = (#_slicePushBack returning Slice<T>)(ret, elem);
@@ -138,7 +138,7 @@ noir_def std::slice::filter<T: Type, Env: Type>(self: Slice<T>, predicate: λ(T)
 }
 
 noir_def std::slice::join<T: Type>(self: Slice<T>, separator: T) -> T := {
-  let mut (ret: T) = ((T as std::append::Append<>)::empty<> as λ() -> T)();
+  let mut ret = ((T as std::append::Append<>)::empty<> as λ() -> T)();
   if (#_uNeq returning bool)((#_arrayLen returning u32)(self), (0: u32)) then {
     ret = (#_sliceIndex returning T)(self, (0: u32));
     for i in (1: u32) .. (#_arrayLen returning u32)(self) do {
@@ -151,11 +151,11 @@ noir_def std::slice::join<T: Type>(self: Slice<T>, separator: T) -> T := {
 }
 
 noir_def std::slice::all<T: Type, Env: Type>(self: Slice<T>, predicate: λ(T) -> bool) -> bool := {
-  let mut (ret: bool) = #_true;
+  let mut ret = #_true;
   {
-    let (ζi0: Slice<T>) = self;
+    let ζi0 = self;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: T) = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
       {
         ret = (#_bAnd returning bool)(ret, (predicate as λ(T) -> bool)(elem));
         #_skip
@@ -167,11 +167,11 @@ noir_def std::slice::all<T: Type, Env: Type>(self: Slice<T>, predicate: λ(T) ->
 }
 
 noir_def std::slice::any<T: Type, Env: Type>(self: Slice<T>, predicate: λ(T) -> bool) -> bool := {
-  let mut (ret: bool) = #_false;
+  let mut ret = #_false;
   {
-    let (ζi0: Slice<T>) = self;
+    let ζi0 = self;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: T) = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_sliceIndex returning T)(ζi0, (#_cast returning u32)(ζi1));
       {
         ret = (#_bOr returning bool)(ret, (predicate as λ(T) -> bool)(elem));
         #_skip
@@ -183,46 +183,46 @@ noir_def std::slice::any<T: Type, Env: Type>(self: Slice<T>, predicate: λ(T) ->
 }
 
 noir_def std::slice::test::map_empty<>() -> Unit := {
-  (#_assert returning Unit)(((Slice<Field> as Eq<>)::eq<> as λ(Slice<Field>, Slice<Field>) -> bool)((std::slice::map<Field, Unit> as λ(Slice<Field>, λ(Field) -> Field) -> Slice<Field>)((#_mkSlice returning Slice<Field>)(), (fn((x: Field)): Field := (#_fAdd returning Field)(x, (1: Field)))), (#_mkSlice returning Slice<Field>)()));
+  (#_assert returning Unit)(((Slice<Field> as Eq<>)::eq<> as λ(Slice<Field>, Slice<Field>) -> bool)((std::slice::map<Field, Unit> as λ(Slice<Field>, λ(Field) -> Field) -> Slice<Field>)((#_mkSlice returning Slice<Field>)(), (fn(x: Field): Field := (#_fAdd returning Field)(x, (1: Field)))), (#_mkSlice returning Slice<Field>)()));
   #_skip
 }
 
 noir_def std::slice::test::mapi_empty<>() -> Unit := {
-  (#_assert returning Unit)(((Slice<u32> as Eq<>)::eq<> as λ(Slice<u32>, Slice<u32>) -> bool)((std::slice::mapi<u32, Unit> as λ(Slice<u32>, λ(u32, u32) -> u32) -> Slice<u32>)((#_mkSlice returning Slice<u32>)(), (fn((i: u32), (x: u32)): u32 := (#_uAdd returning u32)((#_uMul returning u32)(i, x), (1: u32)))), (#_mkSlice returning Slice<u32>)()));
+  (#_assert returning Unit)(((Slice<u32> as Eq<>)::eq<> as λ(Slice<u32>, Slice<u32>) -> bool)((std::slice::mapi<u32, Unit> as λ(Slice<u32>, λ(u32, u32) -> u32) -> Slice<u32>)((#_mkSlice returning Slice<u32>)(), (fn(i: u32, x: u32): u32 := (#_uAdd returning u32)((#_uMul returning u32)(i, x), (1: u32)))), (#_mkSlice returning Slice<u32>)()));
   #_skip
 }
 
 noir_def std::slice::test::for_each_empty<>() -> Unit := {
-  let (empty_slice: Slice<Field>) = (#_mkSlice returning Slice<Field>)();
-  (std::slice::for_each<Field, Unit> as λ(Slice<Field>, λ(Field) -> Unit) -> Unit)(empty_slice, (fn((_x: Field)): Unit := (#_assert returning Unit)(#_false)));
+  let empty_slice = (#_mkSlice returning Slice<Field>)();
+  (std::slice::for_each<Field, Unit> as λ(Slice<Field>, λ(Field) -> Unit) -> Unit)(empty_slice, (fn(_x: Field): Unit := (#_assert returning Unit)(#_false)));
   #_skip
 }
 
 noir_def std::slice::test::for_eachi_empty<>() -> Unit := {
-  let (empty_slice: Slice<Field>) = (#_mkSlice returning Slice<Field>)();
-  (std::slice::for_eachi<Field, Unit> as λ(Slice<Field>, λ(u32, Field) -> Unit) -> Unit)(empty_slice, (fn((_i: u32), (_x: Field)): Unit := (#_assert returning Unit)(#_false)));
+  let empty_slice = (#_mkSlice returning Slice<Field>)();
+  (std::slice::for_eachi<Field, Unit> as λ(Slice<Field>, λ(u32, Field) -> Unit) -> Unit)(empty_slice, (fn(_i: u32, _x: Field): Unit := (#_assert returning Unit)(#_false)));
   #_skip
 }
 
 noir_def std::slice::test::map_example<>() -> Unit := {
-  let (a: Slice<Field>) = (#_mkSlice returning Slice<Field>)((1: Field), (2: Field), (3: Field));
-  let (b: Slice<Field>) = (std::slice::map<Field, Unit> as λ(Slice<Field>, λ(Field) -> Field) -> Slice<Field>)(a, (fn((a: Field)): Field := (#_fMul returning Field)(a, (2: Field))));
+  let a = (#_mkSlice returning Slice<Field>)((1: Field), (2: Field), (3: Field));
+  let b = (std::slice::map<Field, Unit> as λ(Slice<Field>, λ(Field) -> Field) -> Slice<Field>)(a, (fn(a: Field): Field := (#_fMul returning Field)(a, (2: Field))));
   (#_assert returning Unit)(((Slice<Field> as Eq<>)::eq<> as λ(Slice<Field>, Slice<Field>) -> bool)(b, (#_mkSlice returning Slice<Field>)((2: Field), (4: Field), (6: Field))));
   #_skip
 }
 
 noir_def std::slice::test::mapi_example<>() -> Unit := {
-  let (a: Slice<u32>) = (#_mkSlice returning Slice<u32>)((1: u32), (2: u32), (3: u32));
-  let (b: Slice<u32>) = (std::slice::mapi<u32, Unit> as λ(Slice<u32>, λ(u32, u32) -> u32) -> Slice<u32>)(a, (fn((i: u32), (a: u32)): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(a, (2: u32)))));
+  let a = (#_mkSlice returning Slice<u32>)((1: u32), (2: u32), (3: u32));
+  let b = (std::slice::mapi<u32, Unit> as λ(Slice<u32>, λ(u32, u32) -> u32) -> Slice<u32>)(a, (fn(i: u32, a: u32): u32 := (#_uAdd returning u32)(i, (#_uMul returning u32)(a, (2: u32)))));
   (#_assert returning Unit)(((Slice<u32> as Eq<>)::eq<> as λ(Slice<u32>, Slice<u32>) -> bool)(b, (#_mkSlice returning Slice<u32>)((2: u32), (5: u32), (8: u32))));
   #_skip
 }
 
 noir_def std::slice::test::for_each_example<>() -> Unit := {
-  let (a: Slice<Field>) = (#_mkSlice returning Slice<Field>)((1: Field), (2: Field), (3: Field));
-  let mut (b: Slice<Field>) = (#_mkSlice returning Slice<Field>)();
-  let (b_ref: & Slice<Field>) = (#_ref returning & Slice<Field>)(b);
-  (std::slice::for_each<Field, Tuple<& Slice<Field> > > as λ(Slice<Field>, λ(Field) -> Unit) -> Unit)(a, (fn((a: Field)): Unit := {
+  let a = (#_mkSlice returning Slice<Field>)((1: Field), (2: Field), (3: Field));
+  let mut b = (#_mkSlice returning Slice<Field>)();
+  let b_ref = (#_ref returning & Slice<Field>)(b);
+  (std::slice::for_each<Field, Tuple<& Slice<Field> > > as λ(Slice<Field>, λ(Field) -> Unit) -> Unit)(a, (fn(a: Field): Unit := {
     (*b_ref: Slice<Field>) = (#_slicePushBack returning Slice<Field>)((#_readRef returning Slice<Field>)(b_ref), (#_fMul returning Field)(a, (2: Field)));
     #_skip
   }));
@@ -231,10 +231,10 @@ noir_def std::slice::test::for_each_example<>() -> Unit := {
 }
 
 noir_def std::slice::test::for_eachi_example<>() -> Unit := {
-  let (a: Slice<u32>) = (#_mkSlice returning Slice<u32>)((1: u32), (2: u32), (3: u32));
-  let mut (b: Slice<u32>) = (#_mkSlice returning Slice<u32>)();
-  let (b_ref: & Slice<u32>) = (#_ref returning & Slice<u32>)(b);
-  (std::slice::for_eachi<u32, Tuple<& Slice<u32> > > as λ(Slice<u32>, λ(u32, u32) -> Unit) -> Unit)(a, (fn((i: u32), (a: u32)): Unit := {
+  let a = (#_mkSlice returning Slice<u32>)((1: u32), (2: u32), (3: u32));
+  let mut b = (#_mkSlice returning Slice<u32>)();
+  let b_ref = (#_ref returning & Slice<u32>)(b);
+  (std::slice::for_eachi<u32, Tuple<& Slice<u32> > > as λ(Slice<u32>, λ(u32, u32) -> Unit) -> Unit)(a, (fn(i: u32, a: u32): Unit := {
     (*b_ref: Slice<u32>) = (#_slicePushBack returning Slice<u32>)((#_readRef returning Slice<u32>)(b_ref), (#_uAdd returning u32)(i, (#_uMul returning u32)(a, (2: u32))));
     #_skip
   }));

--- a/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/ConstGenerics.lean
+++ b/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/ConstGenerics.lean
@@ -10,14 +10,14 @@ namespace Extracted
 
 noir_def const_generics::nat_generic_test<N: u32>() -> Array<Field, N: u32> := {
   for i in (0: u32) .. uConst!(N: u32) do {
-    let (_: u32) = i;
+    let _ = i;
     #_skip
   };
   (#_mkRepeatedArray returning Array<Field, N: u32>)((1: Field))
 }
 
 noir_def const_generics::nat_generic_test_2<N: u8>(x: Field) -> Field := {
-  let mut (res: Field) = x;
+  let mut res = x;
   for _ in (0: u8) .. uConst!(N: u8) do {
     res = (#_fMul returning Field)(res, (2: Field));
     #_skip

--- a/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/Experiments.lean
+++ b/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/Experiments.lean
@@ -37,26 +37,26 @@ noir_def experiments::cast_test<>(a: u8) -> u64 := {
 }
 
 noir_def experiments::tuple_test<>(a: u8) -> Tuple<u8, u8> := {
-  let (_b: λ(u8) -> u8) = (fn((c: u8)): u8 := (#_uAdd returning u8)((#_uAdd returning u8)(c, a), (10: u8)));
+  let _b = (fn(c: u8): u8 := (#_uAdd returning u8)((#_uAdd returning u8)(c, a), (10: u8)));
   (#_makeData returning Tuple<u8, u8>)(a, a)
 }
 
 noir_def experiments::literal_test<>() -> Unit := {
-  let (_a: Field) = (1: Field);
-  let (b: bool) = #_true;
-  let (_c: bool) = #_false;
-  let (_d: Array<Field, 5: u32>) = (#_mkRepeatedArray returning Array<Field, 5: u32>)((1: Field));
-  let (_e: Slice<Field>) = (#_mkRepeatedSlice returning Slice<Field>)((1: Field), (5: u32));
-  let (_f: Array<Field, 3: u32>) = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
-  let (_h: String<4: u32>) = "asdf";
-  let (_i: FmtString<4: u32, Tuple<bool> >) = (#_mkFormatString returning FmtString<4: u32, Tuple<bool> >)("${}{b}", b);
+  let _a = (1: Field);
+  let b = #_true;
+  let _c = #_false;
+  let _d = (#_mkRepeatedArray returning Array<Field, 5: u32>)((1: Field));
+  let _e = (#_mkRepeatedSlice returning Slice<Field>)((1: Field), (5: u32));
+  let _f = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
+  let _h = "asdf";
+  let _i = (#_mkFormatString returning FmtString<4: u32, Tuple<bool> >)("${}{b}", b);
   #_skip
 }
 
 noir_def experiments::assigns<>(x: u8) -> Unit := {
-  let mut (y: u8) = (3: u8);
+  let mut y = (3: u8);
   y = (#_uAdd returning u8)(y, x);
-  let mut (arr: Array<Field, 2: u32>) = (#_mkArray returning Array<Field, 2: u32>)((1: Field), (2: Field));
+  let mut arr = (#_mkArray returning Array<Field, 2: u32>)((1: Field), (2: Field));
   (arr[(0: u32)]: Field) = (10: Field);
   #_skip
 }
@@ -105,13 +105,13 @@ noir_trait_impl[impl_433]<T: Type> experiments::MyTrait<> for Tuple<T, bool> whe
 }
 
 noir_def experiments::string_test<>() -> String<5: u32> := {
-  let (x: String<5: u32>) = "Hello";
+  let x = "Hello";
   x
 }
 
 noir_def experiments::fmtstr_test<>(x: Field, y: Field) -> Field := {
   (#_assert returning Unit)((#_fNeq returning bool)(x, y));
-  let (_a: FmtString<37: u32, Tuple<Field, Field> >) = (#_mkFormatString returning FmtString<37: u32, Tuple<Field, Field> >)("this is first:{}{x}{}  this is second:{}{y}", x, y);
+  let _a = (#_mkFormatString returning FmtString<37: u32, Tuple<Field, Field> >)("this is first:{}{x}{}  this is second:{}{y}", x, y);
   (#_fAdd returning Field)(x, y)
 }
 
@@ -120,21 +120,21 @@ noir_def experiments::is_alias_some<T: Type>(x: @AliasedOpt<T>) -> bool := {
 }
 
 noir_def experiments::main<>() -> Unit := {
-  let mut (op1: experiments::Option2<Field>) = (experiments::Option2::some<Field> as λ(Field) -> experiments::Option2<Field>)((5: Field));
-  let (op2: experiments::Option2<Field>) = ((experiments::Option2<Field> as std::default::Default<>)::default<> as λ() -> experiments::Option2<Field>)();
-  let (_op3: experiments::Option2<Field>) = ((experiments::Option2<Field> as experiments::MyTrait<>)::foo<> as λ(experiments::Option2<Field>) -> experiments::Option2<Field>)(if #_true then {
+  let mut op1 = (experiments::Option2::some<Field> as λ(Field) -> experiments::Option2<Field>)((5: Field));
+  let op2 = ((experiments::Option2<Field> as std::default::Default<>)::default<> as λ() -> experiments::Option2<Field>)();
+  let _op3 = ((experiments::Option2<Field> as experiments::MyTrait<>)::foo<> as λ(experiments::Option2<Field>) -> experiments::Option2<Field>)(if #_true then {
     op1
   } else {
     op2
   });
-  let (_: bool) = (experiments::Option2::is_some<Field> as λ(experiments::Option2<Field>) -> bool)(op1);
-  let mut (l: Array<Field, 3: u32>) = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
-  let (_: Field) = (#_arrayIndex returning Field)(l, (0: u32));
-  let (t: Tuple<Field, bool, Field>) = (#_makeData returning Tuple<Field, bool, Field>)((1: Field), #_true, (3: Field));
-  let (_: Field) = t.2;
+  let _ = (experiments::Option2::is_some<Field> as λ(experiments::Option2<Field>) -> bool)(op1);
+  let mut l = (#_mkArray returning Array<Field, 3: u32>)((1: Field), (2: Field), (3: Field));
+  let _ = (#_arrayIndex returning Field)(l, (0: u32));
+  let t = (#_makeData returning Tuple<Field, bool, Field>)((1: Field), #_true, (3: Field));
+  let _ = t.2;
   (l[(1: u32)]: Field) = (4: Field);
   (op1.0: bool) = #_false;
-  let mut (tpl: Tuple<Field, bool>) = (#_makeData returning Tuple<Field, bool>)((1: Field), #_true);
+  let mut tpl = (#_makeData returning Tuple<Field, bool>)((1: Field), #_true);
   (tpl.0: Field) = (2: Field);
   #_skip
 }

--- a/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/FieldGenerics.lean
+++ b/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/FieldGenerics.lean
@@ -15,7 +15,7 @@ noir_def field_generics::foo1<A: Field>() -> Field := {
 }
 
 noir_def field_generics::main<>() -> Unit := {
-  let (_: Field) = (field_generics::foo1<4294967297: Field> as λ() -> Field)();
+  let _ = (field_generics::foo1<4294967297: Field> as λ() -> Field)();
   #_skip
 }
 

--- a/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/Patterns.lean
+++ b/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/Patterns.lean
@@ -13,9 +13,9 @@ noir_def patterns::Option2::some<T: Type>(value: T) -> patterns::Option2<T> := {
 }
 
 noir_def patterns::pattern_test<>() -> Unit := {
-  let (opt: patterns::Option2<bool>) = (patterns::Option2::some<bool> as λ(bool) -> patterns::Option2<bool>)(#_true);
-  let (t: Tuple<Field, patterns::Option2<bool>, Field>) = (#_makeData returning Tuple<Field, patterns::Option2<bool>, Field>)((1: Field), opt, (3: Field));
-  let ((_x: Field), ((_: bool), (_: bool)), mut (_z: Field)) = t;
+  let opt = (patterns::Option2::some<bool> as λ(bool) -> patterns::Option2<bool>)(#_true);
+  let t = (#_makeData returning Tuple<Field, patterns::Option2<bool>, Field>)((1: Field), opt, (3: Field));
+  let (_x, (_, _), mut _z) = t;
   #_skip
 }
 

--- a/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/StructNamespaces.lean
+++ b/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/StructNamespaces.lean
@@ -17,8 +17,8 @@ noir_def struct_namespaces::test::Foo::bar2<>() -> Field := {
 }
 
 noir_def struct_namespaces::baz<>(a: struct_namespaces::test::Foo<>) -> Field := {
-  let (x: Field) = (struct_namespaces::test::Foo::bar2<> as λ() -> Field)();
-  let (y: Field) = (struct_namespaces::test::Foo::bar<> as λ(struct_namespaces::test::Foo<>) -> Field)(a);
+  let x = (struct_namespaces::test::Foo::bar2<> as λ() -> Field)();
+  let y = (struct_namespaces::test::Foo::bar<> as λ(struct_namespaces::test::Foo<>) -> Field)(a);
   (#_fAdd returning Field)(x, y)
 }
 

--- a/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/UnitReturn.lean
+++ b/testing/ExtractionTests/lampe/ExtractionTests-0.0.0/Extracted/UnitReturn.lean
@@ -9,18 +9,18 @@ namespace «ExtractionTests-0.0.0»
 namespace Extracted
 
 noir_def unit_return::foo2<>() -> Unit := {
-  let (_x: Field) = (3: Field);
+  let _x = (3: Field);
   #_skip
 }
 
 noir_def unit_return::bar<>() -> Unit := {
-  let mut (x: Field) = (3: Field);
+  let mut x = (3: Field);
   x = (4: Field);
   #_skip
 }
 
 noir_def unit_return::baz<>() -> Unit := {
-  let (_x: Field) = (3: Field);
+  let _x = (3: Field);
   (unit_return::bar<> as λ() -> Unit)();
   #_skip
 }

--- a/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Bar.lean
+++ b/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Bar.lean
@@ -9,9 +9,9 @@ namespace «Merkle-0.0.0»
 namespace Extracted
 
 noir_def bar::bar<>(a: Field) -> Field := {
-  let (bytes: Array<u8, 32: u32>) = (utils::bytes::to_le_bytes<> as λ(Field) -> Array<u8, 32: u32>)(a);
-  let mut (new_left: Array<u8, 16: u32>) = (#_mkRepeatedArray returning Array<u8, 16: u32>)((0: u8));
-  let mut (new_right: Array<u8, 16: u32>) = (#_mkRepeatedArray returning Array<u8, 16: u32>)((0: u8));
+  let bytes = (utils::bytes::to_le_bytes<> as λ(Field) -> Array<u8, 32: u32>)(a);
+  let mut new_left = (#_mkRepeatedArray returning Array<u8, 16: u32>)((0: u8));
+  let mut new_right = (#_mkRepeatedArray returning Array<u8, 16: u32>)((0: u8));
   for i in (0: u32) .. (16: u32) do {
     (new_left[i]: u8) = (utils::sbox<> as λ(u8) -> u8)((#_arrayIndex returning u8)(bytes, (#_cast returning u32)(i)));
     #_skip
@@ -20,11 +20,11 @@ noir_def bar::bar<>(a: Field) -> Field := {
     (new_right[i]: u8) = (utils::sbox<> as λ(u8) -> u8)((#_arrayIndex returning u8)(bytes, (#_cast returning u32)((#_uAdd returning u32)((16: u32), i))));
     #_skip
   };
-  let mut (new_bytes: Slice<u8>) = (#_asSlice returning Slice<u8>)(new_right);
+  let mut new_bytes = (#_asSlice returning Slice<u8>)(new_right);
   {
-    let (ζi0: Array<u8, 16: u32>) = new_left;
+    let ζi0 = new_left;
     for ζi1 in (0: u32) .. (#_arrayLen returning u32)(ζi0) do {
-      let (elem: u8) = (#_arrayIndex returning u8)(ζi0, (#_cast returning u32)(ζi1));
+      let elem = (#_arrayIndex returning u8)(ζi0, (#_cast returning u32)(ζi1));
       {
         new_bytes = (#_slicePushBack returning Slice<u8>)(new_bytes, elem);
         #_skip
@@ -32,7 +32,7 @@ noir_def bar::bar<>(a: Field) -> Field := {
     };
     #_skip
   };
-  let (new_bytes_array: Array<u8, 32: u32>) = (utils::as_array<> as λ(Slice<u8>) -> Array<u8, 32: u32>)(new_bytes);
+  let new_bytes_array = (utils::as_array<> as λ(Slice<u8>) -> Array<u8, 32: u32>)(new_bytes);
   (utils::bytes::from_le_bytes<> as λ(Array<u8, 32: u32>) -> Field)(new_bytes_array)
 }
 

--- a/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Main.lean
+++ b/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Main.lean
@@ -9,10 +9,10 @@ namespace «Merkle-0.0.0»
 namespace Extracted
 
 noir_def mtree_recover<H: Type, N: u32>(idx: Array<bool, N: u32>, p: Array<Field, N: u32>, item: Field) -> Field := {
-  let mut (curr_h: Field) = item;
+  let mut curr_h = item;
   for i in (0: u32) .. uConst!(N: u32) do {
-    let (dir: bool) = (#_arrayIndex returning bool)(idx, (#_cast returning u32)(i));
-    let (sibling_root: Field) = (#_arrayIndex returning Field)(p, (#_cast returning u32)(i));
+    let dir = (#_arrayIndex returning bool)(idx, (#_cast returning u32)(i));
+    let sibling_root = (#_arrayIndex returning Field)(p, (#_cast returning u32)(i));
     if dir then {
       curr_h = ((H as hasher::BinaryHasher<Field>)::hash<> as λ(Field, Field) -> Field)(sibling_root, curr_h);
       #_skip
@@ -25,7 +25,7 @@ noir_def mtree_recover<H: Type, N: u32>(idx: Array<bool, N: u32>, p: Array<Field
 }
 
 noir_def main<>(root: Field, proof: Array<Field, 32: u32>, item: Field, idx: Array<bool, 32: u32>) -> Unit := {
-  let (calculated_root: Field) = (mtree_recover<skyscraper::Skyscraper<>, 32: u32> as λ(Array<bool, 32: u32>, Array<Field, 32: u32>, Field) -> Field)(idx, proof, item);
+  let calculated_root = (mtree_recover<skyscraper::Skyscraper<>, 32: u32> as λ(Array<bool, 32: u32>, Array<Field, 32: u32>, Field) -> Field)(idx, proof, item);
   (witness::weird_assert_eq<> as λ(Field, Field) -> Unit)(root, calculated_root);
   #_skip
 }

--- a/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Permute.lean
+++ b/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Permute.lean
@@ -9,17 +9,17 @@ namespace «Merkle-0.0.0»
 namespace Extracted
 
 noir_def permute::permute<>(s: Array<Field, 2: u32>) -> Array<Field, 2: u32> := {
-  let ((l: Field), (r: Field)) = (#_makeData returning Tuple<Field, Field>)((#_arrayIndex returning Field)(s, (0: u32)), (#_arrayIndex returning Field)(s, (1: u32)));
-  let ((l: Field), (r: Field)) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)(r, (utils::square<> as λ(Field) -> Field)(l)), l);
-  let ((l: Field), (r: Field)) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (utils::square<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (0: u32))), l);
-  let ((l: Field), (r: Field)) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (bar::bar<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (1: u32))), l);
-  let ((l: Field), (r: Field)) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (bar::bar<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (2: u32))), l);
-  let ((l: Field), (r: Field)) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (utils::square<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (3: u32))), l);
-  let ((l: Field), (r: Field)) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (utils::square<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (4: u32))), l);
-  let ((l: Field), (r: Field)) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (bar::bar<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (5: u32))), l);
-  let ((l: Field), (r: Field)) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (bar::bar<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (6: u32))), l);
-  let ((l: Field), (r: Field)) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (utils::square<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (7: u32))), l);
-  let ((l: Field), (r: Field)) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)(r, (utils::square<> as λ(Field) -> Field)(l)), l);
+  let (l, r) = (#_makeData returning Tuple<Field, Field>)((#_arrayIndex returning Field)(s, (0: u32)), (#_arrayIndex returning Field)(s, (1: u32)));
+  let (l, r) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)(r, (utils::square<> as λ(Field) -> Field)(l)), l);
+  let (l, r) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (utils::square<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (0: u32))), l);
+  let (l, r) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (bar::bar<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (1: u32))), l);
+  let (l, r) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (bar::bar<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (2: u32))), l);
+  let (l, r) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (utils::square<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (3: u32))), l);
+  let (l, r) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (utils::square<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (4: u32))), l);
+  let (l, r) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (bar::bar<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (5: u32))), l);
+  let (l, r) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (bar::bar<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (6: u32))), l);
+  let (l, r) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)((#_fAdd returning Field)(r, (utils::square<> as λ(Field) -> Field)(l)), (#_arrayIndex returning Field)((globals::RC<> as λ() -> Array<Field, 8: u32>)(), (7: u32))), l);
+  let (l, r) = (#_makeData returning Tuple<Field, Field>)((#_fAdd returning Field)(r, (utils::square<> as λ(Field) -> Field)(l)), l);
   (#_mkArray returning Array<Field, 2: u32>)(l, r)
 }
 

--- a/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Skyscraper/Mod.lean
+++ b/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Skyscraper/Mod.lean
@@ -10,7 +10,7 @@ namespace Extracted
 
 noir_trait_impl[impl_430]<> hasher::BinaryHasher<Field> for skyscraper::Skyscraper<> where [] := {
   noir_def hash<>(a: Field, b: Field) -> Field := {
-    let (x: Array<Field, 2: u32>) = (permute::permute<> as λ(Array<Field, 2: u32>) -> Array<Field, 2: u32>)((#_mkArray returning Array<Field, 2: u32>)(a, b));
+    let x = (permute::permute<> as λ(Array<Field, 2: u32>) -> Array<Field, 2: u32>)((#_mkArray returning Array<Field, 2: u32>)(a, b));
     (#_fAdd returning Field)((#_arrayIndex returning Field)(x, (0: u32)), a)
   };
 }

--- a/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Utils/Bits/Mod.lean
+++ b/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Utils/Bits/Mod.lean
@@ -9,8 +9,8 @@ namespace «Merkle-0.0.0»
 namespace Extracted
 
 noir_def utils::bits::to_le_bits<>(self: Field) -> Array<u1, 256: u32> := {
-  let mut (val: Field) = self;
-  let mut (bits: Array<u1, 256: u32>) = (#_mkRepeatedArray returning Array<u1, 256: u32>)((0: u1));
+  let mut val = self;
+  let mut bits = (#_mkRepeatedArray returning Array<u1, 256: u32>)((0: u1));
   for i in (0: u32) .. (256: u32) do {
     (bits[i]: u1) = (utils::sgn0<> as λ(Field) -> u1)(val);
     if (#_uEq returning bool)((#_arrayIndex returning u1)(bits, (#_cast returning u32)(i)), (0: u1)) then {

--- a/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Utils/Bytes.lean
+++ b/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Utils/Bytes.lean
@@ -9,8 +9,8 @@ namespace «Merkle-0.0.0»
 namespace Extracted
 
 noir_def utils::bytes::to_le_bytes<>(self: Field) -> Array<u8, 32: u32> := {
-  let (bits: Array<u1, 256: u32>) = (utils::bits::to_le_bits<> as λ(Field) -> Array<u1, 256: u32>)(self);
-  let mut (bytes: Array<u8, 32: u32>) = (#_mkRepeatedArray returning Array<u8, 32: u32>)((0: u8));
+  let bits = (utils::bits::to_le_bits<> as λ(Field) -> Array<u1, 256: u32>)(self);
+  let mut bytes = (#_mkRepeatedArray returning Array<u8, 32: u32>)((0: u8));
   for i in (0: u32) .. (32: u32) do {
     (bytes[i]: u8) = (#_uAdd returning u8)((#_uAdd returning u8)((#_uAdd returning u8)((#_uAdd returning u8)((#_uAdd returning u8)((#_uAdd returning u8)((#_uAdd returning u8)((#_cast returning u8)((#_arrayIndex returning u1)(bits, (#_cast returning u32)((#_uMul returning u32)((8: u32), i)))), (#_uMul returning u8)((2: u8), (#_cast returning u8)((#_arrayIndex returning u1)(bits, (#_cast returning u32)((#_uAdd returning u32)((#_uMul returning u32)((8: u32), i), (1: u32))))))), (#_uMul returning u8)((4: u8), (#_cast returning u8)((#_arrayIndex returning u1)(bits, (#_cast returning u32)((#_uAdd returning u32)((#_uMul returning u32)((8: u32), i), (2: u32))))))), (#_uMul returning u8)((8: u8), (#_cast returning u8)((#_arrayIndex returning u1)(bits, (#_cast returning u32)((#_uAdd returning u32)((#_uMul returning u32)((8: u32), i), (3: u32))))))), (#_uMul returning u8)((16: u8), (#_cast returning u8)((#_arrayIndex returning u1)(bits, (#_cast returning u32)((#_uAdd returning u32)((#_uMul returning u32)((8: u32), i), (4: u32))))))), (#_uMul returning u8)((32: u8), (#_cast returning u8)((#_arrayIndex returning u1)(bits, (#_cast returning u32)((#_uAdd returning u32)((#_uMul returning u32)((8: u32), i), (5: u32))))))), (#_uMul returning u8)((64: u8), (#_cast returning u8)((#_arrayIndex returning u1)(bits, (#_cast returning u32)((#_uAdd returning u32)((#_uMul returning u32)((8: u32), i), (6: u32))))))), (#_uMul returning u8)((128: u8), (#_cast returning u8)((#_arrayIndex returning u1)(bits, (#_cast returning u32)((#_uAdd returning u32)((#_uMul returning u32)((8: u32), i), (7: u32)))))));
     #_skip
@@ -19,8 +19,8 @@ noir_def utils::bytes::to_le_bytes<>(self: Field) -> Array<u8, 32: u32> := {
 }
 
 noir_def utils::bytes::from_le_bytes<>(bytes: Array<u8, 32: u32>) -> Field := {
-  let mut (v: Field) = (1: Field);
-  let mut (result: Field) = (0: Field);
+  let mut v = (1: Field);
+  let mut result = (0: Field);
   for i in (0: u32) .. (32: u32) do {
     result = (#_fAdd returning Field)(result, (#_fMul returning Field)((#_cast returning Field)((#_arrayIndex returning u8)(bytes, (#_cast returning u32)(i))), v));
     v = (#_fMul returning Field)(v, (256: Field));

--- a/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Utils/Mod.lean
+++ b/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Utils/Mod.lean
@@ -9,12 +9,12 @@ namespace «Merkle-0.0.0»
 namespace Extracted
 
 noir_def utils::rl<>(u: u8) -> u8 := {
-  let (top_bit: u8) = (#_uShr returning u8)(u, (7: u8));
+  let top_bit = (#_uShr returning u8)(u, (7: u8));
   (#_uOr returning u8)((#_uShl returning u8)(u, (1: u8)), top_bit)
 }
 
 noir_def utils::rotate_left<>(u: u8, N: u8) -> u8 := {
-  let mut (result: u8) = u;
+  let mut result = u;
   for _ in (0: u8) .. N do {
     result = (utils::rl<> as λ(u8) -> u8)(result);
     #_skip
@@ -23,12 +23,12 @@ noir_def utils::rotate_left<>(u: u8, N: u8) -> u8 := {
 }
 
 noir_def utils::sbox<>(v: u8) -> u8 := {
-  let (x1: u8) = (#_uNot returning u8)(v);
-  let (x2: u8) = (utils::rotate_left<> as λ(u8, u8) -> u8)(x1, (1: u8));
-  let (x3: u8) = (utils::rotate_left<> as λ(u8, u8) -> u8)(v, (2: u8));
-  let (x4: u8) = (utils::rotate_left<> as λ(u8, u8) -> u8)(v, (3: u8));
-  let (x5: u8) = (#_uAnd returning u8)((#_uAnd returning u8)(x2, x3), x4);
-  let (x6: u8) = (utils::rotate_left<> as λ(u8, u8) -> u8)(x5, (1: u8));
+  let x1 = (#_uNot returning u8)(v);
+  let x2 = (utils::rotate_left<> as λ(u8, u8) -> u8)(x1, (1: u8));
+  let x3 = (utils::rotate_left<> as λ(u8, u8) -> u8)(v, (2: u8));
+  let x4 = (utils::rotate_left<> as λ(u8, u8) -> u8)(v, (3: u8));
+  let x5 = (#_uAnd returning u8)((#_uAnd returning u8)(x2, x3), x4);
+  let x6 = (utils::rotate_left<> as λ(u8, u8) -> u8)(x5, (1: u8));
   (#_uXor returning u8)(v, x6)
 }
 
@@ -37,7 +37,7 @@ noir_def utils::sgn0<>(self: Field) -> u1 := {
 }
 
 noir_def utils::as_array<>(self: Slice<u8>) -> Array<u8, 32: u32> := {
-  let mut (array: Array<u8, 32: u32>) = (#_mkRepeatedArray returning Array<u8, 32: u32>)((0: u8));
+  let mut array = (#_mkRepeatedArray returning Array<u8, 32: u32>)((0: u8));
   for i in (0: u32) .. (32: u32) do {
     (array[i]: u8) = (#_sliceIndex returning u8)(self, (#_cast returning u32)(i));
     #_skip

--- a/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Witness/Mod.lean
+++ b/testing/Merkle/lampe/Merkle-0.0.0/Extracted/Witness/Mod.lean
@@ -9,7 +9,7 @@ namespace «Merkle-0.0.0»
 namespace Extracted
 
 noir_def witness::weird_assert_eq<>(a: Field, b: Field) -> Unit := {
-  let (wit: Field) = {
+  let wit = {
     (witness::uncons::weird_eq_witness<> as λ(Field, Field) -> Field)(a, b)
   };
   (#_assert returning Unit)((#_fEq returning bool)(wit, a));

--- a/testing/Multiple/lampe/Multiple-0.0.0/Extracted/Main.lean
+++ b/testing/Multiple/lampe/Multiple-0.0.0/Extracted/Main.lean
@@ -9,7 +9,7 @@ namespace «Multiple-0.0.0»
 namespace Extracted
 
 noir_def main<>(x: Field) -> Field := {
-  let mut (x: Field) = x;
+  let mut x = x;
   x = (foo::foo<> as λ(Field) -> Field)(x);
   x = (bar::bar<> as λ(Field) -> Field)(x);
   x = (baz::bang::bang<> as λ(Field) -> Field)(x);


### PR DESCRIPTION
We never ended up using them in compiling the DSL, so we can remove them to have a cleaner (and easier to write by hand) DSL. 