### PR TITLE
Add theorems for `std::cmp::Eq`

### DIFF
--- a/Lampe/Lampe/Ast.lean
+++ b/Lampe/Lampe/Ast.lean
@@ -18,7 +18,7 @@ structure TraitImplRef where
 
 inductive Expr (rep : Tp → Type) : Tp → Type where
 | litNum : (tp : Tp) → Int → Expr rep tp
-| litStr : (len : U 32) → FixedLenStr len.toNat → Expr rep (.str len)
+| litStr : (len : U 32) → NoirStr len.toNat → Expr rep (.str len)
 | constFp : Int → Expr rep .field
 | constU : U w → Expr rep (.u w)
 | fmtStr : (len : U 32) → (tps : Tp) → FormatString len tps → Expr rep (.fmtStr len tps)

--- a/Lampe/Lampe/Builtin/Basic.lean
+++ b/Lampe/Lampe/Builtin/Basic.lean
@@ -97,6 +97,7 @@ and returns a predicate `h : Prop` and an evaluation function `h → (Tp.denote 
 If the builtin succeeds, i.e., the predicate `h` succeeds, it evaluates to `some (eval h)` where `eval = (desc a args).snd`.
 Otherwise, it evaluates to `none`.
 -/
+@[reducible]
 def newGenericPureBuiltin {A : Type}
   (sgn : A → List Tp × Tp)
   (desc : {p : Prime}

--- a/Lampe/Lampe/Builtin/Str.lean
+++ b/Lampe/Lampe/Builtin/Str.lean
@@ -2,14 +2,16 @@ import Lampe.Builtin.Basic
 namespace Lampe.Builtin
 
 /--
-Defines the conversion of strings of length `n` to a byte array of length `n`.
-Accordingly, we assume that the string has UTF-8 byte length of `n`.
+Defines the conversion of strings of length `N` to a byte array of length `N`.
 
-In Noir, this corresponds to `fn as_bytes(self) -> [u8; n]` implemented for `str<n>`.
+It is enforced that Noir strings are uninterpreted bytes, so the length `N` of a string is the
+number of bytes it contains, not the number of characters (regardless of the encoding).
+
+In Noir, this corresponds to `fn as_bytes(self: str<N>) -> [u8; N]`.
 -/
 def strAsBytes := newGenericPureBuiltin
   (fun n => ⟨[.str n], (.array (.u 8) n)⟩)
-  (fun n h![s] => ⟨s.toList.length = n.toNat,
-    fun h => .map (fun u => u.toNat) ⟨s.toList, h⟩⟩)
+  (fun n h![s] => ⟨s.length = n.toNat,
+    fun _ => s⟩)
 
 end Lampe.Builtin

--- a/Lampe/Lampe/Data/Strings.lean
+++ b/Lampe/Lampe/Data/Strings.lean
@@ -1,5 +1,57 @@
 import Mathlib.Data.Vector.Defs
 import Lampe.Data.HList
 
-abbrev FixedLenStr (n : Nat) := List.Vector Char n
+namespace Lampe
+
+/-- A byte in our model of Noir. -/
+abbrev NoirByte := BitVec 8
+
+/-- 
+A Lean-level value representation of a Noir string.
+
+Strings in Noir are simply arrays of bytes, with no interpretation of those bytes imposed by the
+string itself. The length `n` is _always_ intended to be equal to the number of bytes contained
+within the string, and is explicitly _not_ equal to some arbitrary notion of "characters",
+"graphemes" or "grapheme clusters" as is seen in some languages.
+
+Note that this does create an impedance mismatch with Lean strings, which interpret every `Char` as
+a unicode code-point. To that end, we provide restricted conversions from noir strings back into
+Lean strings as they are not useful for theorems.
+-/
+abbrev NoirStr (n : ℕ) := List.Vector NoirByte n
+
+namespace NoirStr
+
+/-- Creates a fixed length Noir string from the provided bytes. -/
+@[reducible]
+def mk {n : ℕ} (bytes : List.Vector UInt8 n) : NoirStr n :=
+  bytes.map (·.toBitVec)
+
+/-- Gets the length of the noir string in bytes. -/
+@[reducible]
+def length {n : ℕ} (_ : NoirStr n) : ℕ := n
+
+/--
+Converts the provided Lean String into a noir string, interpreting it as a series of UTF-8 encoded
+bytes. 
+-/
+@[reducible]
+def of (str : String) : NoirStr (str.toUTF8.toList.length) :=
+  let bytes := str.toUTF8.toList 
+  NoirStr.mk ⟨bytes, by rfl⟩
+
+/--
+Converts the provided Noir string into a standard Lean string, interpreting the byte sequence as
+UTF-8 encoded text.
+-/
+@[reducible]
+def toString {n : ℕ} (ns : NoirStr n) : String :=
+  let bytes := ⟨ns.map UInt8.ofBitVec |>.toList.toArray⟩
+  String.fromUTF8! bytes
+
+end NoirStr
+
+instance {n : ℕ} : CoeOut (NoirStr n) String where
+  coe := NoirStr.toString 
+attribute [coe] NoirStr.toString 
 

--- a/Lampe/Lampe/Hoare/Builtins.lean
+++ b/Lampe/Lampe/Hoare/Builtins.lean
@@ -278,7 +278,7 @@ theorem uEq_intro : STHoarePureBuiltin p Γ Builtin.uEq (by tauto) h![a, b] := b
    apply pureBuiltin_intro_consequence <;> try tauto
    tauto
 
-theorem iEq_intro : STHoarePureBuiltin p Γ Builtin.uEq (by tauto) h![a, b] := by
+theorem iEq_intro : STHoarePureBuiltin p Γ Builtin.iEq (by tauto) h![a, b] := by
    simp only [STHoarePureBuiltin, SLP.exists_pure]
    apply pureBuiltin_intro_consequence <;> try tauto
    tauto

--- a/Lampe/Lampe/Syntax/Builders.lean
+++ b/Lampe/Lampe/Syntax/Builders.lean
@@ -169,7 +169,10 @@ partial def makeExpr [MonadDSL m]
 | `(noir_expr|-$n:num : $tp) => do
   wrapInLet (←``(Expr.litNum $(←makeNoirType tp) (-$n))) binder k
 | `(noir_expr|$s:str) => do
-  wrapInLet (←`(Expr.litStr (String.length $s) (⟨String.data $s, by rfl⟩))) binder k
+  let bytes := s.getString.toUTF8.toList
+  let bytes ← bytes.mapM fun c => do ``($(Syntax.mkNatLit c.toNat))
+  let bytesLit ← makeListLit bytes
+  wrapInLet (←``(Expr.litStr (String.length $s) (⟨$bytesLit, by rfl⟩))) binder k
 | `(noir_expr|#_true) => do wrapInLet (←``(Expr.litNum Tp.bool 1)) binder k
 | `(noir_expr|#_false) => do wrapInLet (←``(Expr.litNum Tp.bool 0)) binder k
 | `(noir_expr|#_unit) => do wrapInLet (←``(Expr.skip)) binder k

--- a/Lampe/Lampe/Tactic/Steps.lean
+++ b/Lampe/Lampe/Tactic/Steps.lean
@@ -105,9 +105,21 @@ def getClosingTerm (val : Lean.Expr) : TacticM (Option (TSyntax `term)) := withT
 
         | ``Lampe.Builtin.fEq => return some (←``(genericTotalPureBuiltin_intro Builtin.fEq rfl (a := ())))
         | ``Lampe.Builtin.uEq => return some (←``(genericTotalPureBuiltin_intro Builtin.uEq rfl))
