### PR TITLE
Add the remaining theorems for `Option`

### DIFF
--- a/Lampe/Lampe/Hoare/SepTotal.lean
+++ b/Lampe/Lampe/Hoare/SepTotal.lean
@@ -442,10 +442,22 @@ theorem iteTrue_intro :
     STHoare p Γ P (.ite true mainBody elseBody) Q := by
   tauto
 
+lemma ite_intro_of_true {cond : Bool} (h : cond = true) :
+    STHoare p Γ P mainBody Q →
+    STHoare p Γ P (.ite cond mainBody elseBody) Q := by
+  cases h
+  apply STHoare.iteTrue_intro
+
 theorem iteFalse_intro :
     STHoare p Γ P elseBody Q →
     STHoare p Γ P (.ite false mainBody elseBody) Q := by
   tauto
+
+lemma ite_intro_of_false {cond : Bool} (h : cond = false) :
+    STHoare p Γ P elseBody Q →
+    STHoare p Γ P (.ite cond mainBody elseBody) Q := by
+  cases h
+  apply STHoare.iteFalse_intro
 
 theorem ite_intro {cnd : Bool}
     (h₁ : cnd = true → STHoare p Γ P mainBody Q)

--- a/Lampe/Lampe/Tactic/SL/Term.lean
+++ b/Lampe/Lampe/Tactic/SL/Term.lean
@@ -82,8 +82,8 @@ partial def parseSLExpr (e: Lean.Expr): TacticM SLTerm := do
     return SLTerm.singleton e fst snd
   else if e.isAppOf' ``State.lmbSingleton then
     let args := e.getAppArgs'
-    let fst ← liftOption args[1]?
-    let snd ← liftOption args[2]?
+    let fst ← liftOption args[3]?
+    let snd ← liftOption args[4]?
     return SLTerm.lmbSingleton e fst snd
   else if e.isAppOf' ``SLP.top then
     return SLTerm.top e

