### PR TITLE
Add theorems for `Append.lean`

### DIFF
--- a/stdlib/lampe/Stdlib/Append.lean
+++ b/stdlib/lampe/Stdlib/Append.lean
@@ -1,6 +1,55 @@
 import «std-1.0.0-beta.12».Extracted
 import Lampe
 
+import Stdlib.Slice
+
 namespace Lampe.Stdlib.Append
 
 open «std-1.0.0-beta.12»
+open Lampe.Stdlib
+
+set_option Lampe.pp.Expr true
+set_option Lampe.pp.STHoare true
+
+/-- A shorthand for a call to the `std::append::Append::empty` method. -/
+@[reducible]
+def empty {p}
+    (generics : HList Kind.denote «std-1.0.0-beta.12::append::Append».«#genericKinds»)
+    (Self : Tp)
+    (associatedTypes : HList Kind.denote «std-1.0.0-beta.12::append::Append».«#associatedTypesKinds»)
+    (fnGenerics : HList Kind.denote «std-1.0.0-beta.12::append::Append».«#genericKinds»)
+  : HList (Tp.denote p)
+      («std-1.0.0-beta.12::append::Append».empty.«#inputs» generics Self associatedTypes fnGenerics)
+  → Expr (Tp.denote p)
+      («std-1.0.0-beta.12::append::Append».empty.«#output» generics Self associatedTypes fnGenerics) :=
+  «std-1.0.0-beta.12::append::Append».empty generics Self associatedTypes fnGenerics
+
+/-- A shorthand for a call to the `std::append::Append::append` method. -/
+@[reducible]
+def append {p}
+    (generics : HList Kind.denote «std-1.0.0-beta.12::append::Append».«#genericKinds»)
+    (Self : Tp)
+    (associatedTypes : HList Kind.denote «std-1.0.0-beta.12::append::Append».«#associatedTypesKinds»)
+    (fnGenerics : HList Kind.denote «std-1.0.0-beta.12::append::Append».«#genericKinds»)
+  : HList (Tp.denote p)
+      («std-1.0.0-beta.12::append::Append».append.«#inputs» generics Self associatedTypes fnGenerics)
+  → Expr (Tp.denote p)
+      («std-1.0.0-beta.12::append::Append».append.«#output» generics Self associatedTypes fnGenerics) :=
+  «std-1.0.0-beta.12::append::Append».append generics Self associatedTypes fnGenerics
+
+theorem slice_empty_spec {p T }
+  : STHoare p env ⟦⟧
+    (empty h![] (Tp.slice T) h![] h![] h![])
+    (fun r => r = []) := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem slice_append_spec {p T self other}
+  : STHoare p env ⟦⟧
+    (append h![] (Tp.slice T) h![] h![] h![self, other])
+    (fun r => r = self ++ other) := by
+  resolve_trait
+  steps [Slice.append_spec]
+  simp_all
+

--- a/stdlib/lampe/Stdlib/Slice.lean
+++ b/stdlib/lampe/Stdlib/Slice.lean
@@ -6,10 +6,37 @@ open «std-1.0.0-beta.12»
 
 set_option maxRecDepth 10000
 
+set_option Lampe.pp.Expr true
+set_option Lampe.pp.STHoare true
+
+theorem append_spec {p T a b}
+  : STHoare p env ⟦⟧
+    («std-1.0.0-beta.12::slice::append».call h![T] h![a, b])
+    (fun r => r = a ++ b) := by
+  enter_decl
+  steps
+  step_as ([self ↦ ⟨T.slice, a⟩]) (fun _ => [self ↦ ⟨T.slice, a ++ b⟩])
+  · steps
+
+    loop_inv nat fun i hlo hhi => [self ↦ ⟨T.slice, a ++ (b.take i)⟩]
+    · simp
+    · simp
+    · intro cond hlo hhi
+      steps
+      simp_all
+    · steps
+      simp_all
+  · steps
+    simp_all
+
 lemma for_each_inv {T Env p f fb l}
     (Inv: List (Tp.denote p T) → SLP (State p))
-    (h_inv: ∀(lp: List (Tp.denote p T)) (e: T.denote p), ((lp ++ [e]) <+: l) → STHoare p env (Inv lp) (fb h![e]) (fun _ => Inv (lp ++ [e]))):
-    STHoare p env (Inv [] ⋆ [λf ↦ fb]) ((«std-1.0.0-beta.12::slice::for_each».call h![T, Env] h![l, f])) (fun _ => Inv l ⋆ [λf ↦ fb]) := by
+    (h_inv: ∀(lp: List (Tp.denote p T)) (e: T.denote p),
+      ((lp ++ [e]) <+: l) → STHoare p env (Inv lp) (fb h![e]) (fun _ => Inv (lp ++ [e])))
+  : STHoare p env
+    (Inv [] ⋆ [λf ↦ fb])
+    ((«std-1.0.0-beta.12::slice::for_each».call h![T, Env] h![l, f]))
+      (fun _ => Inv l ⋆ [λf ↦ fb]) := by
   enter_decl
   steps []
   loop_inv nat fun i _ _ => Inv (l.take i) ⋆ [λf ↦ fb]
@@ -31,11 +58,17 @@ lemma for_each_inv {T Env p f fb l}
 
 lemma slice_map_inv {T U Env p f fb l}
     (Inv: List (Tp.denote p T) → List (Tp.denote p U) → SLP (State p))
-    (h_inv: ∀(ip: List (Tp.denote p T)) (rp: List (Tp.denote p U)) (e: T.denote p), ((ip ++ [e]) <+: l) → STHoare p env (Inv ip rp) (fb h![e]) (fun r => Inv (ip ++ [e]) (rp ++ [r]))):
-    STHoare p env (Inv [] [] ⋆ [λf ↦ fb]) ((«std-1.0.0-beta.12::slice::map».call h![T, U, Env] h![l, f])) (fun v => Inv l v ⋆ [λf ↦ fb]) := by
+    (h_inv: ∀(ip: List (Tp.denote p T)) (rp: List (Tp.denote p U)) (e: T.denote p),
+      ((ip ++ [e]) <+: l) → STHoare p env (Inv ip rp) (fb h![e])
+        (fun r => Inv (ip ++ [e]) (rp ++ [r])))
+  : STHoare p env
+    (Inv [] [] ⋆ [λf ↦ fb])
+      ((«std-1.0.0-beta.12::slice::map».call h![T, U, Env] h![l, f]))
+        (fun v => Inv l v ⋆ [λf ↦ fb]) := by
   enter_decl
   steps
-  step_as ([ret ↦ ⟨U.slice, []⟩] ⋆ [λf ↦ fb] ⋆ Inv [] []) (fun _ => ∃∃v, [ret ↦ ⟨U.slice, v⟩] ⋆ [λf ↦ fb] ⋆ Inv l v)
+  step_as ([ret ↦ ⟨U.slice, []⟩] ⋆ [λf ↦ fb] ⋆ Inv [] [])
+    (fun _ => ∃∃v, [ret ↦ ⟨U.slice, v⟩] ⋆ [λf ↦ fb] ⋆ Inv l v)
   · steps
     loop_inv nat fun i _ _ => ∃∃v, [ret ↦ ⟨U.slice, v⟩] ⋆ [λf ↦ fb] ⋆ Inv (l.take i) v
     · sl
@@ -59,9 +92,12 @@ lemma slice_map_inv {T U Env p f fb l}
   sl
 
 lemma slice_pure_map {T U Env p f fb func l}
-    (h_pure : ∀x, STHoare p env ⟦⟧ (fb h![x]) (fun r => r = func x)):
-    STHoare p env [λf ↦ fb] ((«std-1.0.0-beta.12::slice::map».call h![T, U, Env] h![l, f])) (fun v => v = l.map func) := by
+    (h_pure : ∀x, STHoare p env ⟦⟧ (fb h![x]) (fun r => r = func x))
+  : STHoare p env [λf ↦ fb]
+    ((«std-1.0.0-beta.12::slice::map».call h![T, U, Env] h![l, f]))
+    (fun v => v = l.map func) := by
   steps [slice_map_inv (Inv := fun i o => o = i.map func)]
   · rfl
   · assumption
   · intros; steps [h_pure]; simp_all
+


### PR DESCRIPTION
This adds theorems for the single implementation of the `std::append::Append` trait contained in that file, and also for the implementation of `std::slice::Slice::append` that it depends on.

Partial work for #50 