+        | ``Lampe.Builtin.iEq => return some (←``(genericTotalPureBuiltin_intro Builtin.iEq rfl))
 
         | ``Lampe.Builtin.uAdd => return some (←``(uAdd_intro))
         | ``Lampe.Builtin.uMul => return some (←``(uMul_intro))
+        | ``Lampe.Builtin.uDiv => return some (←``(uDiv_intro))
+        | ``Lampe.Builtin.uSub => return some (←``(uSub_intro))
+        | ``Lampe.Builtin.uRem => return some (←``(uRem_intro))
+
+        | ``Lampe.Builtin.iAdd => return some (←``(iAdd_intro))
+        | ``Lampe.Builtin.iMul => return some (←``(iMul_intro))
+        | ``Lampe.Builtin.iDiv => return some (←``(iDiv_intro))
+        | ``Lampe.Builtin.iSub => return some (←``(iSub_intro))
+        | ``Lampe.Builtin.iRem => return some (←``(iRem_intro))
+
+        | ``Lampe.Builtin.strAsBytes => return some (←``(strAsBytes_intro))
 
         -- Array builtins
         | ``Lampe.Builtin.mkArray =>

--- a/Lampe/Lampe/Tp.lean
+++ b/Lampe/Lampe/Tp.lean
@@ -165,7 +165,7 @@ def Tp.denote : Tp → Type
 | .bi => Int
 | .bool => Bool
 | .unit => Unit
