### PR TITLE
Add proofs for the bitwise operations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.85.1
+          toolchain: 1.90.0
           default: true
           components: rustfmt, clippy
       - name: Build (cargo)
@@ -131,7 +131,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.85.1
+          toolchain: 1.90.0
           default: true
           components: rustfmt, clippy
       - name: Lint (clippy)
@@ -150,7 +150,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.85.1
+          toolchain: 1.90.0
           default: true
           components: rustfmt, clippy
       - name: Test (cargo)
@@ -180,7 +180,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.85.1
+          toolchain: 1.90.0
           default: true
           components: rustfmt, clippy
       - name: Set up Lean 4
@@ -219,7 +219,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.85.1
+          toolchain: 1.90.0
           default: true
           components: rustfmt, clippy
       - name: Set up Lean 4

--- a/Lampe/Lampe/Builtin/Bit.lean
+++ b/Lampe/Lampe/Builtin/Bit.lean
@@ -82,25 +82,25 @@ def uXor := newGenericTotalPureBuiltin
   (fun _ h![a, b] => a.xor b)
 
 /--
-Defines the bitwise left shift of an `s`-bit uint `a: U s`
-with an amount represented by an 8-bit uint `b : U 8`.
-This is assumed to evaluate to `(a <<< b) : U s`.
+Defines the bitwise left shift of an `s`-bit uint `a: U s` with the shift amount sharing the same
+type.
 
-In Noir, this builtin corresponds to `a << b` for an uint `a` of bit-size `s` and an uint `b` of bit-size `8`.
+This is assumed to evaluate to `(a <<< b) : U s`. In Noir, this builtin corresponds to `a << b` for
+an uint `a` of bit-size `s` and an uint `b` of bit-size `s`.
 -/
 def uShl := newGenericTotalPureBuiltin
-  (fun s => ⟨[(.u s), (.u 8)], (.u s)⟩)
+  (fun s => ⟨[(.u s), (.u s)], (.u s)⟩)
   (fun _ h![a, b] => a <<< b)
 
 /--
-Defines the bitwise right shift of an `s`-bit uint `a: U s`
-with an amount represented by an 8-bit uint `b : U 8`.
-This is assumed to evaluate to `(a >>> b) : U s`.
+Defines the bitwise right shift of an `s`-bit uint `a: U s` with the shift amount sharing the same
+type.
 
-In Noir, this builtin corresponds to `a >> b` for an uint `a` of bit-size `s` and an uint `b` of bit-size `8`.
+This is assumed to evaluate to `(a >>> b) : U s`. In Noir, this builtin corresponds to `a >> b` for
+an uint `a` of bit-size `s` and an uint `b` of bit-size `s`.
 -/
 def uShr := newGenericTotalPureBuiltin
-  (fun s => ⟨[(.u s), (.u 8)], (.u s)⟩)
+  (fun s => ⟨[(.u s), (.u s)], (.u s)⟩)
   (fun _ h![a, b] => a >>> b)
 
 /--
@@ -144,26 +144,27 @@ def iXor := newGenericTotalPureBuiltin
   (fun _ h![a, b] => a.xor b)
 
 /--
-Defines the bitwise left shift of an `s`-bit int `a: I s`
-with an amount represented by an 8-bit uint `b : U 8`.
-This is assumed to evaluate to `(a <<< b) : I s`.
+Defines the bitwise left shift of an `s`-bit int `a: U s` with the shift amount sharing the same
+type.
 
-In Noir, this builtin corresponds to `a << b` for an int `a` of bit-size `s` and an uint `b` of bit-size `8`.
+This is assumed to evaluate to `(a <<< b) : U s`. In Noir, this builtin corresponds to `a << b` for
+an int `a` of bit-size `s` and an int `b` of bit-size `s`. If the shift is negative, then the
+precondition check fails and this builtin evaluates to an error.
 -/
-def iShl := newGenericTotalPureBuiltin
-  (fun s => ⟨[(.i s), (.u 8)], (.i s)⟩)
-  (fun _ h![a, b] => a <<< b)
+def iShl := newGenericPureBuiltin
+  (fun s => ⟨[(.i s), (.i s)], (.i s)⟩)
+  (fun _ h![a, b] => ⟨b.toInt > 0, fun _ => a <<< b⟩)
 
 /--
-Defines the bitwise right shift of an `s`-bit int `a: I s`
-with an amount represented by an 8-bit uint `b : U 8`.
-This is assumed to evaluate to `(a >>> b) : I s`.
+Defines the bitwise right shift of an `s`-bit int `a: U s` with the shift amount sharing the same
+type.
 