--- a/docs/Extracted Project Structure.md
+++ b/docs/Extracted Project Structure.md
@@ -64,5 +64,10 @@ For smaller sets of theorems, we recommend creating a `Spec.lean` file in the `L
 directory described above. However, when working to verify an entire library, our advice is to
 create a separate tree directly under the `<extraction_target>` directory that contains all of the
 various files needed to state and prove your theorems. This directory structure can mirror the one
-in the `Extracted` directory, or can be entirely its own thing.
+in the `Extracted` directory, or can be entirely its own thing. 
+
+Regardless, we recommend putting proofs to do with a given type in a namespace named like the type.
+For example, `unwrap_spec` for `Option` is in the `Option` namespace, making it clear which proof
+is being referred to from another proof; it will be `Option.unwrap_spec` instead of a bare (and
+potentially ambiguous) `unwrap_spec`.
 

--- a/docs/Tips for Proving.md
+++ b/docs/Tips for Proving.md
@@ -1,0 +1,43 @@
+# Tips for Proving
+
+This document contains some tips for stating and proving theorems about extracted Noir code, and
+aims to be a compendium of useful patterns and knowledge.
+
+## Existing Logic Over Custom Logic
+
+> If you can write a piece of logic using existing Lean functionality, do so.
+
+It is always possible to state program properties in Lean in terms of hand-written logic—such as
+`if`, `match`, and so on—when stating theorems. However, if there is an equivalent to that logic in
+terms of existing types and/or functionality it should always be preferred. This means that
+downstream dependents of that theorem will have as much of the existing set of Lean theorems at 
+their disposal as is possible, rather than having to manually work with the constructs.
+
+An example would be the post-condition for `std::option::Option::map_or`. Using bare, hand-written
+logic, it could be stated as follows:
+
+```lean
+fun r => r = match v with
+| some x => f x
+| none => default
+```
+
+This would mean that a user of the theorem would have to deal with that match explicitly every
+single time it was employed. Alternatively, this can be stated in terms of operations on `Option`.
+
+```lean
+fun r => r = (v.map f).getD default
+```
+
+Constructs such as `Option.map` and `Option.getD` all have significant existing bodies of theorems
+accompanying them, and are hence _much_ more useful in a theorem statement.
+
+## Reason About Lean Types
+
+> Wherever possible, translate the problem statement to be in terms of _Lean_ types and functions
+> instead of Noir ones.
+
+One of the major aims of Lampe is to avoid the need to reason directly about _Noir_ constructs and
+types. Lean constructs have a significant base of theorems and work available with them, that does
+not exist when directly reasoning about Noir's constructs.
+

--- a/stdlib/lampe/Stdlib/Array/Mod.lean
+++ b/stdlib/lampe/Stdlib/Array/Mod.lean
@@ -23,6 +23,8 @@ export «std-1.0.0-beta.11».Extracted (
 
 open «std-1.0.0-beta.11».Extracted
 
+namespace Array
+
 theorem concat_spec: STHoare p env ⟦⟧
     («std::array::concat».call h![T, M, N] h![a₁, a₂])
     (fun r => r.toList = a₁.toList ++ a₂.toList) := by

--- a/stdlib/lampe/Stdlib/Option.lean
+++ b/stdlib/lampe/Stdlib/Option.lean
@@ -30,91 +30,463 @@ export «std-1.0.0-beta.11».Extracted (
 
 open «std-1.0.0-beta.11».Extracted
 
-set_option maxRecDepth 1000
+namespace Option
 
-def from_option {p t}: Option (t.denote p) -> («std::option::Option».tp h![t] |>.denote p)
-| none => (false, Lampe.Tp.zero p t, ())
+/-- 
+Convert a Lean option into a Noir `std::option::Option`.
+
+We recommend providing the user with `std::option::Option`s at the boundary of the theorem for any
+option values 'created' by the theorem.
+-/
+def fromOption {p t} : Option (t.denote p) -> («std::option::Option».tp h![t] |>.denote p)
+| none => (false, Tp.zero p t, ())
 | some val => (true, val, ())
 
-def to_option {p t}: («std::option::Option».tp h![t] |>.denote p) -> Option (t.denote p)
+/-- 
+Convert a Noir `std::option::Option` into a Lean option.
+
+We recommend converting user-provided `std::option::Option`s from the user, and converting them
+within the theorem.
+-/
+def toOption {p t} : («std::option::Option».tp h![t] |>.denote p) -> Option (t.denote p)
 | (false, _, _) => none
 | (true, val, _) => some val
 
-lemma from_option_to_option_id : to_option (from_option v) = v := by
+@[simp]
+lemma fromOption_toOption_id : toOption (fromOption v) = v := by
   cases v <;> rfl
 
-lemma none_spec {p T} : Lampe.STHoare p env ⟦⟧ («std::option::Option::none».call h![T] h![]) 
-    (fun v => v = from_option none) := by
-  enter_decl
-  steps
-  assumption
+@[simp]
+lemma option_fst_eq_toOption_isSome {p T} 
+    {v : Tp.denote p $ «std::option::Option».tp h![T]}
+  : Builtin.indexTpl v Builtin.Member.head = (toOption v).isSome := by
+  rcases v with ⟨_|_, _⟩ 
+  all_goals rfl
 
-lemma some_spec {p T v} : Lampe.STHoare p env ⟦⟧ («std::option::Option::some».call h![T] h![v])
-    (fun r => r = from_option (some v)) := by
-  enter_decl
-  steps
-  assumption
+@[simp]
+lemma option_snd_eq_toOption_get_of_isSome {p T}
+    {v : Tp.denote p $ «std::option::Option».tp h![T]}
+    (v_is_some : (toOption v).isSome = true)
+  : Builtin.indexTpl v Builtin.Member.head.tail = (toOption v).get v_is_some := by
+  rcases v with ⟨_|_, _, _⟩ 
+  . contradiction
+  . rfl
 
-lemma is_none_spec {p T v} : Lampe.STHoare p env ⟦⟧ 
-    («std::option::Option::is_none».call h![T] h![from_option v]) 
-    (fun r => r = v.isNone) := by
+lemma getD_map_of_isSome {α β} {f : α → β} {d : β} {o : Option α}
+    (h : o.isSome)
+  : (o.map f).getD d = f (o.get h) := by
+  rcases (Option.isSome_iff_exists.mp h) with ⟨_, rfl⟩
+  rfl
+
+@[simp]
+lemma bind_def_of_isSome {α β} {v : Option α} {f : α → Option β} (v_is_some : v.isSome = true) 
+  : v >>= f = f (v.get v_is_some) := by  
+  rcases (Option.isSome_iff_exists.mp v_is_some) with ⟨_, rfl⟩
+  simp_all
+
+theorem none_spec {p T} : STHoare p env ⟦⟧ («std::option::Option::none».call h![T] h![]) 
+    (fun v => v = fromOption none) := by
   enter_decl
   steps
   subst_vars
-  cases v <;> rfl
+  rfl
+
+theorem some_spec {p T v} : STHoare p env ⟦⟧ («std::option::Option::some».call h![T] h![v])
+    (fun r => r = fromOption (some v)) := by
+  enter_decl
+  steps
+  subst_vars
+  rfl
+
+theorem is_none_spec {p T v} : STHoare p env ⟦⟧ 
+    («std::option::Option::is_none».call h![T] h![v]) 
+    (fun r => r = (toOption v).isNone) := by
+  enter_decl
+  steps
+  subst_vars
+  simp
   exact ()
 
-lemma is_some_spec {p T v} : Lampe.STHoare p env ⟦⟧ 
-    («std::option::Option::is_some».call h![T] h![from_option v]) 
-    (fun r => r = v.isSome) := by
+theorem is_some_spec {p T v} : STHoare p env ⟦⟧ 
+    («std::option::Option::is_some».call h![T] h![v]) 
+    (fun r => r = (toOption v).isSome) := by
   enter_decl
   steps
   subst_vars
-  cases v <;> rfl
+  simp
 
-lemma unwrap_spec {p T v} : Lampe.STHoare p env ⟦⟧ 
-    («std::option::Option::unwrap».call h![T] h![from_option v]) 
-    (fun r => ∃h, r = v.get h) := by
+theorem unwrap_spec {p T v} : STHoare p env ⟦⟧ 
+    («std::option::Option::unwrap».call h![T] h![v]) 
+    (fun r => ∃h, r = (toOption v).get h) := by
   enter_decl
   steps
-  cases v
-  · subst_vars
-    rename _ = _ => hp
-    cases hp
-  · subst_vars
-    simp
-    rfl
+  simp only [option_fst_eq_toOption_isSome, beq_true] at *
+  rename _ = true => v
+  use v
+  subst_vars
+  rename Tp.denote p («std::option::Option».tp _) => h
+  rcases h with ⟨(_|_), _, _⟩
+  . contradiction
+  . rfl
 
-lemma map_none_spec {p T U E f} : Lampe.STHoare p env ⟦⟧ 
-  («std::option::Option::map».call h![T, U, E] h![from_option none, f]) 
-  (fun r => r = from_option (none: Option (U.denote p))) := by
+theorem map_none_spec {p T U E f v} 
+    (v_is_none : (toOption v).isNone)
+  : STHoare p env ⟦⟧ 
+    («std::option::Option::map».call h![T, U, E] h![v, f]) 
+    (fun r => r = fromOption none) := by
   enter_decl
   steps
-  apply Lampe.STHoare.iteFalse_intro
+  apply STHoare.ite_intro_of_false
+  . simp_all
+
   steps [none_spec]
-  assumption
+  simp_all
 
-lemma map_some_spec {p T U E f fb v P Q}
-    (h_lam : Lampe.STHoare p env P (fb h![v]) Q):
-    Lampe.STHoare p env
-      (P ⋆ [λf ↦ fb])
-      («std::option::Option::map».call h![T, U, E] h![from_option (some v), f])
-      (fun v => (∃∃vin, v = (from_option (some vin)) ⋆ Q vin) ⋆ [λf ↦ fb]) := by
+theorem map_some_spec {p T U E f fb v P Q}
+    (v_is_some : (toOption v).isSome)
+    (h_lam : STHoare p env P (fb h![(toOption v).get v_is_some]) Q)
+  : STHoare p env
+    (P ⋆ [λf ↦ fb])
+    («std::option::Option::map».call h![T, U, E] h![v, f])
+    (fun r => (∃∃vin, r = fromOption (some vin) ⋆ Q vin) ⋆ [λf ↦ fb]) := by
   enter_decl
   steps
-  apply Lampe.STHoare.iteTrue_intro
-  steps [Lampe.STHoare.callLambda_intro (hlam := h_lam), some_spec]
+  apply STHoare.ite_intro_of_true
+  . simp_all
+
+  steps
+  simp only [option_snd_eq_toOption_get_of_isSome v_is_some]
+  steps [STHoare.callLambda_intro (hlam := h_lam), some_spec]
   case _ : _ = _ => assumption
   sl
 
-lemma map_pure_spec {p T U E f fb v f_emb}
-    (h_f: ∀arg, Lampe.STHoare p env ⟦⟧ (fb h![arg]) (fun r => r = f_emb arg)):
-    Lampe.STHoare p env 
-      [λf ↦ fb] 
-      («std::option::Option::map».call h![T, U, E] h![from_option v, f]) 
-      (fun r => r = from_option (v.map f_emb)) := by
-  cases v
-  · steps [map_none_spec]
-    assumption
-  · steps [map_some_spec (h_f _)]
+theorem map_pure_spec {p T U E P f fb v}
+    {f_emb : T.denote p → U.denote p}
+    (h_f : ∀arg, STHoare p env P (fb h![arg]) (fun r => r = f_emb arg ⋆ P))
+  : STHoare p env 
+    (P ⋆ [λf ↦ fb])
+    («std::option::Option::map».call h![T, U, E] h![v, f]) 
+    (fun r => r = fromOption ((toOption v).map f_emb) ⋆ P) := by
+  by_cases h : (toOption v).isSome = true
+  . steps [map_some_spec h (h_f _)]
+    subst_vars
+    simp only [←Option.map_some, Option.some_get]
+  . steps [map_none_spec]
+    all_goals simp_all
+
+theorem map_or_none_spec {p T U E v default f}
+    (v_is_none : (toOption v).isNone)
+  : STHoare p env ⟦⟧
+    («std::option::Option::map_or».call h![T, U, E] h![v, default, f])
+    (fun r => r = default) := by
+  enter_decl
+  steps
+  apply STHoare.ite_intro_of_false
+  . simp_all
+  
+  steps
+  simp_all
+
+theorem map_or_some_spec {p T U E v f fb default P Q}
+    (v_is_some : (toOption v).isSome)
+    (h_lam : STHoare p env P (fb h![(toOption v).get v_is_some]) Q)
+  : STHoare p env
+    (P ⋆ [λf ↦ fb])
+    («std::option::Option::map_or».call h![T, U, E] h![v, default, f])
+    (fun r => Q r ⋆ [λf ↦ fb]) := by
+  enter_decl
+  steps
+  apply STHoare.ite_intro_of_true
+  . simp_all
+
+  steps
+  simp only [option_snd_eq_toOption_get_of_isSome v_is_some]
+  steps [STHoare.callLambda_intro (hlam := h_lam), some_spec]
+
+theorem map_or_pure_spec {p T U E P v f fb default}
+    {f_emb : T.denote p → U.denote p}
+    (h_f : ∀arg, STHoare p env P (fb h![arg]) (fun r => r = f_emb arg ⋆ P))
+  : STHoare p env
+    (P ⋆ [λf ↦ fb])
+    («std::option::Option::map_or».call h![T, U, E] h![v, default, f])
+    (fun r => r = ((toOption v).map f_emb).getD default ⋆ P) := by
+  by_cases h : (toOption v).isSome = true
+  . steps [map_or_some_spec (E := E) h (h_f _)]
+    subst_vars
+    rw [getD_map_of_isSome (f := f_emb) h]
+  . steps [map_or_none_spec]
+    all_goals simp_all
+
+theorem map_or_else_none_spec {p T U E1 E2 P Q v default default_b func}
+    (v_is_none : (toOption v).isNone)
+    (default_f : STHoare p env P (default_b h![]) Q)
+  : STHoare p env
+    (P ⋆ [λdefault ↦ default_b])
+    («std::option::Option::map_or_else».call h![T, U, E1, E2] h![v, default, func])
+    (fun r => Q r ⋆ [λdefault ↦ default_b]) := by
+  enter_decl
+  steps
+  apply STHoare.ite_intro_of_false
+  . simp_all
+
+  steps [STHoare.callLambda_intro (hlam := default_f)]
+
+theorem map_or_else_some_spec {p T U E1 E2 P Q v default func func_b}
+    (v_is_some : (toOption v).isSome)
+    (func_f : STHoare p env P (func_b h![(toOption v).get v_is_some]) Q)
+  : STHoare p env
+    (P ⋆ [λfunc ↦ func_b])
+    («std::option::Option::map_or_else».call h![T, U, E1, E2] h![v, default, func])
+    (fun r => Q r ⋆ [λfunc ↦ func_b]) := by
+  enter_decl
+  steps
+  apply STHoare.ite_intro_of_true
+  . simp_all
+
+  steps
+  simp only [option_snd_eq_toOption_get_of_isSome v_is_some]
+  steps [STHoare.callLambda_intro (hlam := func_f)]
+
+theorem map_or_else_pure_spec {p T U E1 E2 P v default default_b func func_b}
+    {default_emb : U.denote p}
+    {func_emb : T.denote p → U.denote p}
+    (default_f : STHoare p env P (default_b h![]) (fun r => r = default_emb ⋆ P))
+    (func_f : ∀arg, STHoare p env P (func_b h![arg]) (fun r => r = func_emb arg ⋆ P))
+  : STHoare p env
+    (P ⋆ [λdefault ↦ default_b] ⋆ [λfunc ↦ func_b])
+    («std::option::Option::map_or_else».call h![T, U, E1, E2] h![v, default, func])
+    (fun r => r = ((toOption v).map func_emb).getD default_emb ⋆ P) := by
+  by_cases h : (toOption v).isSome = true
+  . steps [map_or_else_some_spec (E1 := E1) (E2 := E2) h (func_f _)]
+    subst_vars
+    rw [getD_map_of_isSome (f := func_emb) h]
+  . have h : (toOption v).isNone := by 
+      simp_all
+    steps [map_or_else_none_spec (E1 := E1) (E2 := E2) h default_f]
+    subst_vars
     simp_all
+
+theorem and_spec {p T v w}
+  : STHoare p env ⟦⟧
+    («std::option::Option::and».call h![T] h![v, w])
+    (fun r => r = if (toOption v).isSome then w else fromOption none) := by
+  enter_decl
+  steps [is_none_spec]
+  apply STHoare.ite_intro
+  . intro cond
+    steps [none_spec]
+    simp_all
+  . intro cond
+    steps
+    simp_all
+
+theorem and_then_none_spec {p T U E self f}
+    (self_is_none : (toOption self).isNone)
+  : STHoare p env ⟦⟧ 
+    («std::option::Option::and_then».call h![T, U, E] h![self, f])
+    (fun r => r = fromOption none) := by
+  enter_decl
+  steps
+  apply STHoare.ite_intro_of_false
+  . simp_all
+  
+  steps [none_spec]
+  simp_all
+
+theorem and_then_some_spec {p T U E P Q self f fb}
+    (self_is_some : (toOption self).isSome)
+    (f_lam : STHoare p env P (fb h![(toOption self).get self_is_some]) Q)
+  : STHoare p env
+    (P ⋆ [λf ↦ fb])
+    («std::option::Option::and_then».call h![T, U, E] h![self, f])
+    (fun r => Q r ⋆ [λf ↦ fb]) := by
+  enter_decl
+  steps
+  apply STHoare.ite_intro_of_true
+  . simp_all
+  
+  steps
+  simp [option_snd_eq_toOption_get_of_isSome self_is_some]
+  steps [STHoare.callLambda_intro (hlam := f_lam)]
+
+theorem and_then_pure_spec {p T U E P self f fb}
+    {f_emb : T.denote p → (Tp.denote p $ «std::option::Option».tp h![U])}
+    (f_f : ∀arg, STHoare p env P (fb h![arg]) (fun r => r = f_emb arg ⋆ P))
+  : STHoare p env
+    (P ⋆ [λf ↦ fb])
+    («std::option::Option::and_then».call h![T, U, E] h![self, f])
+    (fun r => r = ((toOption self).map f_emb).getD (fromOption none) ⋆ P) := by
+  by_cases h : (toOption self).isSome = true
+  . steps [and_then_some_spec (E := E) h (f_f _)]
+    subst_vars
+    rw [getD_map_of_isSome h]
+  . have h : (toOption self).isNone := by simp_all
+    steps [and_then_none_spec (E := E) h]
+    simp_all
+
+theorem or_spec {p T self default}
+  : STHoare p env ⟦⟧
+    («std::option::Option::or».call h![T] h![self, default])
+    (fun r => r = if (toOption self).isSome then self else default) := by
+  enter_decl
+  steps
+  apply STHoare.ite_intro
+  . intro cond
+    rw [option_fst_eq_toOption_isSome] at cond
+    steps
+    subst_vars
+    simp_all
+  . intro cond
+    rw [option_fst_eq_toOption_isSome] at cond
+    simp_all only [Option.isSome_eq_false_iff, Option.isNone_iff_eq_none, Option.isSome_none,
+                   Bool.false_eq_true, ↓reduceIte]
+    steps
+    simp_all
+
+theorem or_else_none_spec {p T E P Q self default default_b}
+    (self_is_none : (toOption self).isNone)
+    (default_f : STHoare p env P (default_b h![]) Q)
+  : STHoare p env 
+    (P ⋆ [λdefault ↦ default_b])
+    («std::option::Option::or_else».call h![T, E] h![self, default])
+    (fun r => Q r ⋆ [λdefault ↦ default_b]) := by
+  enter_decl
+  steps
+  apply STHoare.ite_intro_of_false
+  . simp_all
+
+  steps [STHoare.callLambda_intro (hlam := default_f)]
+
+theorem or_else_some_spec {p T E self default}
+    (self_is_some : (toOption self).isSome)
+  : STHoare p env ⟦⟧
+    («std::option::Option::or_else».call h![T, E] h![self, default])
+    (fun r => r = self) := by
+  enter_decl
+  steps
+  apply STHoare.ite_intro_of_true
+  . simp_all
+
+  steps
+  simp_all
+
+theorem or_else_pure_spec {p T E P self default default_b}
+    {default_emb : Tp.denote p $ «std::option::Option».tp h![T]}
+    (default_f : STHoare p env P (default_b h![]) (fun r => r = default_emb ⋆ P))
+  : STHoare p env
+    (P ⋆ [λdefault ↦ default_b])
+    («std::option::Option::or_else».call h![T, E] h![self, default])
+    (fun r => (r = if (toOption self).isSome then self else default_emb) ⋆ P) := by
+  by_cases h : (toOption self).isSome = true
+  . steps [or_else_some_spec h]
+    subst_vars
+    simp_all
+  . have h : (toOption self).isNone := by simp_all
+    steps [or_else_none_spec (E := E) h default_f]
+    subst_vars
+    simp_all
+
+theorem xor_spec {p T self other}
+  : STHoare p env ⟦⟧
+    («std::option::Option::xor».call h![T] h![self, other])
+    (fun r => r = if (toOption self).isSome then 
+        if (toOption other).isSome then fromOption none else self 
+      else if (toOption other).isSome then
+        other
+      else
+        fromOption none
+    ) := by
+  enter_decl
+  steps
+  apply STHoare.ite_intro
+  . intros
+    steps
+    apply STHoare.ite_intro
+    . intros
+      steps [none_spec]
+      simp_all
+    . intros
+      steps
+      simp_all
+  . intros
+    steps
+    apply STHoare.ite_intro
+    . intros
+      steps
+      simp_all
+    . intros
+      steps [none_spec]
+      simp_all
+
+theorem filter_none_spec {p T E self pred}
+    (self_is_none : (toOption self).isNone)
+  : STHoare p env ⟦⟧ 
+    («std::option::Option::filter».call h![T, E] h![self, pred])
+    (fun r => r = fromOption none) := by
+  enter_decl
+  steps
+  rw [option_fst_eq_toOption_isSome]
+  apply STHoare.ite_intro_of_false
+  . simp_all
+
+  steps [none_spec]
+  simp_all
+
+theorem filter_some_spec {p T E P Q self pred pred_b}
+    (self_is_some : (toOption self).isSome)
+    (pred_f : STHoare p env P (pred_b h![(toOption self).get self_is_some]) Q)
+  : STHoare p env
+    (P ⋆ [λpred ↦ pred_b])
+    («std::option::Option::filter».call h![T, E] h![self, pred])
+    (fun r => ∃∃b, Q b ⋆ r = if b then self else fromOption none) := by
+  enter_decl
+  steps
+  rw [option_fst_eq_toOption_isSome]
+  apply STHoare.ite_intro_of_true
+  . simp_all
+
+  steps
+  simp_all only [option_snd_eq_toOption_get_of_isSome]
+  steps [STHoare.callLambda_intro (hlam := pred_f)]
+
+  apply STHoare.ite_intro
+  . intros
+    steps unsafe
+    subst_vars
+    sl unsafe
+    simp_all
+      
+  . intros
+    steps [none_spec]
+    subst_vars
+    sl unsafe
+    simp_all
+
+theorem flatten_spec {p T opt}
+  : STHoare p env ⟦⟧
+    («std::option::Option::flatten».call h![T] h![opt])
+    (fun r => r = (toOption opt).getD (fromOption none)) := by
+  enter_decl
+  steps
+  rw [option_fst_eq_toOption_isSome]
+  apply STHoare.ite_intro
+  . intros
+    steps
+    subst_vars
+    rw [option_snd_eq_toOption_get_of_isSome]
+    rotate_left
+    simp_all
+    apply Option.get_eq_getD
+
+  . intros
+    steps [none_spec]
+    subst_vars
+    simp_all
+
+theorem default_spec {p T} : STHoare p env ⟦⟧ 
+    («std::default::Default».default h![] («std::option::Option».tp h![T]) h![] h![] h![])
+    (fun r => r = fromOption none) := by
+  resolve_trait
+  steps [none_spec]
+  simp_all
+    

--- a/stdlib/lampe/Stdlib/Slice.lean
+++ b/stdlib/lampe/Stdlib/Slice.lean
@@ -25,6 +25,8 @@ open «std-1.0.0-beta.11».Extracted
 
 set_option maxRecDepth 10000
 
+namespace Slice
+
 lemma for_each_inv {T Env p f fb l}
     (Inv: List (Tp.denote p T) → SLP (State p))
     (h_inv: ∀(lp: List (Tp.denote p T)) (e: T.denote p), ((lp ++ [e]) <+: l) → STHoare p env (Inv lp) (fb h![e]) (fun _ => Inv (lp ++ [e]))):


### PR DESCRIPTION
This commit adds statements and proofs of the remaining theorems to accompany the functionality of the `std::option::Option<T>` type. It also introduces a document that aims to collate useful tips for stating theorems and proving.

Do note that it does not contain proofs for some of the traits implemented for `Option` as these will be influenced by the "lawful" trait initiative, and hence are not worth doing at this stage.

It also adds the `unsafe` mode to both the `steps` and `sl` tactics. This allows `sl` (and uses thereof embedded in `steps`) to unify from the entire proof state instead of the state of the current goal.

This is work toward #50.