### PR TITLE
Improve our Prime representation

### DIFF
--- a/Lampe/Lampe/Data/HList.lean
+++ b/Lampe/Lampe/Data/HList.lean
@@ -17,6 +17,13 @@ def replicate {rep : α → Type _} (v : rep tp) : (n : Nat) → HList rep (List
 | .zero => HList.nil
 | .succ n' => HList.cons v (HList.replicate v n')
 
+@[reducible]
+def snoc (hs : HList f tps) (a : f tp)
+  : HList f (tps ++ [tp]) :=
+match tps, hs with
+| [], h![] => h![a]
+| _::_, HList.cons x xs => HList.cons x (HList.snoc xs a)
+
 open Lean PrettyPrinter
 
 @[app_unexpander HList.nil]

--- a/Lampe/Lampe/Tactic/Steps.lean
+++ b/Lampe/Lampe/Tactic/Steps.lean
@@ -107,6 +107,11 @@ def getClosingTerm (val : Lean.Expr) : TacticM (Option (TSyntax `term)) := withT
         | ``Lampe.Builtin.uEq => return some (←``(genericTotalPureBuiltin_intro Builtin.uEq rfl))
         | ``Lampe.Builtin.iEq => return some (←``(genericTotalPureBuiltin_intro Builtin.iEq rfl))
 
+        | ``Lampe.Builtin.iGt => return some (←``(genericTotalPureBuiltin_intro Builtin.iGt rfl))
+        | ``Lampe.Builtin.iLt => return some (←``(genericTotalPureBuiltin_intro Builtin.iLt rfl))
+        | ``Lampe.Builtin.uGt => return some (←``(genericTotalPureBuiltin_intro Builtin.uGt rfl))
+        | ``Lampe.Builtin.uLt => return some (←``(genericTotalPureBuiltin_intro Builtin.uLt rfl))
+
         | ``Lampe.Builtin.uAdd => return some (←``(uAdd_intro))
         | ``Lampe.Builtin.uMul => return some (←``(uMul_intro))
         | ``Lampe.Builtin.uDiv => return some (←``(uDiv_intro))

--- a/testing/Merkle/lampe/Merkle-0.0.0/Field.lean
+++ b/testing/Merkle/lampe/Merkle-0.0.0/Field.lean
@@ -5,11 +5,15 @@ open Lampe
 namespace «Merkle-0.0.0»
 namespace Field
 
-def p := 21888242871839275222246405745257275088548364400416034343698204186575808495617 - 1
+def fieldP := 21888242871839275222246405745257275088548364400416034343698204186575808495617
 
-axiom pPrime : Nat.Prime (p + 1)
+axiom fieldP_prime : Nat.Prime fieldP
 
-abbrev bnField := Fp ⟨p, pPrime⟩
+lemma fieldP_gt_2 : fieldP > 2 := by unfold fieldP; norm_num
+
+def p := Prime.ofNat fieldP fieldP_prime fieldP_gt_2
+
+abbrev bnField := Fp p
 
 instance : ToString bnField where
   toString b := s!"{b.val}"

--- a/testing/Merkle/lampe/Merkle-0.0.0/Spec.lean
+++ b/testing/Merkle/lampe/Merkle-0.0.0/Spec.lean
@@ -11,7 +11,7 @@ open Lampe «Merkle-0.0.0» «Merkle-0.0.0».Field
 
 namespace Spec
 
-def lp : Lampe.Prime := ⟨p, pPrime⟩
+def lp : Lampe.Prime := p
 
 def _root_.List.Vector.pad {α n} (v : List.Vector α n) (d : Nat) (pad : α) : List.Vector α d := match d, n with
 | 0, _ => List.Vector.nil
@@ -200,8 +200,15 @@ theorem to_le_bits_intro {input} : STHoare lp env ⟦⟧ («Merkle-0.0.0::utils:
     · decide
     · have : input.val / 115792089237316195423570985008687907853269984665640564039457584007913129639936 = 0 := by
         cases input
+        rename_i val isLt
         conv => lhs; arg 1; whnf
-        simp [Nat.div_eq_zero_iff, *, lp, p] at *
+        simp only [lp, p] at isLt
+        have h : 1 < fieldP := by simp only [fieldP]; linarith
+        conv at isLt => rhs; apply Nat.sub_add_cancel h
+        simp only [Int.cast_zero, BitVec.ofNat_eq_ofNat, BitVec.toNat_ofNat, Nat.reducePow,
+          Nat.zero_mod, Int.cast_ofNat, Nat.reduceMod, zero_le, Nat.div_eq_zero_iff,
+          OfNat.ofNat_ne_zero, false_or, gt_iff_lt] at *
+        unfold fieldP at isLt
         linarith
       congr 1
       simp [Int.cast, IntCast.intCast]

--- a/testing/MerkleFromScratch/lampe/Merkle-1.0.0/Field.lean
+++ b/testing/MerkleFromScratch/lampe/Merkle-1.0.0/Field.lean
@@ -5,11 +5,15 @@ open Lampe
 namespace «Merkle-1.0.0»
 namespace Field
 
-def p := 21888242871839275222246405745257275088548364400416034343698204186575808495617 - 1
+def fieldP := 21888242871839275222246405745257275088548364400416034343698204186575808495617
 
-axiom pPrime : Nat.Prime (p + 1)
+axiom fieldP_prime : Nat.Prime fieldP
 
-abbrev bnField := Fp ⟨p, pPrime⟩
+lemma fieldP_gt_2 : fieldP > 2 := by unfold fieldP; norm_num
+
+def p := Prime.ofNat fieldP fieldP_prime fieldP_gt_2
+
+abbrev bnField := Fp p
 
 instance : ToString bnField where
   toString b := s!"{b.val}"

--- a/testing/MerkleFromScratch/lampe/lakefile.toml
+++ b/testing/MerkleFromScratch/lampe/lakefile.toml
@@ -8,15 +8,11 @@ name = "«Merkle-1.0.0»"
 
 [[require]]
 name = "Lampe"
-git = "https://github.com/reilabs/lampe"
-rev = "main"
-subDir = "Lampe"
+path = "../../../Lampe/"
 
 [[require]]
 name = "std-1.0.0-beta.12"
-git = "https://github.com/reilabs/lampe"
-rev = "main"
-subDir = "stdlib/lampe"
+path = "../../../stdlib/lampe/"
 
 [[require]]
 name = "proven-zk"

--- a/testing/MerkleFromScratch/user_files/Field.lean
+++ b/testing/MerkleFromScratch/user_files/Field.lean
@@ -5,11 +5,15 @@ open Lampe
 namespace «Merkle-1.0.0»
 namespace Field
 
-def p := 21888242871839275222246405745257275088548364400416034343698204186575808495617 - 1
+def fieldP := 21888242871839275222246405745257275088548364400416034343698204186575808495617
 
-axiom pPrime : Nat.Prime (p + 1)
+axiom fieldP_prime : Nat.Prime fieldP
 
-abbrev bnField := Fp ⟨p, pPrime⟩
+lemma fieldP_gt_2 : fieldP > 2 := by unfold fieldP; norm_num
+
+def p := Prime.ofNat fieldP fieldP_prime fieldP_gt_2
+
+abbrev bnField := Fp p
 
 instance : ToString bnField where
   toString b := s!"{b.val}"


### PR DESCRIPTION
While we are mostly agnostic to the prime that is used, we do care that it is larger than a lower bound (currently two). This is now encoded in the definition of the `Prime` type to make it possible to prove certain theorems.

In addition, we now provide a way to easily construct primes using the n + 1 representation without resorting to awkward definitions of p - 1 to just construct the `Prime`.