-| .str n => FixedLenStr n.toNat
+| .str n => NoirStr n.toNat
 | .fmtStr n tps => FormatString n tps
 | .field => Fp p
 | .slice tp => List (denote tp)
@@ -241,7 +241,7 @@ match tp with
 | .u _ | .i _ | .bi | .field => 0
 | .bool => False
 | .unit => ()
-| .str n => List.Vector.replicate n.toNat '\x00'
+| .str n => List.Vector.replicate n.toNat 0
 | .fmtStr _ _ => ""
 | .slice _ => []
 | .array tp n => List.Vector.replicate n.toNat tp.zero

--- a/Lampe/Tests/Errors.lean
+++ b/Lampe/Tests/Errors.lean
@@ -14,7 +14,7 @@ error: Unable to find a declaration in the environment with the right name
 -/
 #guard_msgs in
 theorem enter_decl_error : STHoare p env ⟦⟧ (hello.call h![] h![])
-    fun output => (String.mk output.toList) = "hello" := by
+    fun output => output.toString = "hello" := by
   enter_decl
 
 /- testing enter_block_as error reporting -/
@@ -29,9 +29,9 @@ due to the absence of the instance above
 Additional diagnostic information may be available using the `set_option diagnostics true` command.-/
 #guard_msgs in
 theorem enter_block_error : STHoare p helloEnv ⟦⟧ (hello.call h![] h![])
-    fun output => (String.mk output.toList) = "hello" := by
+    fun output => output.toString = "hello" := by
   enter_decl
-  step_as (⟦⟧) (fun (v : Tp.denote p (Tp.str 5)) => (String.mk v.toList) = 5)
+  step_as (⟦⟧) (fun (v : Tp.denote p (Tp.str 5)) => v.toString = 5)
   sorry
 
 /- testing steps error messaging -/
@@ -39,7 +39,7 @@ theorem enter_block_error : STHoare p helloEnv ⟦⟧ (hello.call h![] h![])
 /-- error: unknown identifier 'bad_lemma'-/
 #guard_msgs in
 theorem steps_error : STHoare p helloEnv ⟦⟧ (hello.call h![] h![])
-    fun output => (String.mk output.toList) = "hello" := by
+    fun output => output.toString = "hello" := by
   enter_decl
   steps [bad_lemma]
   sorry
@@ -69,3 +69,4 @@ theorem loop_inv_error : STHoare p loopEnv ⟦⟧ (loop_fn.call h![] h![])
   steps
   loop_inv fun i _ _ => [u ↦ ⟨Tp.field, 3⟩] -- random mal-formed loop invariant to show it works
   all_goals sorry
+

--- a/stdlib/lampe/Stdlib/Cmp.lean
+++ b/stdlib/lampe/Stdlib/Cmp.lean
@@ -28,22 +28,173 @@ open «std-1.0.0-beta.12».Extracted
 
 namespace Eq
 
-theorem field_eq_spec {a b}:
-    STHoare p env ⟦⟧ («std::cmp::Eq».eq h![] .field h![] h![] h![a, b]) fun r: Bool => ⟦r ↔ a = b⟧ := by
+theorem field_eq_spec {p a b}
+  : STHoare p env ⟦⟧ 
+    («std::cmp::Eq».eq h![] .field h![] h![] h![a, b]) 
+    fun r: Bool => ⟦r ↔ a = b⟧ := by
   resolve_trait
   steps
   simp_all
 
