### PR TITLE
Add theorems for conversions

### DIFF
--- a/Lampe/Lampe/Builtin/Cast.lean
+++ b/Lampe/Lampe/Builtin/Cast.lean
@@ -1,62 +1,88 @@
 import Lampe.Builtin.Basic
 namespace Lampe.Builtin
 
-/--
-   Represents the Noir types that can be casted to each other.
- -/
- class CastTp (tp tp' : Tp) where
-   cast : Tp.denote p tp → Tp.denote p tp'
+/-- Represents the Noir types that can be casted to each other. -/
+class CastTp (tp tp' : Tp) where
+  cast : Tp.denote p tp → Tp.denote p tp'
 
- @[simp]
- instance : CastTp tp tp where
-   cast := fun a => a
+@[simp]
+instance : CastTp tp tp where
+  cast := fun a => a
 
- @[simp]
- instance : CastTp (.u s₁) (.i s₂) where
-   cast := fun a => a.toNat
+@[simp]
+instance : CastTp (.u s₁) (.i s₂) where
+  cast := fun a => a.zeroExtend s₂
 
- @[simp]
- instance : CastTp (.i s₁) (.u s₂) where
-   cast := fun a => a.toNat
+@[simp]
+instance : CastTp (.i s₁) (.u s₂) where
+  cast := fun a => a.zeroExtend s₂
 
- @[simp]
- instance : CastTp (.u s₁) (.u s₂) where
-   cast := fun a => a.toNat
+@[simp]
+instance : CastTp (.u s₁) (.u s₂) where
+  cast := fun a => a.zeroExtend s₂
 
- @[simp]
- instance : CastTp (.u s) (.field) where
-   cast := fun a => a.toNat
+@[simp]
+instance : CastTp (.i s₁) (.i s₂) where
+  cast := fun a => a.signExtend s₂
 
- @[simp]
- instance : CastTp (.i s) (.field) where
-   cast := fun a => a.toNat
+@[simp]
+instance : CastTp (.u s) (.field) where
+  cast := fun a => a.toNat
 
- @[simp]
- instance : CastTp (.field) (.u s) where
-   cast := fun a => a.val
+@[simp]
+instance : CastTp (.i s) (.field) where
+  cast := fun a => a.toNat
 
- @[simp]
- instance : CastTp (.field) (.i s) where
-   cast := fun a => a.val
+@[simp]
+instance : CastTp (.field) (.u s) where
+  cast := fun a => a.val
 
- inductive castOmni : Omni where
- | ok {P st tp tp' v Q} [CastTp tp tp'] :
-   Q (some (st, CastTp.cast v)) → castOmni P st [tp] tp' h![v] Q
+@[simp]
+instance : CastTp (.field) (.i s) where
+  cast := fun a => a.val
 
- def cast : Builtin := {
-   omni := castOmni
-   conseq := by
-     unfold omni_conseq
-     intros
-     cases_type castOmni
-     . apply castOmni.ok;
-       simp_all
-   frame := by
-     unfold omni_frame
-     intros
-     cases_type castOmni
-     . apply castOmni.ok
-       . constructor <;> tauto
- }
+@[simp]
+instance : CastTp (.bool) (.u s) where
+  cast := fun a => if a then 1 else 0
 
- end Lampe.Builtin
+@[simp]
+instance : CastTp (.u s) (.bool) where
+  cast := fun a => a ≠ 0
+
+@[simp]
+instance : CastTp (.i s) (.bool) where
+  cast := fun a => a ≠ 0
+
+@[simp]
+instance : CastTp (.field) (.bool) where
+  cast := fun a => a ≠ 0
+
+@[simp]
+instance : CastTp (.bool) (.i s) where
+  cast := fun a => if a then 1 else 0
+
+@[simp]
+instance : CastTp (.bool) (.field) where
+  cast := fun a => if a then 1 else 0
+
+inductive castOmni : Omni where
+| ok {P st tp tp' v Q} [CastTp tp tp'] :
+  Q (some (st, CastTp.cast v)) → castOmni P st [tp] tp' h![v] Q
+
+def cast : Builtin := {
+  omni := castOmni
+  conseq := by
+    unfold omni_conseq
+    intros
+    cases_type castOmni
+    . apply castOmni.ok;
+      simp_all
+  frame := by
+    unfold omni_frame
+    intros
+    cases_type castOmni
+    . apply castOmni.ok
+      . constructor <;> tauto
+}
+
+end Lampe.Builtin

--- a/Lampe/Lampe/Hoare/SepTotal.lean
+++ b/Lampe/Lampe/Hoare/SepTotal.lean
@@ -151,6 +151,14 @@ theorem litU_intro: STHoare p Γ ⟦⟧ (.litNum (.u s) n) fun v => v = n := by
   apply SLP.ent_star_top
   assumption
 
+theorem litI_intro: STHoare p Γ ⟦⟧ (.litNum (.i s) n) fun v => v = n := by
+  unfold STHoare THoare
+  intro H st hp
+  constructor
+  simp only
+  apply SLP.ent_star_top
+  assumption
+
 theorem litField_intro: STHoare p Γ ⟦⟧ (.litNum .field n) fun v => v = n := by
   unfold STHoare THoare
   intro H st hp
@@ -322,7 +330,7 @@ theorem loop_inv_intro
     (fun _ => Inv
       (i + 1)
       (BitVec.le_trans hlo (U.le_add_one_of_exists_lt hhi))
-      (U.le_plus_one_of_lt hhi))) 
+      (U.le_plus_one_of_lt hhi)))
     → STHoare p Γ
       (∃∃h, Inv lo BitVec.le_refl h)
       (.loop lo hi body)
@@ -392,7 +400,7 @@ theorem loop_inv_intro'
   : (∀(i:Nat),
       (hlo: lo.toNat ≤ i) → (hhi: i < hi.toNat) → STHoare p Γ (Inv i hlo (by linarith))
       (body $ BitVec.ofNatLT i (lt_trans hhi hi.toFin.prop))
-      (fun _ => Inv (i + 1) (by linarith) (by linarith))) 
+      (fun _ => Inv (i + 1) (by linarith) (by linarith)))
     → STHoare p Γ
       (∃∃h, Inv lo.toNat BitVec.le_refl h)
       (.loop lo hi body)