-In Noir, this builtin corresponds to `a >> b` for an int `a` of bit-size `s` and an uint `b` of bit-size `8`.
+This is assumed to evaluate to `(a >>> b) : U s`. In Noir, this builtin corresponds to `a >> b` for
+an int `a` of bit-size `s` and an int `b` of bit-size `s`. If the shift is negative, then the
+precondition check fails and this builtin evaluates to an error.
 -/
-def iShr := newGenericTotalPureBuiltin
-  (fun s => ⟨[(.i s), (.u 8)], (.i s)⟩)
-  (fun _ h![a, b] => a >>> b)
-
+def iShr := newGenericPureBuiltin
+  (fun s => ⟨[(.i s), (.i s)], (.i s)⟩)
+  (fun _ h![a, b] => ⟨b.toInt > 0, fun _ => a >>> b⟩)
 
 end Lampe.Builtin

--- a/Lampe/Lampe/Hoare/Builtins.lean
+++ b/Lampe/Lampe/Hoare/Builtins.lean
@@ -74,85 +74,85 @@ def genericTotalPureBuiltin_intro {A : Type} {sgn : A → List Tp × Tp} {desc}
 
 -- Arithmetics
 
- theorem uAdd_intro : STHoarePureBuiltin p Γ Builtin.uAdd (by tauto) h![a, b] := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try rfl
-   tauto
+theorem uAdd_intro : STHoarePureBuiltin p Γ Builtin.uAdd (by tauto) h![a, b] := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try rfl
+  tauto
 
- theorem uSub_intro : STHoarePureBuiltin p Γ Builtin.uSub (by tauto) h![a, b] := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try rfl
-   tauto
+theorem uSub_intro : STHoarePureBuiltin p Γ Builtin.uSub (by tauto) h![a, b] := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try rfl
+  tauto
 
- theorem uMul_intro : STHoarePureBuiltin p Γ Builtin.uMul (by tauto) h![a, b] := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try rfl
-   tauto
+theorem uMul_intro : STHoarePureBuiltin p Γ Builtin.uMul (by tauto) h![a, b] := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try rfl
+  tauto
 
- theorem uDiv_intro : STHoarePureBuiltin p Γ Builtin.uDiv (by tauto) h![a, b] := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try rfl
-   tauto
+theorem uDiv_intro : STHoarePureBuiltin p Γ Builtin.uDiv (by tauto) h![a, b] := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try rfl
+  tauto
 
- theorem uRem_intro : STHoarePureBuiltin p Γ Builtin.uRem (by tauto) h![a, b] := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try rfl
-   tauto
+theorem uRem_intro : STHoarePureBuiltin p Γ Builtin.uRem (by tauto) h![a, b] := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try rfl
+  tauto
 
- theorem iAdd_intro : STHoarePureBuiltin p Γ Builtin.iAdd (by tauto) h![a, b] := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try rfl
-   tauto
+theorem iAdd_intro : STHoarePureBuiltin p Γ Builtin.iAdd (by tauto) h![a, b] := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try rfl
+  tauto
 
- theorem iSub_intro : STHoarePureBuiltin p Γ Builtin.iSub (by tauto) h![a, b] := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try rfl
-   tauto
+theorem iSub_intro : STHoarePureBuiltin p Γ Builtin.iSub (by tauto) h![a, b] := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try rfl
+  tauto
 
- theorem iMul_intro : STHoarePureBuiltin p Γ Builtin.iMul (by tauto) h![a, b] := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try rfl
-   tauto
+theorem iMul_intro : STHoarePureBuiltin p Γ Builtin.iMul (by tauto) h![a, b] := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try rfl
+  tauto
 
- theorem iDiv_intro : STHoarePureBuiltin p Γ Builtin.iDiv (by tauto) h![a, b] := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try rfl
-   tauto
+theorem iDiv_intro : STHoarePureBuiltin p Γ Builtin.iDiv (by tauto) h![a, b] := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try rfl
+  tauto
 
- theorem iRem_intro : STHoarePureBuiltin p Γ Builtin.iRem (by tauto) h![a, b] := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try rfl
-   tauto
+theorem iRem_intro : STHoarePureBuiltin p Γ Builtin.iRem (by tauto) h![a, b] := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try rfl
+  tauto
 
- theorem iNeg_intro : STHoarePureBuiltin p Γ Builtin.iNeg (by tauto) h![a] := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try rfl
-   tauto
+theorem iNeg_intro : STHoarePureBuiltin p Γ Builtin.iNeg (by tauto) h![a] := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try rfl
+  tauto
 