-theorem u8_eq_spec {a b}:
-    STHoare p env ⟦⟧ («std::cmp::Eq».eq h![] (.u 8) h![] h![] h![a, b]) fun r: Bool => ⟦r ↔ a = b⟧ := by
+theorem u128_eq_spec {p a b}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (.u 128) h![] h![] h![a, b])
+    (fun r : Bool => r ↔ a = b) := by
   resolve_trait
   steps
   simp_all
 
-theorem slice_eq_spec {T a b}
-    (h_trait_res : TraitResolvable env ({trait := { name := "«std::cmp::Eq»", traitGenericKinds := [], traitGenerics := h![] }, self := T}))
-    (h_eq_child: ∀a b, STHoare p env ⟦⟧ («std::cmp::Eq».eq h![] T h![] h![] h![a, b]) fun r: Bool => ⟦r ↔ a = b⟧):
-    STHoare p env ⟦⟧ («std::cmp::Eq».eq h![] T.slice h![] h![] h![a, b]) fun r: Bool => ⟦r ↔ a = b⟧ := by
+theorem u64_eq_spec {p a b}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (.u 64) h![] h![] h![a, b])
+    (fun r : Bool => r ↔ a = b) := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem u32_eq_spec {p a b}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (.u 32) h![] h![] h![a, b])
+    (fun r : Bool => r ↔ a = b) := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem u16_eq_spec {p a b}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (.u 16) h![] h![] h![a, b])
+    (fun r : Bool => r ↔ a = b) := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem u8_eq_spec {p a b}
+  : STHoare p env ⟦⟧ 
+    («std::cmp::Eq».eq h![] (.u 8) h![] h![] h![a, b]) 
+    fun r : Bool => ⟦r ↔ a = b⟧ := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem u1_eq_spec {p a b}
+  : STHoare p env ⟦⟧ 
+    («std::cmp::Eq».eq h![] (.u 1) h![] h![] h![a, b]) 
+    fun r : Bool => ⟦r ↔ a = b⟧ := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem i8_eq_spec {p a b}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (.i 8) h![] h![] h![a, b])
+    fun r : Bool => ⟦r ↔ a = b⟧ := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem i16_eq_spec {p a b}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (.i 16) h![] h![] h![a, b])
+    fun r : Bool => ⟦r ↔ a = b⟧ := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem i32_eq_spec {p a b}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (.i 32) h![] h![] h![a, b])
+    fun r : Bool => ⟦r ↔ a = b⟧ := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem i64_eq_spec {p a b}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (.i 64) h![] h![] h![a, b])
+    fun r : Bool => ⟦r ↔ a = b⟧ := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem unit_eq_spec {p a b}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (.unit) h![] h![] h![a, b])
+    fun r : Bool => ⟦r ↔ a = b⟧ := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem bool_eq_spec {p a b}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (.bool) h![] h![] h![a, b])
+    fun r : Bool => ⟦r ↔ a = b⟧ := by
+  resolve_trait
+  steps
+  · simp_all
+  · exact ()
+
+theorem array_eq_pure_spec {p T N a b}
+    {t_eq : «std::cmp::Eq».hasImpl env h![] T}
+    {t_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] T h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (T.array N) h![] h![] h![a, b])
+    (fun r : Bool => ⟦r ↔ a = b⟧) := by
+  resolve_trait
+  steps
+  loop_inv nat fun i _ _ => ∃∃v, [result ↦ ⟨.bool, v⟩] ⋆ (v = (a.toList.take i = b.toList.take i))
+  · sl
+    simp only [eq_iff_iff, true_iff]
+    norm_cast
+  · simp
+  · intro i _ _ 
+    steps [t_eq_f]
+    rotate_left
+    · exact ()
+
+    simp_all only [BitVec.toNat_intCast, Int.reducePow, EuclideanDomain.zero_mod, Int.toNat_zero,
+      zero_le, eq_iff_iff, Builtin.instCastTpU, BitVec.natCast_eq_ofNat, BitVec.ofNat_toNat,
+      BitVec.setWidth_eq, BitVec.toNat_ofNatLT, Lens.modify, Option.get_some, Bool.and_eq_true]
+
+    simp_all only [Lens.modify, Option.isSome_some]
+    conv => rhs; rw [←List.reverse_inj]
+    
+    generalize_proofs
+    simp only [List.take_succ, List.reverse_append]
+    rw [List.getElem?_eq_getElem, List.getElem?_eq_getElem]
+    simp only [Option.toList_some, List.reverse_cons, List.reverse_nil, List.nil_append,
+      List.cons_append, List.cons.injEq, List.reverse_inj] 
+    tauto
+
+  steps
+  simp_all only [BitVec.toNat_intCast, Int.reducePow, EuclideanDomain.zero_mod, Int.toNat_zero,
+    BitVec.natCast_eq_ofNat, BitVec.ofNat_toNat, BitVec.setWidth_eq, zero_le, eq_iff_iff]
+
+  have h_a : BitVec.toNat N = a.toList.length := by
+    simp
+
+  have h_b : BitVec.toNat N = b.toList.length := by
+    simp
+
+  conv =>
+    lhs
+    congr
+    · lhs; rw [h_a]
+    · lhs; rw [h_b]
+
+  simp_rw [List.take_length]
+
+  exact Iff.intro (fun eq => List.Vector.eq _ _ eq) (fun eq => congrArg _ eq)
+
+theorem slice_eq_pure_spec {p T a b}
+    (h_trait_res : «std::cmp::Eq».hasImpl env h![] T)
+    (h_eq_child: ∀a b, STHoare p env ⟦⟧ 
+      («std::cmp::Eq».eq h![] T h![] h![] h![a, b]) 
+      fun r : Bool => ⟦r ↔ a = b⟧)
+  : STHoare p env ⟦⟧ 
+    («std::cmp::Eq».eq h![] T.slice h![] h![] h![a, b]) 
+    fun r : Bool => ⟦r ↔ a = b⟧ := by
   resolve_trait
   steps
   by_cases a.length = b.length