--- a/Lampe/Lampe/Semantics.lean
+++ b/Lampe/Lampe/Semantics.lean
@@ -12,7 +12,7 @@ namespace Lampe
 -- The value of the field prime under which the semantics are operating.
 variable (p : Prime)
 
-/-- 
+/--
 Omni provides our implementation of the program semantics for Noir, demonstrating how state
 transitions can occur within the program.
 
@@ -20,7 +20,7 @@ It effectively says that if the program with the environment `Γ` begins in stat
 program fragment `expr` is executed, then execution succeeds and the postcondition `Q` holds, or
 execution has failed.
 
-Noir as a language exhibits explicitly nondeterministic behavior, which we want to capture in our 
+Noir as a language exhibits explicitly nondeterministic behavior, which we want to capture in our
 semantics explicitly. The type of `Q` represents this through making the postcondition into a _set_,
 modeled explicitly as a selector function. This is wrapped in an `Option`, where a value of `some`
 implies a successful execution, while `none` suggests a failure. The interpretation is that, if
@@ -34,6 +34,7 @@ inductive Omni : (Γ : Env) → (st : State p) → (expr : Expr (Tp.denote p) tp
 | litFalse {Q} : Q (some (st, false)) → Omni Γ st (.litNum .bool 0) Q
 | litTrue {Q} : Q (some (st, true)) → Omni Γ st (.litNum .bool 1) Q
 | litU {Q} : Q (some (st, ↑n)) → Omni Γ st (.litNum (.u s) n) Q
+| litI {Q} : Q (some (st, ↑n)) → Omni Γ st (.litNum (.i s) n) Q
 | litUnit {Q} : Q (some (st, ())) → Omni Γ st (.litNum .unit n) Q
 | constFp {Q} {c : Int} : Q (some (st, c)) → Omni Γ st (.constFp c) Q
 | constU {Q} {c : U w} : Q (some (st, c)) → Omni Γ st (.constU c) Q
@@ -132,6 +133,7 @@ theorem frame {p Γ tp} {st₁ st₂ : State p} {e : Expr (Tp.denote p) tp} {Q} 
   | litFalse hq
   | litTrue hq
   | litU hq
+  | litI hq
   | litUnit
   | constU
   | constFp
@@ -260,7 +262,7 @@ theorem frame {p Γ tp} {st₁ st₂ : State p} {e : Expr (Tp.denote p) tp} {Q} 
       rw [Finmap.union_comm_of_disjoint hd₁]
       tauto
 
-/-- 
+/--
 Any theorem over our Omnisemantics that is proved for an environment Γ₁ is also valid for Γ₂, where
 Γ₁ ⊆ Γ₂.
 

--- a/Lampe/Lampe/Syntax/Builders.lean
+++ b/Lampe/Lampe/Syntax/Builders.lean
@@ -92,7 +92,7 @@ def makeLambdaParam [MonadDSL m] (p : TSyntax `noir_lam_param) : m LambdaParam :
   let pat ← makePat pat
   let ty ← makeNoirType ty
   pure ⟨pat, ty⟩
-| _ => throwUnsupportedSyntax 
+| _ => throwUnsupportedSyntax
 
 mutual
 
@@ -317,7 +317,7 @@ partial def makeLambda [MonadDSL m]
   → m (TSyntax `term)
 | `(noir_lambda|fn( $params,* ): $retType := $body), binder, k => do
   let retType : TSyntax `term ← makeNoirType retType
-  let params ← params.getElems.toList.mapM makeLambdaParam 
+  let params ← params.getElems.toList.mapM makeLambdaParam
   let paramTypes := params.map fun p => p.type
   let paramTypes ← makeListLit paramTypes
   let paramNames ← params.mapM fun b => match b.binder with
@@ -496,15 +496,15 @@ def makeTraitDef [MonadUtil m] : Syntax → m (List $ TSyntax `command)
     `(abbrev $(makeTraitDefAssociatedTypesKindsIdent traitName) : List Kind := $assocTypeGenKinds)
   outputs := outputs.concat associatedTypesKindDecl
 
-  let traitHasImplDecl : TSyntax `command ← 
-    `(@[reducible] def $(makeTraitDefHasImplIdent traitName) 
+  let traitHasImplDecl : TSyntax `command ←
+    `(@[reducible] def $(makeTraitDefHasImplIdent traitName)
       (env : $(←``(Env)))
       (traitGenerics : HList Kind.denote $(makeTraitDefGenericKindsIdent traitName))
       (selfType : Tp) :=
-        $(←``(TraitResolvable)) env 
-        ⟨⟨$(Syntax.mkStrLit traitName.getId.toString), 
-          $(makeTraitDefGenericKindsIdent traitName), 
-          traitGenerics⟩, 
+        $(←``(TraitResolvable)) env
+        ⟨⟨$(Syntax.mkStrLit traitName.getId.toString),
+          $(makeTraitDefGenericKindsIdent traitName),
+          traitGenerics⟩,
         selfType⟩)
   outputs := outputs.concat traitHasImplDecl
 
@@ -519,7 +519,7 @@ def makeTraitDef [MonadUtil m] : Syntax → m (List $ TSyntax `command)
 
     let params ← params.getElems.toList.mapM makeNoirType
     let inTypesDecl ← `(
-      def $(makeTraitFunDefInputsIdent traitName fnName)
+      @[reducible] def $(makeTraitFunDefInputsIdent traitName fnName)
       : HList Kind.denote $(makeTraitDefGenericKindsIdent traitName)
       → Tp
       → HList Kind.denote $(makeTraitDefAssociatedTypesKindsIdent traitName)
@@ -533,7 +533,7 @@ def makeTraitDef [MonadUtil m] : Syntax → m (List $ TSyntax `command)
 
     let outTp ← makeNoirType retType
     let outTypeDecl ← `(
-      def $(makeTraitFunDefOutputIdent traitName fnName)
+      @[reducible] def $(makeTraitFunDefOutputIdent traitName fnName)
       : HList Kind.denote $(makeTraitDefGenericKindsIdent traitName)
       → Tp
       → HList Kind.denote $(makeTraitDefAssociatedTypesKindsIdent traitName)
@@ -546,7 +546,7 @@ def makeTraitDef [MonadUtil m] : Syntax → m (List $ TSyntax `command)
     outputs := outputs.concat outTypeDecl
 
     let callDecl ← `(
-      def $(makeTraitFunDefIdent traitName fnName) {p}
+      @[reducible] def $(makeTraitFunDefIdent traitName fnName) {p}
         (generics : HList Kind.denote $(makeTraitDefGenericKindsIdent traitName))
         (Self : Tp)
         (associatedTypes : HList Kind.denote $(makeTraitDefAssociatedTypesKindsIdent traitName))

--- a/src/lean/generator.rs
+++ b/src/lean/generator.rs
@@ -1426,7 +1426,13 @@ impl LeanGenerator<'_, '_, '_> {
                     .chain(generics.named.iter().map(|g| &g.typ))
                     .map(|g| self.generate_lean_type_value(g, None))
                     .collect_vec();
-                let bound = Type::data_type(&trait_name, generics.clone());
+                let bound_trait_id = cons.trait_bound.trait_id;
+                let bound_trait_data = self.context.def_interner.get_trait(bound_trait_id);
+                let bound_trait_name = quote_lean_keywords(
+                    &self.fully_qualified_trait_name(bound_trait_data.crate_id, bound_trait_id),
+                );
+
+                let bound = Type::data_type(&bound_trait_name, generics.clone());
 
                 WhereClause {
                     var,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -635,4 +635,34 @@ fn leq<A: Ord>(a: A, b: A) -> bool {
 
         print!("{}", result.unwrap().1);
     }
+
+    #[test]
+    fn trait_where_bounds() {
+        let source = r"
+trait MyFrom<T> {
+    fn from(input: T) -> Self;
+}
+
+trait MyInto<T> {
+    fn into(self) -> T;
+}
+
+impl<T> MyFrom<T> for T {
+    fn from(input: T) -> Self {
+        input
+    }
+}
+
+impl<T, U> MyInto<T> for U where T: From<U> {
+    fn into(self) -> T {
+        T::from(self)
+    }
+}
+";
+
+        let result = display_extraction_results(source);
+        assert!(result.is_ok());
+
+        print!("{}", result.unwrap().1);
+    }
 }

--- a/stdlib/lampe/Stdlib/Array/CheckShuffle.lean
+++ b/stdlib/lampe/Stdlib/Array/CheckShuffle.lean
@@ -195,8 +195,6 @@ theorem check_shuffle_spec
       rename List.Vector.get rhs _  = List.Vector.get lhs _ => hpeq
       rw [Eq.comm] at hpeq
       convert hpeq
-      · simp
-      · simp [GetElem.getElem]
     · simp_all
 
   steps

--- a/stdlib/lampe/Stdlib/Cmp.lean
+++ b/stdlib/lampe/Stdlib/Cmp.lean
@@ -909,7 +909,7 @@ theorem array_ord_pure_spec {p T N a b}
   resolve_trait
   steps [equal_spec]
 
-  loop_inv nat fun i hlo hhi => [result ↦ 
+  loop_inv nat fun i hlo hhi => [result ↦
     ⟨NoirOrdering, fromOrdering (List.compareWith t_ord_emb (a.toList.take i) (b.toList.take i))⟩]
   · simp
   · intro i hlo hhi
@@ -934,7 +934,7 @@ theorem array_ord_pure_spec {p T N a b}
       steps
       congr 1
       conv_rhs => rw [List.compareWith_take_then_drop i]
-      simp_all [Function.Injective.eq_iff fromOrdering_inj, List.take_take, List.drop_take, 
+      simp_all [Function.Injective.eq_iff fromOrdering_inj, List.take_take, List.drop_take,
         Ordering.then_of_ne_eq]
 
   steps [equal_spec, Eq.ordering_eq_spec]
@@ -972,7 +972,7 @@ theorem slice_ord_pure_spec {p T a b}
 
   steps [equal_spec]
 
-  loop_inv nat fun i hlo hhi => [result ↦ 
+  loop_inv nat fun i hlo hhi => [result ↦
     ⟨NoirOrdering, fromOrdering (List.compareWith t_ord_emb (a.take i) (b.take i))⟩]
   · simp
   · intro i hlo hhi
@@ -1263,7 +1263,7 @@ theorem tuple4_ord_pure_spec {p A B C D self other}
   subst_vars
   rfl
 
-set_option maxHeartbeats 300000 in
+set_option maxHeartbeats 350000 in
 theorem tuple5_ord_pure_spec {p A B C D E self other}
     {A_ord : hasOrdImpl env A}
     {B_ord : hasOrdImpl env B}

--- a/stdlib/lampe/Stdlib/Compat.lean
+++ b/stdlib/lampe/Stdlib/Compat.lean
@@ -4,3 +4,15 @@ import Lampe
 namespace Lampe.Stdlib.Compat
 
 open «std-1.0.0-beta.12»
+
+set_option Lampe.pp.Expr true
+set_option Lampe.pp.STHoare true
+
+theorem is_bn254_spec {p}
+  : STHoare p env ⟦⟧
+    («std-1.0.0-beta.12::compat::is_bn254».call h![] h![])
+    (fun r => r = true) := by
+  enter_decl
+  steps
+  simp_all
+

--- a/stdlib/lampe/Stdlib/Convert.lean
+++ b/stdlib/lampe/Stdlib/Convert.lean
@@ -4,3 +4,864 @@ import Lampe
 namespace Lampe.Stdlib.Convert
 
 open «std-1.0.0-beta.12»
+
+set_option Lampe.pp.Expr true
+set_option Lampe.pp.STHoare true
+
+/-- A shorthand for a call to the `std::convert::From::from` method. -/
+@[reducible]
+def «from» {p}
+    (generics : HList Kind.denote «std-1.0.0-beta.12::convert::From».«#genericKinds»)
+    (Self : Tp)
+    (associatedTypes : HList Kind.denote «std-1.0.0-beta.12::convert::From».«#associatedTypesKinds»)
+    (fnGenerics : HList Kind.denote «std-1.0.0-beta.12::convert::From».«from».«#genericKinds»)
+  : HList (Tp.denote p)
+      («std-1.0.0-beta.12::convert::From».«from».«#inputs» generics Self associatedTypes fnGenerics)
+  → Expr (Tp.denote p)
+      («std-1.0.0-beta.12::convert::From».«from».«#output» generics Self associatedTypes fnGenerics) :=
+  «std-1.0.0-beta.12::convert::From».«from» generics Self associatedTypes fnGenerics
+
+/--
+Asserts that the provided `tp` has an implementation of `std::convert::From` in the environment.
+-/
+@[reducible]
+def hasFromImpl (env : Env) (source : Tp) (self : Tp) :=
+  «std-1.0.0-beta.12::convert::From».hasImpl env h![source] self
+
+/-- A shorthand for a call to the `std::convert::Into::into` method. -/
+@[reducible]
+def into {p}
+    (generics : HList Kind.denote «std-1.0.0-beta.12::convert::Into».«#genericKinds»)
+    (Self : Tp)
+    (associatedTypes : HList Kind.denote «std-1.0.0-beta.12::convert::Into».«#associatedTypesKinds»)
+    (fnGenerics : HList Kind.denote «std-1.0.0-beta.12::convert::Into».into.«#genericKinds»)
+  : HList (Tp.denote p)
+      («std-1.0.0-beta.12::convert::Into».into.«#inputs» generics Self associatedTypes fnGenerics)
+  → Expr (Tp.denote p)
+      («std-1.0.0-beta.12::convert::Into».into.«#output» generics Self associatedTypes fnGenerics) :=
+  «std-1.0.0-beta.12::convert::Into».into generics Self associatedTypes fnGenerics
+
+/--
+Asserts that the provided `tp` has an implementation of `std::convert::Into` in the environment.
+-/
+@[reducible]
+def hasIntoImpl (env : Env) (target : Tp) (self : Tp) :=
+  «std-1.0.0-beta.12::convert::Into».hasImpl env h![target] self
+
+/-- A shorthand for a call to the `std::convert::AsPrimitive::as_` method. -/
+@[reducible]
+def as_ {p}
+    (generics : HList Kind.denote «std-1.0.0-beta.12::convert::AsPrimitive».«#genericKinds»)
+    (Self : Tp)
+    (associatedTypes : HList Kind.denote «std-1.0.0-beta.12::convert::AsPrimitive».«#associatedTypesKinds»)
+    (fnGenerics : HList Kind.denote «std-1.0.0-beta.12::convert::AsPrimitive».as_.«#genericKinds»)
+  : HList (Tp.denote p)
+      («std-1.0.0-beta.12::convert::AsPrimitive».as_.«#inputs» generics Self associatedTypes fnGenerics)
+  → Expr (Tp.denote p)
+      («std-1.0.0-beta.12::convert::AsPrimitive».as_.«#output» generics Self associatedTypes fnGenerics) :=
+  «std-1.0.0-beta.12::convert::AsPrimitive».as_ generics Self associatedTypes fnGenerics
+
+/--
+Asserts that the provided `tp` has an implementation of `std::convert::Into` in the environment.
+-/
+@[reducible]
+def hasAsPrimitiveImpl (env : Env) (target : Tp) (self : Tp) :=
+  «std-1.0.0-beta.12::convert::AsPrimitive».hasImpl env h![target] self
+
+theorem from_T_for_T_spec {p T i}
+  : STHoare p env ⟦⟧
+    («from» h![T] T h![] h![] h![i])
+    (fun r => r = i) := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem into_T_for_U_spec {p}
+    {T U : Tp}
+    {i : U.denote p}
+    {has_from : hasFromImpl env U T}
+    {from_emb : U.denote p → T.denote p}
+    (from_f : ∀a, STHoare p env ⟦⟧ («from» h![U] T h![] h![] h![a]) (fun r => r = from_emb a))
+  : STHoare p env ⟦⟧
+    (into h![T] U h![] h![] h![i])
+    (fun r => r = from_emb i) := by
+  resolve_trait
+  steps [from_f]
+  simp_all
+
+@[reducible]
+def convertUintToUintSemantics (s₁ s₂ : ℕ) (p : Prime) (a : Tp.denote p (.u s₁)) :=
+  STHoare p env ⟦⟧
+    («from» h![.u s₁] (.u s₂) h![] h![] h![a])
+    (fun r => r = (a.zeroExtend s₂))
+
+theorem from_u8_for_u16_spec {p a} : convertUintToUintSemantics 8 16 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_u8_for_u32_spec {p a} : convertUintToUintSemantics 8 32 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_u16_for_u32_spec {p a} : convertUintToUintSemantics 16 32 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_u8_for_u64_spec {p a} : convertUintToUintSemantics 8 64 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_u16_for_u64_spec {p a} : convertUintToUintSemantics 16 64 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_u32_for_u64_spec {p a} : convertUintToUintSemantics 32 64 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_u8_for_u128_spec {p a} : convertUintToUintSemantics 8 128 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_u16_for_u128_spec {p a} : convertUintToUintSemantics 16 128 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_u32_for_u128_spec {p a} : convertUintToUintSemantics 32 128 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_u64_for_u128_spec {p a} : convertUintToUintSemantics 64 128 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+@[reducible]
+def convertUintToFieldSemantics (s₁ : ℕ) (p : Prime) (a : Tp.denote p (.u s₁)) :=
+  STHoare p env ⟦⟧
+    («from» h![.u s₁] .field h![] h![] h![a])
+    (fun r => r = a.toNat)
+
+theorem from_u8_for_field_spec {p a} : convertUintToFieldSemantics 8 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_u16_for_field_spec {p a} : convertUintToFieldSemantics 16 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_u32_for_field_spec {p a} : convertUintToFieldSemantics 32 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_u64_for_field_spec {p a} : convertUintToFieldSemantics 64 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_u128_for_field_spec {p a} : convertUintToFieldSemantics 128 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+@[reducible]
+def convertIntToIntSemantics (s₁ s₂ : ℕ) (p : Prime) (a : Tp.denote p (.i s₁)) :=
+  STHoare p env ⟦⟧
+    («from» h![.i s₁] (.i s₂) h![] h![] h![a])
+    (fun r => r = (a.signExtend s₂))
+
+theorem from_i8_for_i16_spec {p a} : convertIntToIntSemantics 8 16 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_i8_for_i32_spec {p a} : convertIntToIntSemantics 8 32 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_i8_for_i64_spec {p a} : convertIntToIntSemantics 8 64 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_i16_for_i64_spec {p a} : convertIntToIntSemantics 16 64 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_i32_for_i64_spec {p a} : convertIntToIntSemantics 32 64 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+@[reducible]
+def convertBoolToUintSemantics (s₁ : ℕ) (p : Prime) (a : Tp.denote p .bool) :=
+  STHoare p env ⟦⟧
+    («from» h![.bool] (.u s₁) h![] h![] h![a])
+    (fun r => r = if a then 1 else 0)
+
+theorem from_bool_for_u8_spec {p a} : convertBoolToUintSemantics 8 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_bool_for_u16_spec {p a} : convertBoolToUintSemantics 16 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_bool_for_u32_spec {p a} : convertBoolToUintSemantics 32 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_bool_for_u64_spec {p a} : convertBoolToUintSemantics 64 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_bool_for_u128_spec {p a} : convertBoolToUintSemantics 128 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+@[reducible]
+def convertBoolToIntSemantics (s₁ : ℕ) (p : Prime) (a : Tp.denote p .bool) :=
+  STHoare p env ⟦⟧
+    («from» h![.bool] (.i s₁) h![] h![] h![a])
+    (fun r => r = if a then 1 else 0)
+
+theorem from_bool_for_i8_spec {p a} : convertBoolToIntSemantics 8 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_bool_for_i16_spec {p a} : convertBoolToIntSemantics 16 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_bool_for_i32_spec {p a} : convertBoolToIntSemantics 32 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_bool_for_i64_spec {p a} : convertBoolToIntSemantics 64 p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem from_bool_for_field_spec {p a}
+  : STHoare p env ⟦⟧
+    («from» h![.bool] .field h![] h![] h![a])
+    (fun r => r = if a then 1 else 0) := by
+  resolve_trait
+  steps
+  simp_all
+
+/--
+The semantics of `AsPrimitive::as_` are defined to be equal to the corresponding primitive cast, so
+we delegate straight to our builtin semantics for those here.
+-/
+@[reducible]
+def asPrimitiveSemantics (src tgt : Tp) [Builtin.CastTp src tgt] (p : Prime) (a : Tp.denote p src) :=
+  STHoare p env ⟦⟧
+    (as_ h![tgt] src h![] h![] h![a])
+    (fun r => r = Builtin.CastTp.cast a)
+
+theorem as_u8_for_bool_spec {p a} : asPrimitiveSemantics .bool (.u 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i8_for_bool_spec {p a} : asPrimitiveSemantics .bool (.i 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u32_for_bool_spec {p a} : asPrimitiveSemantics .bool (.u 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i32_for_bool_spec {p a} : asPrimitiveSemantics .bool (.i 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_bool_for_bool_spec {p a} : asPrimitiveSemantics .bool .bool p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_bool_for_u8_spec {p a} : asPrimitiveSemantics (.u 8) .bool p a := by
+  resolve_trait
+  steps
+  subst_vars
+  rfl
+
+theorem as_bool_for_i8_spec {p a} : asPrimitiveSemantics (.i 8) .bool p a := by
+  resolve_trait
+  steps
+  subst_vars
+  rfl
+
+theorem as_bool_for_u16_spec {p a} : asPrimitiveSemantics (.u 16) .bool p a := by
+  resolve_trait
+  steps
+  subst_vars
+  rfl
+
+theorem as_bool_for_i16_spec {p a} : asPrimitiveSemantics (.i 16) .bool p a := by
+  resolve_trait
+  steps
+  subst_vars
+  rfl
+
+theorem as_bool_for_u32_spec {p a} : asPrimitiveSemantics (.u 32) .bool p a := by
+  resolve_trait
+  steps
+  subst_vars
+  rfl
+
+theorem as_bool_for_i32_spec {p a} : asPrimitiveSemantics (.i 32) .bool p a := by
+  resolve_trait
+  steps
+  subst_vars
+  rfl
+
+theorem as_bool_for_u64_spec {p a} : asPrimitiveSemantics (.u 64) .bool p a := by
+  resolve_trait
+  steps
+  subst_vars
+  rfl
+
+theorem as_bool_for_i64_spec {p a} : asPrimitiveSemantics (.i 64) .bool p a := by
+  resolve_trait
+  steps
+  subst_vars
+  rfl
+
+theorem as_bool_for_u128_spec {p a} : asPrimitiveSemantics (.u 128) .bool p a := by
+  resolve_trait
+  steps
+  subst_vars
+  rfl
+
+theorem as_bool_for_field_spec {p a} : asPrimitiveSemantics .field .bool p a := by
+  resolve_trait
+  steps
+  simp_all
+  rfl
+  exact ()
+
+theorem as_u128_for_bool_spec {p a} : asPrimitiveSemantics .bool (.u 128) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u16_for_bool_spec {p a} : asPrimitiveSemantics .bool (.u 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i16_for_bool_spec {p a} : asPrimitiveSemantics .bool (.i 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u64_for_bool_spec {p a} : asPrimitiveSemantics .bool (.u 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i64_for_bool_spec {p a} : asPrimitiveSemantics .bool (.i 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u8_for_u32_spec {p a} : asPrimitiveSemantics (.u 8) (.u 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u8_for_i32_spec {p a} : asPrimitiveSemantics (.u 8) (.i 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u8_for_u128_spec {p a} : asPrimitiveSemantics (.u 128) (.u 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u8_for_u16_spec {p a} : asPrimitiveSemantics (.u 16) (.u 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u8_for_i16_spec {p a} : asPrimitiveSemantics (.i 16) (.u 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u8_for_u64_spec {p a} : asPrimitiveSemantics (.u 64) (.u 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u8_for_i64_spec {p a} : asPrimitiveSemantics (.i 64) (.u 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u8_for_u8_spec {p a} : asPrimitiveSemantics (.u 8) (.u 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u8_for_i8_spec {p a} : asPrimitiveSemantics (.i 8) (.u 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u16_for_u32_spec {p a} : asPrimitiveSemantics (.u 32) (.u 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u16_for_i32_spec {p a} : asPrimitiveSemantics (.i 32) (.u 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u16_from_bool_spec {p a} : asPrimitiveSemantics .bool (.u 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u16_for_u128_spec {p a} : asPrimitiveSemantics (.u 128) (.u 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u16_for_u16_spec {p a} : asPrimitiveSemantics (.u 16) (.u 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u16_for_i16_spec {p a} : asPrimitiveSemantics (.i 16) (.u 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u16_for_u64_spec {p a} : asPrimitiveSemantics (.u 64) (.u 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u16_for_i64_spec {p a} : asPrimitiveSemantics (.i 64) (.u 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u16_for_u8_spec {p a} : asPrimitiveSemantics (.u 8) (.u 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u16_for_i8_spec {p a} : asPrimitiveSemantics (.i 8) (.u 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u32_for_u32_spec {p a} : asPrimitiveSemantics (.u 32) (.u 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u32_for_i32_spec {p a} : asPrimitiveSemantics (.i 32) (.u 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u32_for_u128_spec {p a} : asPrimitiveSemantics (.u 128) (.u 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u32_for_u16_spec {p a} : asPrimitiveSemantics (.u 16) (.u 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u32_for_i16_spec {p a} : asPrimitiveSemantics (.i 16) (.u 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u32_for_u64_spec {p a} : asPrimitiveSemantics (.u 64) (.u 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u32_for_i64_spec {p a} : asPrimitiveSemantics (.i 64) (.u 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u32_for_u8_spec {p a} : asPrimitiveSemantics (.u 8) (.u 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u32_for_i8_spec {p a} : asPrimitiveSemantics (.i 8) (.u 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u64_for_u32_spec {p a} : asPrimitiveSemantics (.u 32) (.u 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u64_for_i32_spec {p a} : asPrimitiveSemantics (.i 32) (.u 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u64_for_u128_spec {p a} : asPrimitiveSemantics (.u 128) (.u 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u64_for_u16_spec {p a} : asPrimitiveSemantics (.u 16) (.u 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u64_for_i16_spec {p a} : asPrimitiveSemantics (.i 16) (.u 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u64_for_u64_spec {p a} : asPrimitiveSemantics (.u 64) (.u 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u64_for_i64_spec {p a} : asPrimitiveSemantics (.i 64) (.u 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u64_for_u8_spec {p a} : asPrimitiveSemantics (.u 8) (.u 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u64_for_i8_spec {p a} : asPrimitiveSemantics (.i 8) (.u 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u128_for_u32_spec {p a} : asPrimitiveSemantics (.u 32) (.u 128) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u128_for_i32_spec {p a} : asPrimitiveSemantics (.i 32) (.u 128) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u128_for_u128_spec {p a} : asPrimitiveSemantics (.u 128) (.u 128) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u128_for_u16_spec {p a} : asPrimitiveSemantics (.u 16) (.u 128) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u128_for_i16_spec {p a} : asPrimitiveSemantics (.i 16) (.u 128) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u128_for_u64_spec {p a} : asPrimitiveSemantics (.u 64) (.u 128) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u128_for_i64_spec {p a} : asPrimitiveSemantics (.i 64) (.u 128) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u128_for_u8_spec {p a} : asPrimitiveSemantics (.u 8) (.u 128) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u128_for_i8_spec {p a} : asPrimitiveSemantics (.i 8) (.u 128) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i8_for_u128_spec {p a} : asPrimitiveSemantics (.u 128) (.i 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i8_for_u16_spec {p a} : asPrimitiveSemantics (.u 16) (.i 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i8_for_i16_spec {p a} : asPrimitiveSemantics (.i 16) (.i 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i8_for_u64_spec {p a} : asPrimitiveSemantics (.u 64) (.i 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i8_for_i64_spec {p a} : asPrimitiveSemantics (.i 64) (.i 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i8_for_u8_spec {p a} : asPrimitiveSemantics (.u 8) (.i 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i8_for_i8_spec {p a} : asPrimitiveSemantics (.i 8) (.i 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i8_for_u32_spec {p a} : asPrimitiveSemantics (.u 32) (.i 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i8_for_i32_spec {p a} : asPrimitiveSemantics (.i 32) (.i 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_16_for_bool_spec {p a} : asPrimitiveSemantics .bool (.i 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i16_for_u128_spec {p a} : asPrimitiveSemantics (.u 128) (.i 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i16_for_u16_spec {p a} : asPrimitiveSemantics (.u 16) (.i 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i16_for_i16_spec {p a} : asPrimitiveSemantics (.i 16) (.i 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i16_for_u64_spec {p a} : asPrimitiveSemantics (.u 64) (.i 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i16_for_i64_spec {p a} : asPrimitiveSemantics (.i 64) (.i 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i16_for_u8_spec {p a} : asPrimitiveSemantics (.u 8) (.i 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i16_for_i8_spec {p a} : asPrimitiveSemantics (.i 8) (.i 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i16_for_u32_spec {p a} : asPrimitiveSemantics (.u 32) (.i 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i16_for_i32_spec {p a} : asPrimitiveSemantics (.i 32) (.i 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i32_for_u128_spec {p a} : asPrimitiveSemantics (.u 128) (.i 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i32_for_u16_spec {p a} : asPrimitiveSemantics (.u 16) (.i 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i32_for_i16_spec {p a} : asPrimitiveSemantics (.i 16) (.i 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i32_for_u64_spec {p a} : asPrimitiveSemantics (.u 64) (.i 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i32_for_i64_spec {p a} : asPrimitiveSemantics (.i 64) (.i 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i32_for_u8_spec {p a} : asPrimitiveSemantics (.u 8) (.i 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i32_for_i8_spec {p a} : asPrimitiveSemantics (.i 8) (.i 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i32_for_u32_spec {p a} : asPrimitiveSemantics (.u 32) (.i 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i32_for_i32_spec {p a} : asPrimitiveSemantics (.i 32) (.i 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i64_for_u128_spec {p a} : asPrimitiveSemantics (.u 128) (.i 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i64_for_u16_spec {p a} : asPrimitiveSemantics (.u 16) (.i 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i64_for_i16_spec {p a} : asPrimitiveSemantics (.i 16) (.i 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i64_for_u64_spec {p a} : asPrimitiveSemantics (.u 64) (.i 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i64_for_i64_spec {p a} : asPrimitiveSemantics (.i 64) (.i 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i64_for_u8_spec {p a} : asPrimitiveSemantics (.u 8) (.i 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i64_for_i8_spec {p a} : asPrimitiveSemantics (.i 8) (.i 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i64_for_u32_spec {p a} : asPrimitiveSemantics (.u 32) (.i 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_i64_for_i32_spec {p a} : asPrimitiveSemantics (.i 32) (.i 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+-- TODO rename all the above as the order is flipped
+
+theorem as_field_for_bool_spec {p a} : asPrimitiveSemantics .bool .field p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_field_for_u8_spec {p a} : asPrimitiveSemantics (.u 8) .field p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_field_for_u16_spec {p a} : asPrimitiveSemantics (.u 16) .field p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_field_for_u32_spec {p a} : asPrimitiveSemantics (.u 32) .field p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_field_for_u64_spec {p a} : asPrimitiveSemantics (.u 64) .field p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_field_for_u128_spec {p a} : asPrimitiveSemantics (.u 128) .field p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u64_for_field_spec {p a} : asPrimitiveSemantics .field (.u 64) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u32_for_field_spec {p a} : asPrimitiveSemantics .field (.u 32) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u16_for_field_spec {p a} : asPrimitiveSemantics .field (.u 16) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u8_for_field_spec {p a} : asPrimitiveSemantics .field (.u 8) p a := by
+  resolve_trait
+  steps
+  simp_all
+
+theorem as_u128_for_field_spec {p a} : asPrimitiveSemantics .field (.u 128) p a := by
+  resolve_trait
+  steps
+  simp_all
+

--- a/stdlib/lampe/std-1.0.0-beta.12/Extracted/Collections/Map.lean
+++ b/stdlib/lampe/std-1.0.0-beta.12/Extracted/Collections/Map.lean
@@ -292,7 +292,7 @@ noir_def «std-1.0.0-beta.12»::collections::map::HashMap::assert_load_factor<K:
   #_skip
 }
 
-noir_trait_impl[«std-1.0.0-beta.12».impl_35]<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type> «std-1.0.0-beta.12»::cmp::Eq<> for «std-1.0.0-beta.12»::collections::map::HashMap<K, V, N: u32, B> where [K: «std-1.0.0-beta.12»::cmp::Eq<>, K: «std-1.0.0-beta.12»::cmp::Eq<>, V: «std-1.0.0-beta.12»::cmp::Eq<>, B: «std-1.0.0-beta.12»::cmp::Eq<B_as_BuildHasher_H>] := {
+noir_trait_impl[«std-1.0.0-beta.12».impl_35]<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type> «std-1.0.0-beta.12»::cmp::Eq<> for «std-1.0.0-beta.12»::collections::map::HashMap<K, V, N: u32, B> where [K: «std-1.0.0-beta.12»::cmp::Eq<>, K: «std-1.0.0-beta.12»::hash::Hash<>, V: «std-1.0.0-beta.12»::cmp::Eq<>, B: «std-1.0.0-beta.12»::hash::BuildHasher<B_as_BuildHasher_H>] := {
   noir_def eq<>(self: «std-1.0.0-beta.12»::collections::map::HashMap<K, V, N: u32, B>, other: «std-1.0.0-beta.12»::collections::map::HashMap<K, V, N: u32, B>) -> bool := {
     let mut equal = #_false;
     if (#_uEq returning bool)((«std-1.0.0-beta.12»::collections::map::HashMap::len<K, V, N: u32, B> as λ(«std-1.0.0-beta.12»::collections::map::HashMap<K, V, N: u32, B>) -> u32)(self), («std-1.0.0-beta.12»::collections::map::HashMap::len<K, V, N: u32, B> as λ(«std-1.0.0-beta.12»::collections::map::HashMap<K, V, N: u32, B>) -> u32)(other)) then {
@@ -325,7 +325,7 @@ noir_trait_impl[«std-1.0.0-beta.12».impl_35]<K: Type, V: Type, N: u32, B: Type
   };
 }
 
-noir_trait_impl[«std-1.0.0-beta.12».impl_36]<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type> «std-1.0.0-beta.12»::default::Default<> for «std-1.0.0-beta.12»::collections::map::HashMap<K, V, N: u32, B> where [B: «std-1.0.0-beta.12»::default::Default<B_as_BuildHasher_H>, B: «std-1.0.0-beta.12»::default::Default<>] := {
+noir_trait_impl[«std-1.0.0-beta.12».impl_36]<K: Type, V: Type, N: u32, B: Type, B_as_BuildHasher_H: Type> «std-1.0.0-beta.12»::default::Default<> for «std-1.0.0-beta.12»::collections::map::HashMap<K, V, N: u32, B> where [B: «std-1.0.0-beta.12»::hash::BuildHasher<B_as_BuildHasher_H>, B: «std-1.0.0-beta.12»::default::Default<>] := {
   noir_def default<>() -> «std-1.0.0-beta.12»::collections::map::HashMap<K, V, N: u32, B> := {
     let _build_hasher = ((B as «std-1.0.0-beta.12»::default::Default<>)::default<> as λ() -> B)();
     let map = («std-1.0.0-beta.12»::collections::map::HashMap::with_hasher<K, V, N: u32, B> as λ(B) -> «std-1.0.0-beta.12»::collections::map::HashMap<K, V, N: u32, B>)(_build_hasher);

--- a/stdlib/lampe/std-1.0.0-beta.12/Extracted/Collections/Umap.lean
+++ b/stdlib/lampe/std-1.0.0-beta.12/Extracted/Collections/Umap.lean
@@ -210,7 +210,7 @@ noir_def «std-1.0.0-beta.12»::collections::umap::UHashMap::quadratic_probe<K: 
   (#_uRem returning u32)((#_uAdd returning u32)(hash, (#_uDiv returning u32)((#_uAdd returning u32)(attempt, (#_uMul returning u32)(attempt, attempt)), (2: u32))), (#_arrayLen returning u32)(self.0))
 }
 
-noir_trait_impl[«std-1.0.0-beta.12».impl_38]<K: Type, V: Type, B: Type, B_as_BuildHasher_H: Type> «std-1.0.0-beta.12»::cmp::Eq<> for «std-1.0.0-beta.12»::collections::umap::UHashMap<K, V, B> where [K: «std-1.0.0-beta.12»::cmp::Eq<>, K: «std-1.0.0-beta.12»::cmp::Eq<>, V: «std-1.0.0-beta.12»::cmp::Eq<>, B: «std-1.0.0-beta.12»::cmp::Eq<B_as_BuildHasher_H>] := {
+noir_trait_impl[«std-1.0.0-beta.12».impl_38]<K: Type, V: Type, B: Type, B_as_BuildHasher_H: Type> «std-1.0.0-beta.12»::cmp::Eq<> for «std-1.0.0-beta.12»::collections::umap::UHashMap<K, V, B> where [K: «std-1.0.0-beta.12»::cmp::Eq<>, K: «std-1.0.0-beta.12»::hash::Hash<>, V: «std-1.0.0-beta.12»::cmp::Eq<>, B: «std-1.0.0-beta.12»::hash::BuildHasher<B_as_BuildHasher_H>] := {
   noir_def eq<>(self: «std-1.0.0-beta.12»::collections::umap::UHashMap<K, V, B>, other: «std-1.0.0-beta.12»::collections::umap::UHashMap<K, V, B>) -> bool := {
     let mut equal = #_false;
     if (#_uEq returning bool)((«std-1.0.0-beta.12»::collections::umap::UHashMap::len<K, V, B> as λ(«std-1.0.0-beta.12»::collections::umap::UHashMap<K, V, B>) -> u32)(self), («std-1.0.0-beta.12»::collections::umap::UHashMap::len<K, V, B> as λ(«std-1.0.0-beta.12»::collections::umap::UHashMap<K, V, B>) -> u32)(other)) then {
@@ -245,7 +245,7 @@ noir_trait_impl[«std-1.0.0-beta.12».impl_38]<K: Type, V: Type, B: Type, B_as_B
   };
 }
 
-noir_trait_impl[«std-1.0.0-beta.12».impl_39]<K: Type, V: Type, B: Type, B_as_BuildHasher_H: Type> «std-1.0.0-beta.12»::default::Default<> for «std-1.0.0-beta.12»::collections::umap::UHashMap<K, V, B> where [B: «std-1.0.0-beta.12»::default::Default<B_as_BuildHasher_H>, B: «std-1.0.0-beta.12»::default::Default<>] := {
+noir_trait_impl[«std-1.0.0-beta.12».impl_39]<K: Type, V: Type, B: Type, B_as_BuildHasher_H: Type> «std-1.0.0-beta.12»::default::Default<> for «std-1.0.0-beta.12»::collections::umap::UHashMap<K, V, B> where [B: «std-1.0.0-beta.12»::hash::BuildHasher<B_as_BuildHasher_H>, B: «std-1.0.0-beta.12»::default::Default<>] := {
   noir_def default<>() -> «std-1.0.0-beta.12»::collections::umap::UHashMap<K, V, B> := {
     («std-1.0.0-beta.12»::collections::umap::UHashMap::with_hasher<K, V, B> as λ(B) -> «std-1.0.0-beta.12»::collections::umap::UHashMap<K, V, B>)(((B as «std-1.0.0-beta.12»::default::Default<>)::default<> as λ() -> B)())
   };

--- a/stdlib/lampe/std-1.0.0-beta.12/Extracted/Convert.lean
+++ b/stdlib/lampe/std-1.0.0-beta.12/Extracted/Convert.lean
@@ -11,7 +11,7 @@ noir_trait_impl[«std-1.0.0-beta.12».impl_40]<T: Type> «std-1.0.0-beta.12»::c
   };
 }
 
-noir_trait_impl[«std-1.0.0-beta.12».impl_41]<T: Type, U: Type> «std-1.0.0-beta.12»::convert::Into<T> for U where [T: «std-1.0.0-beta.12»::convert::Into<U>] := {
+noir_trait_impl[«std-1.0.0-beta.12».impl_41]<T: Type, U: Type> «std-1.0.0-beta.12»::convert::Into<T> for U where [T: «std-1.0.0-beta.12»::convert::From<U>] := {
   noir_def into<>(self: U) -> T := {
     ((T as «std-1.0.0-beta.12»::convert::From<U>)::«from»<> as λ(U) -> T)(self)
   };

--- a/stdlib/lampe/std-1.0.0-beta.12/Extracted/Hash/Mod.lean
+++ b/stdlib/lampe/std-1.0.0-beta.12/Extracted/Hash/Mod.lean
@@ -63,13 +63,13 @@ noir_def «std-1.0.0-beta.12»::hash::from_field_unsafe<>(scalar: Field) -> «st
   (#_makeData returning «std-1.0.0-beta.12»::embedded_curve_ops::EmbeddedCurveScalar<>)(xlo, xhi)
 }
 
-noir_trait_impl[«std-1.0.0-beta.12».impl_2]<H: Type> «std-1.0.0-beta.12»::hash::BuildHasher<> for «std-1.0.0-beta.12»::hash::BuildHasherDefault<H> where [H: «std-1.0.0-beta.12»::hash::BuildHasher<>, H: «std-1.0.0-beta.12»::hash::BuildHasher<>] := {
+noir_trait_impl[«std-1.0.0-beta.12».impl_2]<H: Type> «std-1.0.0-beta.12»::hash::BuildHasher<> for «std-1.0.0-beta.12»::hash::BuildHasherDefault<H> where [H: «std-1.0.0-beta.12»::hash::Hasher<>, H: «std-1.0.0-beta.12»::default::Default<>] := {
   noir_def build_hasher<>(_self: «std-1.0.0-beta.12»::hash::BuildHasherDefault<H>) -> H := {
     ((H as «std-1.0.0-beta.12»::default::Default<>)::default<> as λ() -> H)()
   };
 }
 
-noir_trait_impl[«std-1.0.0-beta.12».impl_3]<H: Type> «std-1.0.0-beta.12»::default::Default<> for «std-1.0.0-beta.12»::hash::BuildHasherDefault<H> where [H: «std-1.0.0-beta.12»::default::Default<>, H: «std-1.0.0-beta.12»::default::Default<>] := {
+noir_trait_impl[«std-1.0.0-beta.12».impl_3]<H: Type> «std-1.0.0-beta.12»::default::Default<> for «std-1.0.0-beta.12»::hash::BuildHasherDefault<H> where [H: «std-1.0.0-beta.12»::hash::Hasher<>, H: «std-1.0.0-beta.12»::default::Default<>] := {
   noir_def default<>() -> «std-1.0.0-beta.12»::hash::BuildHasherDefault<H> := {
     (#_makeData returning «std-1.0.0-beta.12»::hash::BuildHasherDefault<H>)()
   };


### PR DESCRIPTION
This commit includes theorems for the instances of `std::convert::Into` and `std::convert::From` that are part of the standard library. It also includes added semantics for unsigned integer literals, and more builtins have been given support in the `steps` tactic.

It also fixes a bug with extracting the wrong trait name in trait bounds, and updates the standard library extraction as a result.

Partial work toward #50. 