### PR TITLE
Add theorems for Option's traits

### DIFF
--- a/Lampe/Lampe/Syntax/Utils.lean
+++ b/Lampe/Lampe/Syntax/Utils.lean
@@ -332,6 +332,9 @@ def makeMember [MonadUtil m] : (index : ℕ) → m (TSyntax `term)
 | 0 => ``(Lampe.Builtin.Member.head)
 | n + 1 => do ``(Lampe.Builtin.Member.tail $(←makeMember n))
 
+def makeTraitDefHasImplIdent (traitName : Lean.Ident) : Lean.Ident :=
+  mkIdent $ traitName.getId ++ (.mkSimple "hasImpl")
+
 def makeTraitDefGenericKindsIdent (traitName : Lean.Ident) : Lean.Ident :=
   mkIdent $ traitName.getId ++ (.mkSimple "#genericKinds")
 

--- a/Lampe/Lampe/Tactic/SL.lean
+++ b/Lampe/Lampe/Tactic/SL.lean
@@ -33,10 +33,10 @@ theorem singleton_congr_star_mv {p} {r} {v₁ v₂ : AnyValue p} (heq: v₁ = v�
   simp
   apply SLP.entails_self
 
-theorem lmbSingleton_congr_star_mv 
-    {argTps outTp p} 
-    {r : FuncRef argTps outTp} 
-    {f₁ f₂ : HList (Tp.denote p) argTps → Expr (Tp.denote p) outTp} 
+theorem lmbSingleton_congr_star_mv
+    {argTps outTp p}
+    {r : FuncRef argTps outTp}
+    {f₁ f₂ : HList (Tp.denote p) argTps → Expr (Tp.denote p) outTp}
     (heq: f₁ = f₂)
   : ([λr ↦ f₁] ⊢ [λr ↦ f₂] ⋆ ⟦⟧) := by
   simp_all [SLP.entails_self]
@@ -50,9 +50,9 @@ theorem singleton_congr_star {p} {r} {v₁ v₂ : AnyValue p} {R} (h: v₁ = v�
   cases h
   apply SLP.entails_self
 
-theorem lmbSingleton_congr_star {p} {r : FuncRef i o} 
-    {v₁ v₂ : HList (Tp.denote p) i → Lampe.Expr (Tp.denote p) o} 
-    {R} 
+theorem lmbSingleton_congr_star {p} {r : FuncRef i o}
+    {v₁ v₂ : HList (Tp.denote p) i → Lampe.Expr (Tp.denote p) o}
+    {R}
     (h: v₁ = v₂)
   : [λr ↦ v₁] ⋆ R ⊢ [λr ↦ v₂] ⋆ R := by
   cases h
@@ -126,10 +126,10 @@ lemma solve_compose [LawfulHeap α] {P Q R S : SLP α} (h₁ : P ⊢ Q ⋆ R) (h
   apply SLP.star_mono_l
   assumption
 
-lemma solve_compose_with_sinks {α} [LawfulHeap α] 
-    {P Q R S T : SLP α} 
-    (h₁ : P ⊢ Q ⋆ R) 
-    (h₂ : R ⊢ S ⋆ T) 
+lemma solve_compose_with_sinks {α} [LawfulHeap α]
+    {P Q R S T : SLP α}
+    (h₁ : P ⊢ Q ⋆ R)
+    (h₂ : R ⊢ S ⋆ T)
   : P ⊢ (Q ⋆ S) ⋆ T := by
   simp only [SLP.star_assoc]
   apply solve_compose <;> assumption
@@ -163,7 +163,7 @@ structure SLGoals where
   props : List MVarId
   implicits : List MVarId
 
-abbrev SLM := ReaderT SLConfig TacticM 
+abbrev SLM := ReaderT SLConfig TacticM
 
 def SLM.run {α} (x : SLM α) (r : SLConfig) : TacticM α :=
   ReaderT.run x r
@@ -171,10 +171,10 @@ def SLM.run {α} (x : SLM α) (r : SLConfig) : TacticM α :=
 def SLGoals.flatten (g : SLGoals) : List MVarId := g.entailments ++ g.props ++ g.implicits
 
 instance : Append SLGoals where
-  append g₁ g₂ := { 
-    entailments := g₁.entailments ++ g₂.entailments, 
-    props := g₁.props ++ g₂.props, 
-    implicits := g₁.implicits ++ g₂.implicits 
+  append g₁ g₂ := {
+    entailments := g₁.entailments ++ g₂.entailments,
+    props := g₁.props ++ g₂.props,
+    implicits := g₁.implicits ++ g₂.implicits
   }
 
 instance : Inhabited SLGoals where
@@ -184,10 +184,14 @@ def _root_.Lean.MVarId.apply' (m: MVarId) (e: Lean.Expr): TacticM (List MVarId) 
   trace[Lampe.SL] "Applying {e}"
   m.apply e
 
+lemma dite_lift_lift [Decidable R] [LawfulHeap α] {P : R → Prop} {Q : ¬R → Prop}
+  : (if h: R then (P h : SLP α) else (⟦Q h⟧ : SLP α)) = (⟦if h : R then P h else Q h⟧ : SLP α) := by
+  split <;> rfl
+
 /--
 Solves goals of the form `P ⊢ [r ↦ v] ⋆ ?_`, trying to copy as much evidence as possible to the MVar on the right
 -/
-partial def solveSingletonStarMV (goal : MVarId) (lhs : SLTerm) (rhs : Lean.Expr) : SLM SLGoals := 
+partial def solveSingletonStarMV (goal : MVarId) (lhs : SLTerm) (rhs : Lean.Expr) : SLM SLGoals :=
   goal.withContext $ withTraceNode `Lampe.SL (fun e => return f!"solveSingletonStarMV {Lean.exceptEmoji e}") $ do
   match lhs with
   | SLTerm.singleton _ v _ =>
@@ -239,7 +243,7 @@ For example, if the original goal is `P x ⋆ P y ⊢ (∃∃z, P z) ⋆ P x`, a
 look like `P x ⋆ P y ⊢ P ?v ⋆ P x` and we'd use `P x` to solve `P ?v` and then we're left with
 unsolvable `P y ⊢ P x`. So `?v` cannot be unified by this tactic.
 -/
-def solveExactStarMV (goal : MVarId) (lhs : SLTerm) (rhs : Lean.Expr) : SLM SLGoals := 
+def solveExactStarMV (goal : MVarId) (lhs : SLTerm) (rhs : Lean.Expr) : SLM SLGoals :=
   withTraceNode `Lampe.SL (fun e => return f!"solveExactStarMV {Lean.exceptEmoji e}") do
   let isUnsafe := (←read).isUnsafe
   match lhs with
@@ -266,7 +270,7 @@ def solveExactStarMV (goal : MVarId) (lhs : SLTerm) (rhs : Lean.Expr) : SLM SLGo
       pure $ goals ++ SLGoals.mk [] [] impl
   | _ => throwError "Unrecognized shape in solveExactStarMV"
 
-partial def rewriteSides (goal : MVarId) (newPre newPost : Lean.Expr) (eqPre eqPost : Lean.Expr) 
+partial def rewriteSides (goal : MVarId) (newPre newPost : Lean.Expr) (eqPre eqPost : Lean.Expr)
   : SLM MVarId := do
   let newGoalTp ← mkAppM ``SLP.entails #[newPre, newPost]
   let nextGoal ← mkFreshMVarId
@@ -281,14 +285,14 @@ partial def normalizePre (goal : MVarId) (pre post : SLTerm) : SLM (SLTerm × MV
   let goal ← rewriteSides goal pre'.expr post.expr preEq postEq
   pure (pre', goal)
 
-partial def normalizeSides (goal : MVarId) (pre post : SLTerm) 
+partial def normalizeSides (goal : MVarId) (pre post : SLTerm)
   : SLM (SLTerm × SLTerm × MVarId) := do
   let (pre', preEq) ← Lampe.SL.norm pre
   let (post', postEq) ← Lampe.SL.norm post
   let goal ← rewriteSides goal pre'.expr post'.expr preEq postEq
   pure (pre', post', goal)
 
-partial def solveGoal (goal : MVarId) (pre post : SLTerm) : SLM SLGoals := 
+partial def solveGoal (goal : MVarId) (pre post : SLTerm) : SLM SLGoals :=
   withTraceNode `Lampe.SL (tag := "solveGoal") (fun e => return f!"solveGoal {Lean.exceptEmoji e}") do
   match post with
   | .singleton _ v _ => solveSingletonStarMV goal pre v
@@ -304,8 +308,8 @@ partial def solveGoal (goal : MVarId) (pre post : SLTerm) : SLM SLGoals :=
 
 -- Solves all goals, or moves them to sinks if unable to close.
 -- If this returns (pre, sinks, goal), we have `goal : pre ⊢ sinks`, with both sides normalized
-partial def solveGoals (goal : MVarId) (pre goals sinks : SLTerm) 
-  : SLM (SLGoals × SLTerm × SLTerm × MVarId) := 
+partial def solveGoals (goal : MVarId) (pre goals sinks : SLTerm)
+  : SLM (SLGoals × SLTerm × SLTerm × MVarId) :=
   withTraceNode `Lampe.SL (tag := "solveGoals") (fun e => return f!"solveGoals {Lean.exceptEmoji e}") do
   match goals with
   | .unit _ =>
@@ -358,7 +362,7 @@ partial def doPullWith (pre : SLTerm) (goal : MVarId) (puller finalPuller : Lean
     pure (goal, impls)
   | _ => pure (goal, [])
 
-partial def pullPures (goal : MVarId) (pre post : SLTerm) : SLM (MVarId × List MVarId) := 
+partial def pullPures (goal : MVarId) (pre post : SLTerm) : SLM (MVarId × List MVarId) :=
   goal.withContext $ withTraceNode `Lampe.SL (tag := "pullPures") (fun e => return f!"pullPures {Lean.exceptEmoji e}") do
   let (goal, puller, finalPuller) ← if post.hasMVars then
     let (p, pmv, postEqMVars) ← Lampe.SL.split_by (fun t => match t with
@@ -387,7 +391,7 @@ partial def doApplyExis (goal : MVarId) (postExis : SLTerm) : SLM (MVarId × Lis
     pure (goal, goals ++ g₂)
   | _ => pure (goal, [])
 
-partial def applyExis (goal : MVarId) (pre post : SLTerm): SLM (MVarId × List MVarId) := 
+partial def applyExis (goal : MVarId) (pre post : SLTerm): SLM (MVarId × List MVarId) :=
   goal.withContext do
   let (p, pmv, postEqMVars) ← Lampe.SL.split_by (fun t => match t with
     | SLTerm.exi _ _ => pure .left
@@ -398,7 +402,7 @@ partial def applyExis (goal : MVarId) (pre post : SLTerm): SLM (MVarId × List M
   let goal ← rewriteSides goal pre.expr newPost preEq postEqMVars
   doApplyExis goal p
 
-partial def solveSinks (goal : MVarId) (pre post : SLTerm): SLM SLGoals := 
+partial def solveSinks (goal : MVarId) (pre post : SLTerm): SLM SLGoals :=
   goal.withContext $ withTraceNode `Lampe.SL (tag := "solveSinks") (fun e => return f!"solveSinks {Lean.exceptEmoji e}") do
   trace[Lampe.SL] "Current goal: {←ppExpr pre.expr} ⊢ ({←ppExpr post.expr})"
   match post with
@@ -422,7 +426,7 @@ partial def pullExisLoop (goal : MVarId): SLM (MVarId × List MVarId) := goal.wi
       pure $ (r, impls ++ rs)
   | _ => pure (goal, [])
 
-partial def pullExis (pre post : SLTerm) (goal : MVarId): SLM (MVarId × List MVarId) := 
+partial def pullExis (pre post : SLTerm) (goal : MVarId): SLM (MVarId × List MVarId) :=
   goal.withContext do
   let (goals, sink, postEq) ← Lampe.SL.split_by (fun t => match t with
   | SLTerm.mvar _ => pure .right
@@ -441,7 +445,7 @@ partial def pullExis (pre post : SLTerm) (goal : MVarId): SLM (MVarId × List MV
   let (g, r) ← pullExisLoop goal
   pure (g, r ++ impls)
 
-partial def parseAndNormalizeEntailment (goal : MVarId): SLM (SLTerm × SLTerm × MVarId) := 
+partial def parseAndNormalizeEntailment (goal : MVarId): SLM (SLTerm × SLTerm × MVarId) :=
   goal.withContext do
   let target ← goal.instantiateMVarsInType
   let (pre, post) ← parseEntailment target
@@ -449,12 +453,12 @@ partial def parseAndNormalizeEntailment (goal : MVarId): SLM (SLTerm × SLTerm �
   return (pre, post, goal)
 
 /--
-Solves an entailment of the form `P ⊢ Q ⋆ ⊤` or `P ⊢ Q ⋆ ?M`. 
+Solves an entailment of the form `P ⊢ Q ⋆ ⊤` or `P ⊢ Q ⋆ ?M`.
 
 It pushes all clonable information into the `?M` part to strengthen it for further goals. See how
 it handles pulling pures and existentials to understand.
 -/
-partial def solveEntailment' (goal : MVarId): SLM SLGoals := 
+partial def solveEntailment' (goal : MVarId): SLM SLGoals :=
   goal.withContext $ withTraceNode `Lampe.SL (tag := "solveEntailment") (fun e => return f!"solveEntailment {Lean.exceptEmoji e}") do
   let (pre, post, goal) ← parseAndNormalizeEntailment goal
   let safety := if (←read).isUnsafe then " (unsafe)" else ""
@@ -489,7 +493,7 @@ partial def solveEntailment' (goal : MVarId): SLM SLGoals :=
     pure $ res ++ moreGoals ++ SLGoals.mk [] exiGoals (impls₁ ++ impls₂)
 
 /--
-Solves an entailment of the form `P ⊢ Q ⋆ ⊤` or `P ⊢ Q ⋆ ?M`. 
+Solves an entailment of the form `P ⊢ Q ⋆ ⊤` or `P ⊢ Q ⋆ ?M`.
 
 It pushes all clonable information into the `?M` part to strengthen it for further goals. See how
 it handles pulling pures and existentials to understand.

--- a/Lampe/Lampe/Tactic/Steps.lean
+++ b/Lampe/Lampe/Tactic/Steps.lean
@@ -86,6 +86,7 @@ def getClosingTerm (val : Lean.Expr) : TacticM (Option (TSyntax `term)) := withT
         | ``Lampe.Builtin.bAnd => return some (←``(genericTotalPureBuiltin_intro Builtin.bAnd rfl))
         | ``Lampe.Builtin.bXor => return some (←``(genericTotalPureBuiltin_intro Builtin.bXor rfl))
         | ``Lampe.Builtin.bOr  => return some (←``(genericTotalPureBuiltin_intro Builtin.bOr  rfl))
+        | ``Lampe.Builtin.bEq  => return some (←``(genericTotalPureBuiltin_intro Builtin.bEq  rfl))
 
         | ``Lampe.Builtin.uNot => return some (←``(genericTotalPureBuiltin_intro Builtin.uNot rfl))
         | ``Lampe.Builtin.uAnd => return some (←``(genericTotalPureBuiltin_intro Builtin.uAnd rfl))

--- a/stdlib/lampe/Stdlib/Append.lean
+++ b/stdlib/lampe/Stdlib/Append.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Append
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Append 
 
 export «std-1.0.0-beta.12».Extracted (
   «std::append::Append».«#genericKinds»
@@ -16,7 +15,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::append::Append».append.«#inputs»
   «std::append::Append».append.«#output»
   «std::append::Append».append
-  Append.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Array/CheckShuffle.lean
+++ b/stdlib/lampe/Stdlib/Array/CheckShuffle.lean
@@ -3,8 +3,7 @@ import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 import Stdlib.Cmp
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Array.CheckShuffle
 
 export «std-1.0.0-beta.12».Extracted (
   «std::array::check_shuffle::check_shuffle»
@@ -249,7 +248,6 @@ example :
   steps [check_shuffle_spec]
   · simp_all
   intros
-  apply u8_eq_spec
+  apply Cmp.Eq.u8_eq_spec
 
-end Stdlib
-end Lampe
+end Lampe.Stdlib.Array.CheckShuffle

--- a/stdlib/lampe/Stdlib/Array/Mod.lean
+++ b/stdlib/lampe/Stdlib/Array/Mod.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Array.Mod
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Array
 
 export «std-1.0.0-beta.12».Extracted (
   «std::array::map»
@@ -18,12 +17,9 @@ export «std-1.0.0-beta.12».Extracted (
   «std::array::sort»
   «std::array::sort_via»
   «std::array::test::map_empty»
-  Array.Mod.env
 )
 
 open «std-1.0.0-beta.12».Extracted
-
-namespace Array
 
 theorem concat_spec: STHoare p env ⟦⟧
     («std::array::concat».call h![T, M, N] h![a₁, a₂])

--- a/stdlib/lampe/Stdlib/Array/Quicksort.lean
+++ b/stdlib/lampe/Stdlib/Array/Quicksort.lean
@@ -2,14 +2,12 @@ import «std-1.0.0-beta.12».Extracted.Array.Quicksort
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Array.Quicksort
 
 export «std-1.0.0-beta.12».Extracted (
   «std::array::quicksort::partition»
   «std::array::quicksort::quicksort_loop»
   «std::array::quicksort::quicksort»
-  Array.Quicksort.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Collections/BoundedVec.lean
+++ b/stdlib/lampe/Stdlib/Collections/BoundedVec.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Collections.BoundedVec
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Collections.BoundedVec
 
 export «std-1.0.0-beta.12».Extracted (
   «std::collections::bounded_vec::BoundedVec»
@@ -28,7 +27,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::collections::bounded_vec::BoundedVec::for_eachi»
   «std::collections::bounded_vec::BoundedVec::from_parts»
   «std::collections::bounded_vec::BoundedVec::from_parts_unchecked»
-  Collections.BoundedVec.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Collections/Map.lean
+++ b/stdlib/lampe/Stdlib/Collections/Map.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Collections.Map
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Collections.Map
 
 export «std-1.0.0-beta.12».Extracted (
   «std::collections::map::HashMap»
@@ -33,7 +32,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::collections::map::HashMap::hash»
   «std::collections::map::HashMap::quadratic_probe»
   «std::collections::map::HashMap::assert_load_factor»
-  Collections.Map.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Collections/Umap.lean
+++ b/stdlib/lampe/Stdlib/Collections/Umap.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Collections.Umap
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Collections.Umap
 
 export «std-1.0.0-beta.12».Extracted (
   «std::collections::umap::UHashMap»
@@ -34,7 +33,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::collections::umap::UHashMap::remove»
   «std::collections::umap::UHashMap::hash»
   «std::collections::umap::UHashMap::quadratic_probe»
-  Collections.Umap.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Collections/Vec.lean
+++ b/stdlib/lampe/Stdlib/Collections/Vec.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Collections.Vec
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Collections.Vec
 
 export «std-1.0.0-beta.12».Extracted (
   «std::collections::vec::Vec»
@@ -16,7 +15,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::collections::vec::Vec::insert»
   «std::collections::vec::Vec::remove»
   «std::collections::vec::Vec::len»
-  Collections.Vec.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Compat.lean
+++ b/stdlib/lampe/Stdlib/Compat.lean
@@ -2,12 +2,10 @@ import «std-1.0.0-beta.12».Extracted.Compat
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Compat
 
 export «std-1.0.0-beta.12».Extracted (
   «std::compat::is_bn254»
-  Compat.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Convert.lean
+++ b/stdlib/lampe/Stdlib/Convert.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Convert
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Convert
 
 export «std-1.0.0-beta.12».Extracted (
   «std::convert::AsPrimitive».«#genericKinds»
@@ -24,7 +23,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::convert::Into».into.«#inputs»
   «std::convert::Into».into.«#output»
   «std::convert::Into».into
-  Convert.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Default.lean
+++ b/stdlib/lampe/Stdlib/Default.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Default
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Default
 
 export «std-1.0.0-beta.12».Extracted (
   «std::default::Default».«#genericKinds»
@@ -12,7 +11,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::default::Default».default.«#inputs»
   «std::default::Default».default.«#output»
   «std::default::Default».default
-  Default.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/EmbeddedCurveOps.lean
+++ b/stdlib/lampe/Stdlib/EmbeddedCurveOps.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.EmbeddedCurveOps
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.EmbeddedCurveOps
 
 export «std-1.0.0-beta.12».Extracted (
   «std::embedded_curve_ops::EmbeddedCurvePoint::double»
@@ -17,7 +16,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::embedded_curve_ops::embedded_curve_add»
   «std::embedded_curve_ops::embedded_curve_add_not_nul»
   «std::embedded_curve_ops::embedded_curve_add_unsafe»
-  EmbeddedCurveOps.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Field/Bn254.lean
+++ b/stdlib/lampe/Stdlib/Field/Bn254.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Field.Bn254
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Field.Bn254
 
 export «std-1.0.0-beta.12».Extracted (
   «std::field::bn254::PLO» 
@@ -18,7 +17,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::field::bn254::assert_lt»
   «std::field::bn254::gt»
   «std::field::bn254::lt»
-  Field.Bn254.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Field/Mod.lean
+++ b/stdlib/lampe/Stdlib/Field/Mod.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Field.Mod
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Field
 
 export «std-1.0.0-beta.12».Extracted (
   «std::field::assert_max_bit_size»
@@ -21,7 +20,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::field::field_less_than»
   «std::field::bytes32_to_field»
   «std::field::lt_fallback»
-  Field.Mod.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Hash/Mod.lean
+++ b/stdlib/lampe/Stdlib/Hash/Mod.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Hash.Mod
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Hash
 
 export «std-1.0.0-beta.12».Extracted (
   «std::hash::keccak::keccakf1600»
@@ -15,7 +14,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::hash::derive_generators»
   «std::hash::from_field_unsafe»
   «std::hash::assert_pedersen»
-  Hash.Mod.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Hash/Poseidon2.lean
+++ b/stdlib/lampe/Stdlib/Hash/Poseidon2.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Hash.Poseidon2
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Hash.Poseidon2
 
 export «std-1.0.0-beta.12».Extracted (
   «std::hash::poseidon2::Poseidon2»
@@ -13,7 +12,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::hash::poseidon2::Poseidon2::absorb»
   «std::hash::poseidon2::Poseidon2::squeeze»
   «std::hash::poseidon2::Poseidon2::hash_internal»
-  Hash.Poseidon2.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Lib.lean
+++ b/stdlib/lampe/Stdlib/Lib.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Lib
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Lib
 
 export «std-1.0.0-beta.12».Extracted (
   «std::print_oracle»
@@ -16,7 +15,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::wrapping_mul»
   «std::tests::test_static_assert_custom_message»
   «std::tests::test_wrapping_mul»
-  Lib.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Ops/Arith.lean
+++ b/stdlib/lampe/Stdlib/Ops/Arith.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Ops.Arith
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Ops.Arith
 
 export «std-1.0.0-beta.12».Extracted (
   «std::ops::arith::Add».«#genericKinds»
@@ -67,7 +66,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::ops::arith::split64»
   «std::ops::arith::split_into_64_bit_limbs»
   «std::ops::arith::wrapping_mul128_hlp»
-  Ops.Arith.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Ops/Bit.lean
+++ b/stdlib/lampe/Stdlib/Ops/Bit.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Ops.Bit
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Ops.Bit
 
 export «std-1.0.0-beta.12».Extracted (
   «std::ops::bit::BitAnd».«#genericKinds»
@@ -42,7 +41,6 @@ export «std-1.0.0-beta.12».Extracted (
   «std::ops::bit::Shr».shr.«#inputs»
   «std::ops::bit::Shr».shr.«#output»
   «std::ops::bit::Shr».shr
-  Ops.Bit.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Option.lean
+++ b/stdlib/lampe/Stdlib/Option.lean
@@ -1,9 +1,8 @@
-import «std-1.0.0-beta.12».Extracted.Option
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
+import Stdlib.Cmp
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Option
 
 export «std-1.0.0-beta.12».Extracted (
   «std::option::Option»
@@ -25,14 +24,15 @@ export «std-1.0.0-beta.12».Extracted (
   «std::option::Option::or_else»
   «std::option::Option::xor»
   «std::option::Option::flatten»
-  Option.env
 )
 
 open «std-1.0.0-beta.12».Extracted
+open Cmp.Ord
 
-namespace Option
+set_option Lampe.pp.Expr false
+set_option Lampe.pp.STHoare false
 
-/-- 
+/--
 Convert a Lean option into a Noir `std::option::Option`.
 
 We recommend providing the user with `std::option::Option`s at the boundary of the theorem for any
@@ -42,7 +42,7 @@ def fromOption {p t} : Option (t.denote p) -> («std::option::Option».tp h![t] 
 | none => (false, Tp.zero p t, ())
 | some val => (true, val, ())
 
-/-- 
+/--
 Convert a Noir `std::option::Option` into a Lean option.
 
 We recommend converting user-provided `std::option::Option`s from the user, and converting them
@@ -57,10 +57,10 @@ lemma fromOption_toOption_id : toOption (fromOption v) = v := by
   cases v <;> rfl
 
 @[simp]
-lemma option_fst_eq_toOption_isSome {p T} 
+lemma option_fst_eq_toOption_isSome {p T}
     {v : Tp.denote p $ «std::option::Option».tp h![T]}
   : Builtin.indexTpl v Builtin.Member.head = (toOption v).isSome := by
-  rcases v with ⟨_|_, _⟩ 
+  rcases v with ⟨_|_, _⟩
   all_goals rfl
 
 @[simp]
@@ -68,9 +68,9 @@ lemma option_snd_eq_toOption_get_of_isSome {p T}
     {v : Tp.denote p $ «std::option::Option».tp h![T]}
     (v_is_some : (toOption v).isSome = true)
   : Builtin.indexTpl v Builtin.Member.head.tail = (toOption v).get v_is_some := by
-  rcases v with ⟨_|_, _, _⟩ 
-  . contradiction
-  . rfl
+  rcases v with ⟨_|_, _, _⟩
+  · contradiction
+  · rfl
 
 lemma getD_map_of_isSome {α β} {f : α → β} {d : β} {o : Option α}
     (h : o.isSome)
@@ -79,12 +79,12 @@ lemma getD_map_of_isSome {α β} {f : α → β} {d : β} {o : Option α}
   rfl
 
 @[simp]
-lemma bind_def_of_isSome {α β} {v : Option α} {f : α → Option β} (v_is_some : v.isSome = true) 
-  : v >>= f = f (v.get v_is_some) := by  
+lemma bind_def_of_isSome {α β} {v : Option α} {f : α → Option β} (v_is_some : v.isSome = true)
+  : v >>= f = f (v.get v_is_some) := by
   rcases (Option.isSome_iff_exists.mp v_is_some) with ⟨_, rfl⟩
   simp_all
 
-theorem none_spec {p T} : STHoare p env ⟦⟧ («std::option::Option::none».call h![T] h![]) 
+theorem none_spec {p T} : STHoare p env ⟦⟧ («std::option::Option::none».call h![T] h![])
     (fun v => v = fromOption none) := by
   enter_decl
   steps
@@ -98,8 +98,8 @@ theorem some_spec {p T v} : STHoare p env ⟦⟧ («std::option::Option::some».
   subst_vars
   rfl
 
-theorem is_none_spec {p T v} : STHoare p env ⟦⟧ 
-    («std::option::Option::is_none».call h![T] h![v]) 
+theorem is_none_spec {p T v} : STHoare p env ⟦⟧
+    («std::option::Option::is_none».call h![T] h![v])
     (fun r => r = (toOption v).isNone) := by
   enter_decl
   steps
@@ -107,16 +107,16 @@ theorem is_none_spec {p T v} : STHoare p env ⟦⟧
   simp
   exact ()
 
-theorem is_some_spec {p T v} : STHoare p env ⟦⟧ 
-    («std::option::Option::is_some».call h![T] h![v]) 
+theorem is_some_spec {p T v} : STHoare p env ⟦⟧
+    («std::option::Option::is_some».call h![T] h![v])
     (fun r => r = (toOption v).isSome) := by
   enter_decl
   steps
   subst_vars
   simp
 
-theorem unwrap_spec {p T v} : STHoare p env ⟦⟧ 
-    («std::option::Option::unwrap».call h![T] h![v]) 
+theorem unwrap_spec {p T v} : STHoare p env ⟦⟧
+    («std::option::Option::unwrap».call h![T] h![v])
     (fun r => ∃h, r = (toOption v).get h) := by
   enter_decl
   steps
@@ -126,18 +126,18 @@ theorem unwrap_spec {p T v} : STHoare p env ⟦⟧
   subst_vars
   rename Tp.denote p («std::option::Option».tp _) => h
   rcases h with ⟨(_|_), _, _⟩
-  . contradiction
-  . rfl
+  · contradiction
+  · rfl
 
-theorem map_none_spec {p T U E f v} 
+theorem map_none_spec {p T U E f v}
     (v_is_none : (toOption v).isNone)
-  : STHoare p env ⟦⟧ 
-    («std::option::Option::map».call h![T, U, E] h![v, f]) 
+  : STHoare p env ⟦⟧
+    («std::option::Option::map».call h![T, U, E] h![v, f])
     (fun r => r = fromOption none) := by
   enter_decl
   steps
   apply STHoare.ite_intro_of_false
-  . simp_all
+  · simp_all
 
   steps [none_spec]
   simp_all
@@ -152,7 +152,7 @@ theorem map_some_spec {p T U E f fb v P Q}
   enter_decl
   steps
   apply STHoare.ite_intro_of_true
-  . simp_all
+  · simp_all
 
   steps
   simp only [option_snd_eq_toOption_get_of_isSome v_is_some]
@@ -163,15 +163,15 @@ theorem map_some_spec {p T U E f fb v P Q}
 theorem map_pure_spec {p T U E P f fb v}
     {f_emb : T.denote p → U.denote p}
     (h_f : ∀arg, STHoare p env P (fb h![arg]) (fun r => r = f_emb arg ⋆ P))
-  : STHoare p env 
+  : STHoare p env
     (P ⋆ [λf ↦ fb])
-    («std::option::Option::map».call h![T, U, E] h![v, f]) 
+    («std::option::Option::map».call h![T, U, E] h![v, f])
     (fun r => r = fromOption ((toOption v).map f_emb) ⋆ P) := by
   by_cases h : (toOption v).isSome = true
-  . steps [map_some_spec h (h_f _)]
+  · steps [map_some_spec h (h_f _)]
     subst_vars
     simp only [←Option.map_some, Option.some_get]
-  . steps [map_none_spec]
+  · steps [map_none_spec]
     all_goals simp_all
 
 theorem map_or_none_spec {p T U E v default f}
@@ -182,8 +182,8 @@ theorem map_or_none_spec {p T U E v default f}
   enter_decl
   steps
   apply STHoare.ite_intro_of_false
-  . simp_all
-  
+  · simp_all
+
   steps
   simp_all
 
@@ -197,7 +197,7 @@ theorem map_or_some_spec {p T U E v f fb default P Q}
   enter_decl
   steps
   apply STHoare.ite_intro_of_true
-  . simp_all
+  · simp_all
 
   steps
   simp only [option_snd_eq_toOption_get_of_isSome v_is_some]
@@ -211,10 +211,10 @@ theorem map_or_pure_spec {p T U E P v f fb default}
     («std::option::Option::map_or».call h![T, U, E] h![v, default, f])
     (fun r => r = ((toOption v).map f_emb).getD default ⋆ P) := by
   by_cases h : (toOption v).isSome = true
-  . steps [map_or_some_spec (E := E) h (h_f _)]
+  · steps [map_or_some_spec (E := E) h (h_f _)]
     subst_vars
     rw [getD_map_of_isSome (f := f_emb) h]
-  . steps [map_or_none_spec]
+  · steps [map_or_none_spec]
     all_goals simp_all
 
 theorem map_or_else_none_spec {p T U E1 E2 P Q v default default_b func}
@@ -227,7 +227,7 @@ theorem map_or_else_none_spec {p T U E1 E2 P Q v default default_b func}
   enter_decl
   steps
   apply STHoare.ite_intro_of_false
-  . simp_all
+  · simp_all
 
   steps [STHoare.callLambda_intro (hlam := default_f)]
 
@@ -241,7 +241,7 @@ theorem map_or_else_some_spec {p T U E1 E2 P Q v default func func_b}
   enter_decl
   steps
   apply STHoare.ite_intro_of_true
-  . simp_all
+  · simp_all
 
   steps
   simp only [option_snd_eq_toOption_get_of_isSome v_is_some]
@@ -257,10 +257,10 @@ theorem map_or_else_pure_spec {p T U E1 E2 P v default default_b func func_b}
     («std::option::Option::map_or_else».call h![T, U, E1, E2] h![v, default, func])
     (fun r => r = ((toOption v).map func_emb).getD default_emb ⋆ P) := by
   by_cases h : (toOption v).isSome = true
-  . steps [map_or_else_some_spec (E1 := E1) (E2 := E2) h (func_f _)]
+  · steps [map_or_else_some_spec (E1 := E1) (E2 := E2) h (func_f _)]
     subst_vars
     rw [getD_map_of_isSome (f := func_emb) h]
-  . have h : (toOption v).isNone := by 
+  · have h : (toOption v).isNone := by
       simp_all
     steps [map_or_else_none_spec (E1 := E1) (E2 := E2) h default_f]
     subst_vars
@@ -273,23 +273,23 @@ theorem and_spec {p T v w}
   enter_decl
   steps [is_none_spec]
   apply STHoare.ite_intro
-  . intro cond
+  · intro cond
     steps [none_spec]
     simp_all
-  . intro cond
+  · intro cond
     steps
     simp_all
 
 theorem and_then_none_spec {p T U E self f}
     (self_is_none : (toOption self).isNone)
-  : STHoare p env ⟦⟧ 
+  : STHoare p env ⟦⟧
     («std::option::Option::and_then».call h![T, U, E] h![self, f])
     (fun r => r = fromOption none) := by
   enter_decl
   steps
   apply STHoare.ite_intro_of_false
-  . simp_all
-  
+  · simp_all
+
   steps [none_spec]
   simp_all
 
@@ -303,8 +303,8 @@ theorem and_then_some_spec {p T U E P Q self f fb}
   enter_decl
   steps
   apply STHoare.ite_intro_of_true
-  . simp_all
-  
+  · simp_all
+
   steps
   simp [option_snd_eq_toOption_get_of_isSome self_is_some]
   steps [STHoare.callLambda_intro (hlam := f_lam)]
@@ -317,10 +317,10 @@ theorem and_then_pure_spec {p T U E P self f fb}
     («std::option::Option::and_then».call h![T, U, E] h![self, f])
     (fun r => r = ((toOption self).map f_emb).getD (fromOption none) ⋆ P) := by
   by_cases h : (toOption self).isSome = true
-  . steps [and_then_some_spec (E := E) h (f_f _)]
+  · steps [and_then_some_spec (E := E) h (f_f _)]
     subst_vars
     rw [getD_map_of_isSome h]
-  . have h : (toOption self).isNone := by simp_all
+  · have h : (toOption self).isNone := by simp_all
     steps [and_then_none_spec (E := E) h]
     simp_all
 
@@ -331,12 +331,12 @@ theorem or_spec {p T self default}
   enter_decl
   steps
   apply STHoare.ite_intro
-  . intro cond
+  · intro cond
     rw [option_fst_eq_toOption_isSome] at cond
     steps
     subst_vars
     simp_all
-  . intro cond
+  · intro cond
     rw [option_fst_eq_toOption_isSome] at cond
     simp_all only [Option.isSome_eq_false_iff, Option.isNone_iff_eq_none, Option.isSome_none,
                    Bool.false_eq_true, ↓reduceIte]
@@ -346,14 +346,14 @@ theorem or_spec {p T self default}
 theorem or_else_none_spec {p T E P Q self default default_b}
     (self_is_none : (toOption self).isNone)
     (default_f : STHoare p env P (default_b h![]) Q)
-  : STHoare p env 
+  : STHoare p env
     (P ⋆ [λdefault ↦ default_b])
     («std::option::Option::or_else».call h![T, E] h![self, default])
     (fun r => Q r ⋆ [λdefault ↦ default_b]) := by
   enter_decl
   steps
   apply STHoare.ite_intro_of_false
-  . simp_all
+  · simp_all
 
   steps [STHoare.callLambda_intro (hlam := default_f)]
 
@@ -365,7 +365,7 @@ theorem or_else_some_spec {p T E self default}
   enter_decl
   steps
   apply STHoare.ite_intro_of_true
-  . simp_all
+  · simp_all
 
   steps
   simp_all
@@ -381,7 +381,7 @@ theorem or_else_pure_spec {p T E P self default default_b}
   . steps [or_else_some_spec h]
     subst_vars
     simp_all
-  . have h : (toOption self).isNone := by simp_all
+  · have h : (toOption self).isNone := by simp_all
     steps [or_else_none_spec (E := E) h default_f]
     subst_vars
     simp_all
@@ -389,8 +389,8 @@ theorem or_else_pure_spec {p T E P self default default_b}
 theorem xor_spec {p T self other}
   : STHoare p env ⟦⟧
     («std::option::Option::xor».call h![T] h![self, other])
-    (fun r => r = if (toOption self).isSome then 
-        if (toOption other).isSome then fromOption none else self 
+    (fun r => r = if (toOption self).isSome then
+        if (toOption other).isSome then fromOption none else self
       else if (toOption other).isSome then
         other
       else
@@ -399,35 +399,35 @@ theorem xor_spec {p T self other}
   enter_decl
   steps
   apply STHoare.ite_intro
-  . intros
+  · intros
     steps
     apply STHoare.ite_intro
-    . intros
+    · intros
       steps [none_spec]
       simp_all
-    . intros
+    · intros
       steps
       simp_all
-  . intros
+  · intros
     steps
     apply STHoare.ite_intro
-    . intros
+    · intros
       steps
       simp_all
-    . intros
+    · intros
       steps [none_spec]
       simp_all
 
 theorem filter_none_spec {p T E self pred}
     (self_is_none : (toOption self).isNone)
-  : STHoare p env ⟦⟧ 
+  : STHoare p env ⟦⟧
     («std::option::Option::filter».call h![T, E] h![self, pred])
     (fun r => r = fromOption none) := by
   enter_decl
   steps
   rw [option_fst_eq_toOption_isSome]
   apply STHoare.ite_intro_of_false
-  . simp_all
+  · simp_all
 
   steps [none_spec]
   simp_all
@@ -443,19 +443,19 @@ theorem filter_some_spec {p T E P Q self pred pred_b}
   steps
   rw [option_fst_eq_toOption_isSome]
   apply STHoare.ite_intro_of_true
-  . simp_all
+  · simp_all
 
   steps
   simp_all only [option_snd_eq_toOption_get_of_isSome]
   steps [STHoare.callLambda_intro (hlam := pred_f)]
 
   apply STHoare.ite_intro
-  . intros
+  · intros
     steps unsafe
     subst_vars
     simp_all
-      
-  . intros
+
+  · intros
     steps [none_spec]
     subst_vars
     sl unsafe
@@ -469,7 +469,7 @@ theorem flatten_spec {p T opt}
   steps
   rw [option_fst_eq_toOption_isSome]
   apply STHoare.ite_intro
-  . intros
+  · intros
     steps
     subst_vars
     rw [option_snd_eq_toOption_get_of_isSome]
@@ -477,15 +477,189 @@ theorem flatten_spec {p T opt}
     simp_all
     apply Option.get_eq_getD
 
-  . intros
+  · intros
     steps [none_spec]
     subst_vars
     simp_all
 
-theorem default_spec {p T} : STHoare p env ⟦⟧ 
+set_option maxRecDepth 2000 in
+theorem default_spec {p T}
+  : STHoare p env ⟦⟧
     («std::default::Default».default h![] («std::option::Option».tp h![T]) h![] h![] h![])
     (fun r => r = fromOption none) := by
   resolve_trait
   steps [none_spec]
   simp_all
-    
+
+set_option maxRecDepth 2000 in
+theorem eq_spec {p T self other P Q}
+    {t_eq : «std::cmp::Eq».hasImpl env h![] T}
+    {eq_f : (h_self : (toOption self).isSome)
+          → (h_other : (toOption other).isSome)
+          → STHoare p env P
+            («std::cmp::Eq».eq h![] T h![] h![]
+              h![(toOption self).get h_self, (toOption other).get h_other])
+            Q}
+  : STHoare p env P
+    («std::cmp::Eq».eq h![] («std::option::Option».tp h![T]) h![] h![] h![self, other])
+    (fun r => if h : (toOption self).isSome ∧ (toOption other).isSome then
+        Q r else (r = ((toOption self).isSome == (toOption other).isSome))) := by
+  resolve_trait
+  steps
+  · exact ()
+  apply STHoare.ite_intro
+  · simp only [option_fst_eq_toOption_isSome, decide_eq_true_eq, dite_eq_ite]
+    intro hp
+    steps
+    apply STHoare.ite_intro
+    · simp only [option_fst_eq_toOption_isSome, decide_eq_true_eq, dite_eq_ite]
+      intro hs
+      rw [hs, Eq.comm] at hp
+      steps
+      simp only [option_snd_eq_toOption_get_of_isSome, *]
+      steps [eq_f hs hp]
+    · simp only [option_fst_eq_toOption_isSome, decide_eq_true_eq, dite_eq_ite]
+      intro hp
+      simp_all
+      steps
+      assumption
+  · simp only [option_fst_eq_toOption_isSome, decide_eq_false_iff_not, dite_eq_ite]
+    intro hp
+    split
+    · rename_i hh
+      rcases hh
+      simp_all
+    · steps
+      subst_vars
+      rw [Eq.comm, beq_eq_false_iff_ne]
+      assumption
+
+theorem eq_spec_pure {p T self other}
+    {t_eq : «std::cmp::Eq».hasImpl env h![] T}
+    {eq_emb : T.denote p → T.denote p → Prop}
+    (h_eq : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] T h![] h![] h![a, b])
+      (fun r : Bool => r = eq_emb a b))
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] («std::option::Option».tp h![T]) h![] h![] h![self, other])
+    (fun r : Bool => r = Option.Rel eq_emb (toOption self) (toOption other)) := by
+  apply STHoare.consequence_frame
+  apply eq_spec
+  case t_eq => assumption
+  case eq_f =>
+    intros
+    simp only [←option_snd_eq_toOption_get_of_isSome]
+    apply h_eq
+  case h_ent => sl
+  case q_ent =>
+    intros
+    simp only [SL.dite_lift_lift]
+    sl
+    rename_i hp
+    split at hp
+    · casesm _∧_
+      rename_i hs ho
+      simp only [hp, option_snd_eq_toOption_get_of_isSome, *]
+      conv =>
+        rhs
+        congr
+        · skip
+        · rw [←Option.some_get hs]
+        · rw [←Option.some_get ho]
+      simp only [Option.rel_some_some]
+    · generalize toOption self = self at *
+      generalize toOption other = other at *
+      simp_all only [eq_iff_iff, not_and, Bool.not_eq_true, Option.isSome_eq_false_iff,
+        Option.isNone_iff_eq_none, beq_iff_eq]
+      apply Iff.intro
+      · intro hp
+        have : self.isSome = false := by
+          by_contra
+          simp_all
+        have : self = none := by simp_all
+        have : other = none := by simp_all
+        simp only [*, Option.rel_none_none]
+      · rintro (_ | _) <;> simp_all
+
+set_option maxRecDepth 2000 in
+theorem hash_spec {p T H self P Q R}
+    {state : Tp.denote p $ Tp.ref H}
+    {t_hash : «std::hash::Hash».hasImpl env h![] T}
+    {t_hash_f : (h_self : (toOption self).isSome) → STHoare p env Q
+      («std::hash::Hash».hash h![] T h![] h![H] h![(toOption self).get h_self, state]) fun _ => R}
+    {bool_hash : «std::hash::Hash».hasImpl env h![] Tp.bool}
+    {bool_hash_f : STHoare p env P
+      («std::hash::Hash».hash h![] Tp.bool h![] h![H] h![(toOption self).isSome, state]) fun _ => Q}
+  : STHoare p env P
+    («std::hash::Hash».hash h![] («std::option::Option».tp h![T]) h![] h![H] h![self, state])
+    (fun _ => if (toOption self).isSome then R else Q) := by
+  resolve_trait
+  steps
+
+  step_as (P) (fun _ => Q)
+  · rw [option_fst_eq_toOption_isSome]
+    steps [bool_hash_f]
+  · steps
+    apply STHoare.ite_intro
+    · simp_all only [option_fst_eq_toOption_isSome]
+      intros
+      steps
+      rw [option_snd_eq_toOption_get_of_isSome]
+      rename_i a
+      steps [t_hash_f a]
+
+    · simp only [option_fst_eq_toOption_isSome, Option.isSome_eq_false_iff,
+        Option.isNone_iff_eq_none]
+      intro
+      simp_all only [Option.isSome_none, Bool.false_eq_true, IsEmpty.forall_iff, ↓reduceIte]
+      steps
+
+set_option maxRecDepth 2000 in
+theorem cmp_spec {p T self other P Q}
+    {t_ord : «std::cmp::Ord».hasImpl env h![] T}
+    {t_ord_f : (h_self : (toOption self).isSome)
+             → (h_other : (toOption other).isSome)
+             → STHoare p env P
+               («std::cmp::Ord».cmp h![] T h![] h![]
+                h![(toOption self).get h_self, (toOption other).get h_other])
+               Q}
+  : STHoare p env P
+    («std::cmp::Ord».cmp h![] («std::option::Option».tp h![T]) h![] h![] h![self, other])
+    (fun r => if (toOption self).isSome then
+      if (toOption other).isSome then Q r else r = fromOrdering .gt
+    else if (toOption other).isSome then r = fromOrdering .lt else
+      r = fromOrdering .eq) := by
+  resolve_trait
+  steps
+  rw [option_fst_eq_toOption_isSome]
+  apply STHoare.ite_intro
+  · intro s_some
+    steps
+    rw [option_fst_eq_toOption_isSome]
+    apply STHoare.ite_intro
+    · intro o_some
+      steps
+      rw [option_snd_eq_toOption_get_of_isSome o_some, option_snd_eq_toOption_get_of_isSome s_some]
+      steps [t_ord_f s_some o_some]
+      simp_all only [forall_true_left, ↓reduceIte]
+      sl
+    · intro o_none
+      steps
+      conv => rhs; simp [s_some, o_none]
+      steps [greater_spec]
+      simp_all
+  · intro s_none
+    steps
+    rw [option_fst_eq_toOption_isSome]
+    apply STHoare.ite_intro
+    · intro o_some
+      steps
+      conv => rhs; simp [s_none, o_some]
+      steps [less_spec]
+      simp_all
+    · intro o_none
+      steps
+      conv => rhs; simp [s_none, o_none]
+      steps [equal_spec]
+      simp_all
+

--- a/stdlib/lampe/Stdlib/Panic.lean
+++ b/stdlib/lampe/Stdlib/Panic.lean
@@ -2,12 +2,10 @@ import «std-1.0.0-beta.12».Extracted.Panic
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Panic
 
 export «std-1.0.0-beta.12».Extracted (
   «std::panic::panic»
-  Panic.env
 )
 
 open «std-1.0.0-beta.12».Extracted

--- a/stdlib/lampe/Stdlib/Slice.lean
+++ b/stdlib/lampe/Stdlib/Slice.lean
@@ -2,8 +2,7 @@ import «std-1.0.0-beta.12».Extracted.Slice
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.Slice
 
 export «std-1.0.0-beta.12».Extracted (
   «std::slice::append»
@@ -18,14 +17,11 @@ export «std-1.0.0-beta.12».Extracted (
   «std::slice::join»
   «std::slice::all»
   «std::slice::any»
-  Slice.env
 )
 
 open «std-1.0.0-beta.12».Extracted
 
 set_option maxRecDepth 10000
-
-namespace Slice
 
 lemma for_each_inv {T Env p f fb l}
     (Inv: List (Tp.denote p T) → SLP (State p))

--- a/stdlib/lampe/Stdlib/Stdlib.lean
+++ b/stdlib/lampe/Stdlib/Stdlib.lean
@@ -25,7 +25,6 @@ import Stdlib.String
 
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib
 
 export «std-1.0.0-beta.12».Extracted (env)

--- a/stdlib/lampe/Stdlib/String.lean
+++ b/stdlib/lampe/Stdlib/String.lean
@@ -2,12 +2,10 @@ import «std-1.0.0-beta.12».Extracted.String
 import «std-1.0.0-beta.12».Extracted.«std-1.0.0-beta.12»
 import Lampe
 
-namespace Lampe
-namespace Stdlib
+namespace Lampe.Stdlib.String
 
 export «std-1.0.0-beta.12».Extracted (
   «std::string::as_bytes_vec»
-  String.env
 )
 
 open «std-1.0.0-beta.12».Extracted


### PR DESCRIPTION
We were originally going to work on a `Lawful` system for trait implementations, but in the interests of expediency we are going to leave that for later (#204). This commit adds basic theorems for the remaining traits on Option, and also provides some additional ergonomics for working with traits with `where` bounds.