@@ -90,6 +241,143 @@ theorem slice_eq_spec {T a b}
     steps
     simp_all
 
+theorem string_eq_pure_spec {p N a b}
+    {u8_eq : «std::cmp::Eq».hasImpl env h![] (.u 8)}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (.str N) h![] h![] h![a, b])
+    (fun r : Bool => ⟦r ↔ a = b⟧) := by
+  resolve_trait
+  steps [array_eq_pure_spec (t_eq := u8_eq) (t_eq_f := fun _ _ => u8_eq_spec)]
+  simp_all only [BitVec.natCast_eq_ofNat, List.Vector.mk_toList]
+
+theorem tuple2_eq_pure_spec {p A B self other}
+    {A_eq : «std::cmp::Eq».hasImpl env h![] A}
+    {B_eq : «std::cmp::Eq».hasImpl env h![] B}
+    {A_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] A h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+    {B_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] B h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (Tp.tuple none [A, B]) h![] h![] h![self, other])
+    (fun r : Bool => ⟦r ↔ self = other⟧) := by
+  resolve_trait
+  steps [A_eq_f, B_eq_f]
+  all_goals try exact ()
+  subst_vars
+
+  repeat rcases self with ⟨_, self⟩
+  repeat rcases other with ⟨_, other⟩
+
+  simp_all
+
+theorem tuple3_eq_pure_spec {p A B C self other}
+    {A_eq : «std::cmp::Eq».hasImpl env h![] A}
+    {B_eq : «std::cmp::Eq».hasImpl env h![] B}
+    {C_eq : «std::cmp::Eq».hasImpl env h![] C}
+    {A_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] A h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+    {B_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] B h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+    {C_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] C h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (Tp.tuple none [A, B, C]) h![] h![] h![self, other])
+    (fun r : Bool => ⟦r ↔ self = other⟧) := by
+  resolve_trait
+  steps [A_eq_f, B_eq_f, C_eq_f]
+  all_goals try exact ()
+  subst_vars
+
+  repeat rcases self with ⟨_, self⟩
+  repeat rcases other with ⟨_, other⟩
+
+  simp_all only [Bool.and_eq_true, Prod.mk.injEq, and_true]
+  tauto
+
+set_option maxHeartbeats 500000 in
+theorem tuple4_eq_pure_spec {p A B C D self other}
+    {A_eq : «std::cmp::Eq».hasImpl env h![] A}
+    {B_eq : «std::cmp::Eq».hasImpl env h![] B}
+    {C_eq : «std::cmp::Eq».hasImpl env h![] C}
+    {D_eq : «std::cmp::Eq».hasImpl env h![] D}
+    {A_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] A h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+    {B_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] B h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+    {C_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] C h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+    {D_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] D h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (Tp.tuple none [A, B, C, D]) h![] h![] h![self, other])
+    (fun r : Bool => ⟦r ↔ self = other⟧) := by
+  resolve_trait
+  steps [A_eq_f, B_eq_f, C_eq_f, D_eq_f]
+  all_goals try exact ()
+  subst_vars
+
+  repeat rcases self with ⟨_, self⟩
+  repeat rcases other with ⟨_, other⟩
+
+  simp_all only [Bool.and_eq_true, Prod.mk.injEq, and_true]
+  tauto
+
+set_option maxHeartbeats 1000000 in
+theorem tuple5_eq_pure_spec {p A B C D E self other}
+    {A_eq : «std::cmp::Eq».hasImpl env h![] A}
+    {B_eq : «std::cmp::Eq».hasImpl env h![] B}
+    {C_eq : «std::cmp::Eq».hasImpl env h![] C}
+    {D_eq : «std::cmp::Eq».hasImpl env h![] D}
+    {E_eq : «std::cmp::Eq».hasImpl env h![] E}
+    {A_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] A h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+    {B_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] B h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+    {C_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] C h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+    {D_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] D h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+    {E_eq_f : ∀a b, STHoare p env ⟦⟧
+      («std::cmp::Eq».eq h![] E h![] h![] h![a, b])
+      (fun r : Bool => ⟦r ↔ a = b⟧)}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] (Tp.tuple none [A, B, C, D, E]) h![] h![] h![self, other])
+    (fun r : Bool => ⟦r ↔ self = other⟧) := by
+  resolve_trait
+  steps [A_eq_f, B_eq_f, C_eq_f, D_eq_f, E_eq_f]
+  all_goals try exact ()
+  subst_vars
+
+  repeat rcases self with ⟨_, self⟩
+  repeat rcases other with ⟨_, other⟩
+
+  simp_all only [Bool.and_eq_true, Prod.mk.injEq, and_true]
+  tauto
+
+theorem ordering_eq_pure_spec {p self other}
+  : STHoare p env ⟦⟧
+    («std::cmp::Eq».eq h![] («std::cmp::Ordering».tp h![]) h![] h![] h![self, other])
+    (fun r : Bool => ⟦r ↔ self = other⟧) := by
+  resolve_trait
+  steps
+  rcases self with ⟨_, ⟨_⟩⟩
+  rcases other with ⟨_, ⟨_⟩⟩
+  simp_all only [decide_eq_true_eq]
+  tauto
+
 end Eq
 
 namespace Ord
@@ -110,10 +398,12 @@ def fromOrdering {p} : Ordering → («std::cmp::Ordering».tp h![] |>.denote p)
 Convert a Noir `std::cmp::Ordering` into a Lean ordering.
 
 We recommend converting user-provided `std::cmp::Ordering`s from the user, and converting them
-within the theorem.
+within the theorem. 
+
+Note that in order to ensure that `toOrdering` is total, 
 -/
 def toOrdering {p} : («std::cmp::Ordering».tp h![] |>.denote p) → Ordering
-| (n, ()) => match (n.cast : ZMod 3) with -- TODO is this reasonable?
+| (n, ()) => match (n.cast : ZMod 3) with
   | 0 => .lt
   | 1 => .eq
   | 2 => .gt

--- a/stdlib/lampe/Stdlib/Option.lean
+++ b/stdlib/lampe/Stdlib/Option.lean
@@ -663,3 +663,4 @@ theorem cmp_spec {p T self other P Q}
       steps [equal_spec]
       simp_all
 
+-- TODO cmp_pure_spec (got forgotten before)


### PR DESCRIPTION
This also reworks how we handle Noir strings as our string representation did not match the semantics of Noir's strings properly.

Contains work toward #50.