- theorem fAdd_intro : STHoarePureBuiltin p Γ Builtin.fAdd (by tauto) h![a, b] (a := ()) := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try tauto
-   tauto
+theorem fAdd_intro : STHoarePureBuiltin p Γ Builtin.fAdd (by tauto) h![a, b] (a := ()) := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try tauto
+  tauto
 
- theorem fSub_intro : STHoarePureBuiltin p Γ Builtin.fSub (by tauto) h![a, b] (a := ()) := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try tauto
-   tauto
+theorem fSub_intro : STHoarePureBuiltin p Γ Builtin.fSub (by tauto) h![a, b] (a := ()) := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try tauto
+  tauto
 
- theorem fMul_intro : STHoarePureBuiltin p Γ Builtin.fMul (by tauto) h![a, b] (a := ()) := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try tauto
-   tauto
+theorem fMul_intro : STHoarePureBuiltin p Γ Builtin.fMul (by tauto) h![a, b] (a := ()) := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try tauto
+  tauto
 
- theorem fDiv_intro : STHoarePureBuiltin p Γ Builtin.fDiv (by tauto) h![a, b] (a := ()) := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try tauto
-   tauto
+theorem fDiv_intro : STHoarePureBuiltin p Γ Builtin.fDiv (by tauto) h![a, b] (a := ()) := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try tauto
+  tauto
 
- theorem fNeg_intro : STHoarePureBuiltin p Γ Builtin.fNeg (by tauto) h![a] (a := ()) := by
-   simp only [STHoarePureBuiltin, SLP.exists_pure]
-   apply pureBuiltin_intro_consequence <;> try tauto
-   tauto
+theorem fNeg_intro : STHoarePureBuiltin p Γ Builtin.fNeg (by tauto) h![a] (a := ()) := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try tauto
+  tauto
 
 -- Arrays
 
@@ -254,8 +254,20 @@ def iNot_intro := genericTotalPureBuiltin_intro Builtin.iNot rfl
 def iAnd_intro := genericTotalPureBuiltin_intro Builtin.iAnd rfl
 def iOr_intro := genericTotalPureBuiltin_intro Builtin.iOr rfl
 def iXor_intro := genericTotalPureBuiltin_intro Builtin.iXor rfl
-def iShl_intro := genericTotalPureBuiltin_intro Builtin.iShl rfl
-def iShr_intro := genericTotalPureBuiltin_intro Builtin.iShr rfl
+
+theorem iShl_intro {p Γ W} 
+  {a b : Tp.denote p (.i W)}
+  : STHoarePureBuiltin p Γ Builtin.iShl (by tauto) h![a, b] (a := W) := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try tauto
+  tauto
+
+theorem iShr_intro {p Γ W} 
+  {a b : Tp.denote p (.i W)}
+  : STHoarePureBuiltin p Γ Builtin.iShr (by tauto) h![a, b] (a := W) := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try tauto
+  tauto
 
 -- Comparison
 

--- a/Lampe/Lampe/Tactic/Steps.lean
+++ b/Lampe/Lampe/Tactic/Steps.lean
@@ -95,6 +95,13 @@ def getClosingTerm (val : Lean.Expr) : TacticM (Option (TSyntax `term)) := withT
         | ``Lampe.Builtin.uShl => return some (←``(genericTotalPureBuiltin_intro Builtin.uShl rfl))
         | ``Lampe.Builtin.uShr => return some (←``(genericTotalPureBuiltin_intro Builtin.uShr rfl))
 
+        | ``Lampe.Builtin.iNot => return some (←``(genericTotalPureBuiltin_intro Builtin.iNot rfl))
+        | ``Lampe.Builtin.iAnd => return some (←``(genericTotalPureBuiltin_intro Builtin.iAnd rfl))
+        | ``Lampe.Builtin.iOr => return some (←``(genericTotalPureBuiltin_intro Builtin.iOr rfl))
+        | ``Lampe.Builtin.iXor => return some (←``(genericTotalPureBuiltin_intro Builtin.iXor rfl))
+        | ``Lampe.Builtin.iShl => return some (←``(iShl_intro))
+        | ``Lampe.Builtin.iShr => return some (←``(iShr_intro))
+
         | ``Lampe.Builtin.cast => return some (←``(cast_intro))
 
         | ``Lampe.Builtin.fAdd => return some (←``(genericTotalPureBuiltin_intro Builtin.fAdd rfl (a := ())))

--- a/Lampe/Tests/Syntax.lean
+++ b/Lampe/Tests/Syntax.lean
@@ -683,3 +683,19 @@ theorem returns_string_correct {p}
   subst_vars
   rfl
 
+noir_def integer_shifts<>(a: i32, b: i32) -> i32 := {
+  let x = (#_iShl returning i32)(a, b);
+  let y = (#_iShr returning i32)(a, b);
+  (#_iSub returning i32)(a, b)
+}
+
+def integerShiftsEnv : Env := ⟨[integer_shifts], []⟩
+
+theorem integer_shifts_correct {p a b}
+  : STHoare p integerShiftsEnv ⟦⟧
+    (integer_shifts.call h![] h![a, b])
+    (fun r => r = a - b) := by
+  enter_decl
+  steps
+  simp_all
+

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.90.0"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -69,8 +69,8 @@ fn main() -> ExitCode {
 pub fn run_test_mode(args: &ProgramOptions) -> Result<ExitCode, Error> {
     let list = fs::read_dir(&args.root).map_err(|_| {
         file::Error::Other(format!(
-            "Unable to read directory {:?}",
-            args.root.as_os_str()
+            "Unable to read directory {}",
+            args.root.as_os_str().display()
         ))
     })?;
 
@@ -81,8 +81,8 @@ pub fn run_test_mode(args: &ProgramOptions) -> Result<ExitCode, Error> {
             .metadata()
             .map_err(|_| {
                 file::Error::Other(format!(
-                    "Unable to read metadata of {:?}",
-                    entry.file_name()
+                    "Unable to read metadata of {}",
+                    entry.file_name().display()
                 ))
             })?
             .is_dir()

--- a/src/lean/ast.rs
+++ b/src/lean/ast.rs
@@ -129,6 +129,7 @@ pub struct ParamVal {
     pub value: Box<Expression>,
 }
 
+#[expect(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Statement {
     Assign(AssignStatement),

--- a/src/lean/emit/writer.rs
+++ b/src/lean/emit/writer.rs
@@ -617,7 +617,7 @@ impl Writer<'_> {
             }
             BuiltinTag::U(n) => self.append_to_line(&format!("u{n}")),
             BuiltinTag::Unit => self.append_to_line(UNIT_TYPE_NAME),
-        };
+        }
     }
 
     /// Directly writes the contents of the type arithmetic expression into the

--- a/src/lean/generator.rs
+++ b/src/lean/generator.rs
@@ -874,6 +874,7 @@ impl LeanGenerator<'_, '_, '_> {
         extra_defs
     }
 
+    #[expect(clippy::needless_continue)]
     pub fn generate_module_definitions(&self, module: &ModuleData) -> ModuleDefs {
         let mut globals = HashSet::new();
         let mut functions = HashSet::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ authors = [""]
 
     /// Returns a tuple of warnings and a string representation of the extracted
     /// files
+    #[expect(clippy::format_push_string)]
     fn display_extraction_results(main_source: &str) -> std::io::Result<(Vec<String>, String)> {
         let (temp_dir, mock_project) = set_up_project(main_source)?;
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -25,7 +25,7 @@ use crate::{
 
 pub struct Project {
     /// The root directory of the Noir project
-    project_root: PathBuf,
+    root: PathBuf,
 
     /// The directory where put the Lampe project
     target_path: PathBuf,
@@ -56,7 +56,7 @@ impl Project {
         let (nargo_file_manager, nargo_parsed_files) = noir::parse_workspace(&nargo_workspace);
 
         Ok(Self {
-            project_root,
+            root: project_root,
             target_path,
             nargo_workspace,
             nargo_file_manager,
@@ -556,7 +556,7 @@ impl Debug for Project {
         }
 
         writeln!(f, "Project(")?;
-        writeln!(f, "  project_root: {:?}", self.project_root)?;
+        writeln!(f, "  project_root: {:?}", self.root)?;
         writeln!(f, "  members:")?;
         for p in &self.nargo_workspace.members {
             package_fmt(f, p, "    ")?;

--- a/stdlib/lampe/Stdlib/Field.lean
+++ b/stdlib/lampe/Stdlib/Field.lean
@@ -33,3 +33,4 @@ lemma val_div_of_dvd {p : Prime} {a b : Fp p} (h : b.val ∣ a.val)
   conv_rhs => rw [ZMod.val_mul_of_lt (by norm_cast; rw [ZMod.val_natCast_of_lt this]; assumption)]
   rw [Nat.mul_div_cancel_left _ (by apply Nat.zero_lt_of_ne_zero; assumption)]
   field_simp
+

--- a/stdlib/lampe/Stdlib/Lib.lean
+++ b/stdlib/lampe/Stdlib/Lib.lean
@@ -4,3 +4,4 @@ import Lampe
 namespace Lampe.Stdlib.Lib
 
 open «std-1.0.0-beta.12»
+

--- a/stdlib/lampe/Stdlib/Ops/Bit.lean
+++ b/stdlib/lampe/Stdlib/Ops/Bit.lean
@@ -4,3 +4,665 @@ import Lampe
 namespace Lampe.Stdlib.Ops.Bit
 
 open «std-1.0.0-beta.12»
+
+set_option Lampe.pp.Expr false
+set_option Lampe.pp.STHoare false
+
+/-- A shorthand for a call to the `std::ops::bit::Not::not` method. -/
+@[reducible]
+def not {p}
+    (generics : HList Kind.denote «std-1.0.0-beta.12::ops::bit::Not».«#genericKinds»)
+    (Self : Tp)
+    (associatedTypes : HList Kind.denote «std-1.0.0-beta.12::ops::bit::Not».«#associatedTypesKinds»)
+    (fnGenerics : HList Kind.denote «std-1.0.0-beta.12::ops::bit::Not».not.«#genericKinds»)
+  : HList (Tp.denote p)
+      («std-1.0.0-beta.12::ops::bit::Not».not.«#inputs» generics Self associatedTypes fnGenerics)
+  → Expr (Tp.denote p)
+      («std-1.0.0-beta.12::ops::bit::Not».not.«#output» generics Self associatedTypes fnGenerics) :=
+  «std-1.0.0-beta.12::ops::bit::Not».not generics Self associatedTypes fnGenerics
+
+set_option maxRecDepth 1300 in
+theorem bool_not_spec {p a}
+  : STHoare p env ⟦⟧
+    (not h![] .bool h![] h![] h![a])
+    (fun r => r = !a) := by
+  resolve_trait
+  steps
+  simp_all
+  exact ()
+
+set_option maxRecDepth 1300 in
+theorem u128_not_spec {p a}
+  : STHoare p env ⟦⟧
+    (not h![] (.u 128) h![] h![] h![a])
+    (fun r => r = a.not) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1300 in
+theorem u64_not_spec {p a}
+  : STHoare p env ⟦⟧
+    (not h![] (.u 64) h![] h![] h![a])
+    (fun r => r = a.not) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1300 in
+theorem u32_not_spec {p a}
+  : STHoare p env ⟦⟧
+    (not h![] (.u 32) h![] h![] h![a])
+    (fun r => r = a.not) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1300 in
+theorem u16_not_spec {p a}
+  : STHoare p env ⟦⟧
+    (not h![] (.u 16) h![] h![] h![a])
+    (fun r => r = a.not) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1300 in
+theorem u8_not_spec {p a}
+  : STHoare p env ⟦⟧
+    (not h![] (.u 8) h![] h![] h![a])
+    (fun r => r = a.not) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem u1_not_spec {p a}
+  : STHoare p env ⟦⟧
+    (not h![] (.u 1) h![] h![] h![a])
+    (fun r => r = a.not) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem i8_not_spec {p a}
+  : STHoare p env ⟦⟧
+    (not h![] (.i 8) h![] h![] h![a])
+    (fun r => r = a.not) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem i16_not_spec {p a}
+  : STHoare p env ⟦⟧
+    (not h![] (.i 16) h![] h![] h![a])
+    (fun r => r = a.not) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem i32_not_spec {p a}
+  : STHoare p env ⟦⟧
+    (not h![] (.i 32) h![] h![] h![a])
+    (fun r => r = a.not) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem i64_not_spec {p a}
+  : STHoare p env ⟦⟧
+    (not h![] (.i 64) h![] h![] h![a])
+    (fun r => r = a.not) := by
+  resolve_trait
+  steps
+  simp_all
+
+/-- A shorthand for a call to the `std::ops::bit::BitOr::bitor` method. -/
+@[reducible]
+def bitOr {p}
+    (generics : HList Kind.denote «std-1.0.0-beta.12::ops::bit::BitOr».«#genericKinds»)
+    (Self : Tp)
+    (associatedTypes : HList Kind.denote «std-1.0.0-beta.12::ops::bit::BitOr».«#associatedTypesKinds»)
+    (fnGenerics : HList Kind.denote «std-1.0.0-beta.12::ops::bit::BitOr».bitor.«#genericKinds»)
+  : HList (Tp.denote p)
+      («std-1.0.0-beta.12::ops::bit::BitOr».bitor.«#inputs» generics Self associatedTypes fnGenerics)
+  → Expr (Tp.denote p)
+      («std-1.0.0-beta.12::ops::bit::BitOr».bitor.«#output» generics Self associatedTypes fnGenerics) :=
+  «std-1.0.0-beta.12::ops::bit::BitOr».bitor generics Self associatedTypes fnGenerics
+
+set_option maxRecDepth 1350 in
+theorem bool_bit_or_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitOr h![] .bool h![] h![] h![a, b])
+    (fun r => r = a.or b) := by
+  resolve_trait
+  steps
+  simp_all
+  exact ()
+
+set_option maxRecDepth 1350 in
+theorem u128_bit_or_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitOr h![] (.u 128) h![] h![] h![a, b])
+    (fun r => r = a.or b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem u64_bit_or_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitOr h![] (.u 64) h![] h![] h![a, b])
+    (fun r => r = a.or b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem u32_bit_or_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitOr h![] (.u 32) h![] h![] h![a, b])
+    (fun r => r = a.or b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem u16_bit_or_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitOr h![] (.u 16) h![] h![] h![a, b])
+    (fun r => r = a.or b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem u8_bit_or_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitOr h![] (.u 8) h![] h![] h![a, b])
+    (fun r => r = a.or b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem u1_bit_or_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitOr h![] (.u 1) h![] h![] h![a, b])
+    (fun r => r = a.or b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem i8_bit_or_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitOr h![] (.i 8) h![] h![] h![a, b])
+    (fun r => r = a.or b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem i16_bit_or_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitOr h![] (.i 16) h![] h![] h![a, b])
+    (fun r => r = a.or b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem i32_bit_or_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitOr h![] (.i 32) h![] h![] h![a, b])
+    (fun r => r = a.or b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1350 in
+theorem i64_bit_or_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitOr h![] (.i 64) h![] h![] h![a, b])
+    (fun r => r = a.or b) := by
+  resolve_trait
+  steps
+  simp_all
+
+/-- A shorthand for a call to the `std::ops::bit::BitOr::bitand` method. -/
+@[reducible]
+def bitAnd {p}
+    (generics : HList Kind.denote «std-1.0.0-beta.12::ops::bit::BitAnd».«#genericKinds»)
+    (Self : Tp)
+    (associatedTypes : HList Kind.denote «std-1.0.0-beta.12::ops::bit::BitAnd».«#associatedTypesKinds»)
+    (fnGenerics : HList Kind.denote «std-1.0.0-beta.12::ops::bit::BitAnd».bitand.«#genericKinds»)
+  : HList (Tp.denote p)
+      («std-1.0.0-beta.12::ops::bit::BitAnd».bitand.«#inputs» generics Self associatedTypes fnGenerics)
+  → Expr (Tp.denote p)
+      («std-1.0.0-beta.12::ops::bit::BitAnd».bitand.«#output» generics Self associatedTypes fnGenerics) :=
+  «std-1.0.0-beta.12::ops::bit::BitAnd».bitand generics Self associatedTypes fnGenerics
+
+set_option maxRecDepth 1350 in
+theorem bool_bit_and_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitAnd h![] .bool h![] h![] h![a, b])
+    (fun r => r = a.and b) := by
+  resolve_trait
+  steps
+  simp_all
+  exact ()
+
+set_option maxRecDepth 1400 in
+theorem u128_bit_and_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitAnd h![] (.u 128) h![] h![] h![a, b])
+    (fun r => r = a.and b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1400 in
+theorem u64_bit_and_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitAnd h![] (.u 64) h![] h![] h![a, b])
+    (fun r => r = a.and b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1400 in
+theorem u32_bit_and_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitAnd h![] (.u 32) h![] h![] h![a, b])
+    (fun r => r = a.and b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1400 in
+theorem u16_bit_and_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitAnd h![] (.u 16) h![] h![] h![a, b])
+    (fun r => r = a.and b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1400 in
+theorem u8_bit_and_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitAnd h![] (.u 8) h![] h![] h![a, b])
+    (fun r => r = a.and b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1400 in
+theorem u1_bit_and_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitAnd h![] (.u 1) h![] h![] h![a, b])
+    (fun r => r = a.and b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1400 in
+theorem i8_bit_and_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitAnd h![] (.i 8) h![] h![] h![a, b])
+    (fun r => r = a.and b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1400 in
+theorem i16_bit_and_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitAnd h![] (.i 16) h![] h![] h![a, b])
+    (fun r => r = a.and b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1400 in
+theorem i32_bit_and_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitAnd h![] (.i 32) h![] h![] h![a, b])
+    (fun r => r = a.and b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1400 in
+theorem i64_bit_and_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitAnd h![] (.i 64) h![] h![] h![a, b])
+    (fun r => r = a.and b) := by
+  resolve_trait
+  steps
+  simp_all
+
+/-- A shorthand for a call to the `std::ops::bit::BitXor::bitxor` method. -/
+@[reducible]
+def bitXor {p}
+    (generics : HList Kind.denote «std-1.0.0-beta.12::ops::bit::BitXor».«#genericKinds»)
+    (Self : Tp)
+    (associatedTypes : HList Kind.denote «std-1.0.0-beta.12::ops::bit::BitXor».«#associatedTypesKinds»)
+    (fnGenerics : HList Kind.denote «std-1.0.0-beta.12::ops::bit::BitXor».bitxor.«#genericKinds»)
+  : HList (Tp.denote p)
+      («std-1.0.0-beta.12::ops::bit::BitXor».bitxor.«#inputs» generics Self associatedTypes fnGenerics)
+  → Expr (Tp.denote p)
+      («std-1.0.0-beta.12::ops::bit::BitXor».bitxor.«#output» generics Self associatedTypes fnGenerics) :=
+  «std-1.0.0-beta.12::ops::bit::BitXor».bitxor generics Self associatedTypes fnGenerics
+
+set_option maxRecDepth 1400 in
+theorem bool_bit_xor_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitXor h![] .bool h![] h![] h![a, b])
+    (fun r => r = a.xor b) := by
+  resolve_trait
+  steps
+  simp_all
+  exact ()
+
+set_option maxRecDepth 1400 in
+theorem u128_bit_xor_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitXor h![] (.u 128) h![] h![] h![a, b])
+    (fun r => r = a.xor b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1400 in
+theorem u64_bit_xor_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitXor h![] (.u 64) h![] h![] h![a, b])
+    (fun r => r = a.xor b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1400 in
+theorem u32_bit_xor_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitXor h![] (.u 32) h![] h![] h![a, b])
+    (fun r => r = a.xor b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1400 in
+theorem u16_bit_xor_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitXor h![] (.u 16) h![] h![] h![a, b])
+    (fun r => r = a.xor b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1400 in
+theorem u8_bit_xor_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitXor h![] (.u 8) h![] h![] h![a, b])
+    (fun r => r = a.xor b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem u1_bit_xor_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitXor h![] (.u 1) h![] h![] h![a, b])
+    (fun r => r = a.xor b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem i8_bit_xor_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitXor h![] (.i 8) h![] h![] h![a, b])
+    (fun r => r = a.xor b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem i16_bit_xor_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitXor h![] (.i 16) h![] h![] h![a, b])
+    (fun r => r = a.xor b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem i32_bit_xor_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitXor h![] (.i 32) h![] h![] h![a, b])
+    (fun r => r = a.xor b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem i64_bit_xor_spec {p a b}
+  : STHoare p env ⟦⟧
+    (bitXor h![] (.i 64) h![] h![] h![a, b])
+    (fun r => r = a.xor b) := by
+  resolve_trait
+  steps
+  simp_all
+
+/-- A shorthand for a call to the `std::ops::bit::Shl::shl` method. -/
+@[reducible]
+def shl {p}
+    (generics : HList Kind.denote «std-1.0.0-beta.12::ops::bit::Shl».«#genericKinds»)
+    (Self : Tp)
+    (associatedTypes : HList Kind.denote «std-1.0.0-beta.12::ops::bit::Shl».«#associatedTypesKinds»)
+    (fnGenerics : HList Kind.denote «std-1.0.0-beta.12::ops::bit::Shl».shl.«#genericKinds»)
+  : HList (Tp.denote p)
+      («std-1.0.0-beta.12::ops::bit::Shl».shl.«#inputs» generics Self associatedTypes fnGenerics)
+  → Expr (Tp.denote p)
+      («std-1.0.0-beta.12::ops::bit::Shl».shl.«#output» generics Self associatedTypes fnGenerics) :=
+  «std-1.0.0-beta.12::ops::bit::Shl».shl generics Self associatedTypes fnGenerics
+
+set_option maxRecDepth 1450 in
+theorem u128_shl_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shl h![] (.u 128) h![] h![] h![a, b])
+    (fun r => r = a <<< b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem u64_shl_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shl h![] (.u 64) h![] h![] h![a, b])
+    (fun r => r = a <<< b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem u32_shl_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shl h![] (.u 32) h![] h![] h![a, b])
+    (fun r => r = a <<< b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem u16_shl_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shl h![] (.u 16) h![] h![] h![a, b])
+    (fun r => r = a <<< b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem u8_shl_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shl h![] (.u 8) h![] h![] h![a, b])
+    (fun r => r = a <<< b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem u1_shl_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shl h![] (.u 1) h![] h![] h![a, b])
+    (fun r => r = a <<< b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem i8_shl_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shl h![] (.i 8) h![] h![] h![a, b])
+    (fun r => r = a <<< b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem i16_shl_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shl h![] (.i 16) h![] h![] h![a, b])
+    (fun r => r = a <<< b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem i32_shl_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shl h![] (.i 32) h![] h![] h![a, b])
+    (fun r => r = a <<< b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem i64_shl_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shl h![] (.i 64) h![] h![] h![a, b])
+    (fun r => r = a <<< b) := by
+  resolve_trait
+  steps
+  simp_all
+
+/-- A shorthand for a call to the `std::ops::bit::Shr::shr` method. -/
+@[reducible]
+def shr {p}
+    (generics : HList Kind.denote «std-1.0.0-beta.12::ops::bit::Shr».«#genericKinds»)
+    (Self : Tp)
+    (associatedTypes : HList Kind.denote «std-1.0.0-beta.12::ops::bit::Shr».«#associatedTypesKinds»)
+    (fnGenerics : HList Kind.denote «std-1.0.0-beta.12::ops::bit::Shr».shr.«#genericKinds»)
+  : HList (Tp.denote p)
+      («std-1.0.0-beta.12::ops::bit::Shr».shr.«#inputs» generics Self associatedTypes fnGenerics)
+  → Expr (Tp.denote p)
+      («std-1.0.0-beta.12::ops::bit::Shr».shr.«#output» generics Self associatedTypes fnGenerics) :=
+  «std-1.0.0-beta.12::ops::bit::Shr».shr generics Self associatedTypes fnGenerics
+
+set_option maxRecDepth 1450 in
+theorem u128_shr_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shr h![] (.u 128) h![] h![] h![a, b])
+    (fun r => r = a >>> b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1450 in
+theorem u64_shr_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shr h![] (.u 64) h![] h![] h![a, b])
+    (fun r => r = a >>> b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1500 in
+theorem u32_shr_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shr h![] (.u 32) h![] h![] h![a, b])
+    (fun r => r = a >>> b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1500 in
+theorem u16_shr_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shr h![] (.u 16) h![] h![] h![a, b])
+    (fun r => r = a >>> b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1500 in
+theorem u8_shr_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shr h![] (.u 8) h![] h![] h![a, b])
+    (fun r => r = a >>> b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1500 in
+theorem u1_shr_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shr h![] (.u 1) h![] h![] h![a, b])
+    (fun r => r = a >>> b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1500 in
+theorem i8_shr_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shr h![] (.i 8) h![] h![] h![a, b])
+    (fun r => r = a >>> b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1500 in
+theorem i16_shr_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shr h![] (.i 16) h![] h![] h![a, b])
+    (fun r => r = a >>> b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1500 in
+theorem i32_shr_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shr h![] (.i 32) h![] h![] h![a, b])
+    (fun r => r = a >>> b) := by
+  resolve_trait
+  steps
+  simp_all
+
+set_option maxRecDepth 1500 in
+theorem i64_shr_spec {p a b}
+  : STHoare p env ⟦⟧
+    (shr h![] (.i 64) h![] h![] h![a, b])
+    (fun r => r = a >>> b) := by
+  resolve_trait
+  steps
+  simp_all
+

--- a/stdlib/lampe/Stdlib/Option.lean
+++ b/stdlib/lampe/Stdlib/Option.lean
@@ -683,3 +683,4 @@ theorem cmp_pure_spec {p T self other}
     · intro
       steps [equal_spec]
       simp_all
+

--- a/stdlib/lampe/Stdlib/Panic.lean
+++ b/stdlib/lampe/Stdlib/Panic.lean
@@ -4,3 +4,4 @@ import Lampe
 namespace Lampe.Stdlib.Panic
 
 open «std-1.0.0-beta.12»
+

--- a/stdlib/lampe/Stdlib/Stdlib.lean
+++ b/stdlib/lampe/Stdlib/Stdlib.lean
@@ -34,3 +34,4 @@ import «std-1.0.0-beta.12».Extracted
 namespace Lampe.Stdlib
 
 export «std-1.0.0-beta.12» (env)
+

--- a/stdlib/lampe/Stdlib/String.lean
+++ b/stdlib/lampe/Stdlib/String.lean
@@ -2,3 +2,4 @@ import «std-1.0.0-beta.12».Extracted
 import Lampe
 
 namespace Lampe.Stdlib.String
+

--- a/stdlib/lampe/Stdlib/Tp.lean
+++ b/stdlib/lampe/Stdlib/Tp.lean
@@ -6,3 +6,4 @@ set_option Lampe.pp.Expr false
 set_option Lampe.pp.STHoare false
 
 abbrev comparator (p : Prime) (t : Tp) : Type := t.denote p → t.denote p → Ordering
+


### PR DESCRIPTION
This commit also clarifies the semantics of the shift operations on both unsigned and signed integers as they previously expected a shift of type u8 where the actual trait is defined for `Self -> Self -> Self`.

Partial work for #50.