### PR TITLE
Add support for deprecated annotations

### DIFF
--- a/Lampe/Lampe/Builtin/Str.lean
+++ b/Lampe/Lampe/Builtin/Str.lean
@@ -1,4 +1,6 @@
 import Lampe.Builtin.Basic
+import Lampe.Data.Strings
+
 namespace Lampe.Builtin
 
 /--
@@ -7,11 +9,33 @@ Defines the conversion of strings of length `N` to a byte array of length `N`.
 It is enforced that Noir strings are uninterpreted bytes, so the length `N` of a string is the
 number of bytes it contains, not the number of characters (regardless of the encoding).
 
-In Noir, this corresponds to `fn as_bytes(self: str<N>) -> [u8; N]`.
+In Noir, this corresponds to `fn as_bytes<let N: u32>(self: str<N>) -> [u8; N]`.
 -/
 def strAsBytes := newGenericPureBuiltin
   (fun n => ⟨[.str n], (.array (.u 8) n)⟩)
   (fun n h![s] => ⟨s.length = n.toNat,
     fun _ => s⟩)
+
+/--
+Implements the semantics of the `arrayAsStrUnchecked` builtin in Noir.
+
+In particular it performs no checking as to the validity of the provided bytes and blindly
+constructs a string from them.
+-/
+def arrayAsStr! {N} (array : List.Vector (BitVec 8) N) : NoirStr N := 
+  let bytes := array.map (fun x => UInt8.ofBitVec x)
+  NoirStr.mk bytes
+
+/--
+Defines the conversion of arrays bytes of length `N` to a string of length `N`.
+
+It is enforced that Noir strings are uninterpreted bytes, so the length `N` of the string is the
+number of bytes it contains, not the number of characters (regardless of the encoding).
+
+In Noir, this corresponds to `from<let N: u32>(bytes: [u8, N]) -> str<N>`.
+-/
+def arrayAsStrUnchecked := newGenericTotalPureBuiltin 
+  (fun n => ⟨[(Tp.u 8).array n], (.str n)⟩)
+  (fun _ h![a] => arrayAsStr! a)
 
 end Lampe.Builtin

--- a/Lampe/Lampe/Builtin/Stubs.lean
+++ b/Lampe/Lampe/Builtin/Stubs.lean
@@ -31,7 +31,6 @@ def stub : Builtin := {
 -- to match the name in extracted code that comes from Noir.
 def aes128Encrypt := stub
 def applyRangeConstraint := stub
-def arrayAsStrUnchecked := stub
 def arrayRefcount := stub
 def asWitness := stub
 def assertConstant := stub

--- a/Lampe/Lampe/Hoare/Builtins.lean
+++ b/Lampe/Lampe/Hoare/Builtins.lean
@@ -417,6 +417,11 @@ theorem strAsBytes_intro : STHoarePureBuiltin p Γ Builtin.strAsBytes (by tauto)
   apply pureBuiltin_intro_consequence <;> try tauto
   tauto
 
+theorem arrayAsStrUnchecked_intro : STHoarePureBuiltin p Γ Builtin.arrayAsStrUnchecked (by tauto) h![a] := by
+  simp only [STHoarePureBuiltin, SLP.exists_pure]
+  apply pureBuiltin_intro_consequence <;> try tauto
+  tauto
+
 -- Memory
 
 theorem ref_intro :

--- a/Lampe/Lampe/Syntax/Builders.lean
+++ b/Lampe/Lampe/Syntax/Builders.lean
@@ -459,7 +459,7 @@ def makeTraitImpl [MonadUtil m] : Syntax → m (Lean.Ident × TSyntax `term)
 /--
 Builds a struct definition from the provided syntax, or returns an error if the syntax is invalid.
 -/
-def makeStructDef [MonadUtil m] (name : TSyntax `noir_ident): Syntax → m (TSyntax `term)
+def makeStructDef [MonadUtil m] (name : TSyntax `noir_ident) : Syntax → m (TSyntax `term)
 | `(noir_type_def|< $genDefs,* > { $members,* }) => do
   let (genKinds, genDefs) ← makeGenericDefTerms genDefs.getElems.toList
   let fieldTypes ← members.getElems.toList.mapM fun paramSyn => match paramSyn with
@@ -576,3 +576,17 @@ def makeTraitDef [MonadUtil m] : Syntax → m (List $ TSyntax `command)
 
   pure outputs
 | _ => throwUnsupportedSyntax
+
+-- def makeStructDef [MonadUtil m] (name : TSyntax `noir_ident): Syntax → m (TSyntax `term)
+
+/-- 
+Extracts any deprecation message that may have been attached to a definition.
+
+Returns `some ""` if the entity is deprecated but has no message, and returns `none` if the entity
+is not deprecated at all.
+-/
+def parseDeprecatedMessage [MonadUtil m] : (stx : Syntax) → m (Option String)
+| `(noir_depr?|[[deprecated]]) => pure $ some ""
+| `(noir_depr?|[[deprecated $msg:str]]) => pure msg.getString 
+| _ => pure none
+

--- a/Lampe/Lampe/Syntax/Rules.lean
+++ b/Lampe/Lampe/Syntax/Rules.lean
@@ -27,6 +27,8 @@ declare_syntax_cat noir_type
 
 syntax noir_arrow := "->" <|> "→"
 
+syntax noir_depr? := ("[[" "deprecated" (ppSpace str)? "]]" ppSpace)?
+
 -- GLOBAL DEFINITIONS -----------------------------------------------------------------------------
 -- These include functions, traits, trait implementations, and globals, as well as aliases.
 

--- a/Lampe/Lampe/Tactic/Steps.lean
+++ b/Lampe/Lampe/Tactic/Steps.lean
@@ -137,6 +137,7 @@ def getClosingTerm (val : Lean.Expr) : TacticM (Option (TSyntax `term)) := withT
         | ``Lampe.Builtin.iNeg => return some (←``(iNeg_intro))
 
         | ``Lampe.Builtin.strAsBytes => return some (←``(strAsBytes_intro))
+        | ``Lampe.Builtin.arrayAsStrUnchecked => return some (←``(arrayAsStrUnchecked_intro))
 
         -- Array builtins
         | ``Lampe.Builtin.mkArray =>

--- a/Lampe/Tests/Deprecations.lean
+++ b/Lampe/Tests/Deprecations.lean
@@ -1,0 +1,38 @@
+import Lampe
+
+open Lampe
+
+[[deprecated]]
+noir_def my_func1<>() -> Unit := {
+  #_unit
+}
+
+/--
+warning: `my_func1` has been deprecated:
+-/
+#guard_msgs in
+def my_func1_deprecated := my_func1
+
+[[deprecated "Use XXX instead"]]
+noir_def my_func2<>() -> Unit := {
+  #_unit
+}
+
+/--
+warning: `my_func2` has been deprecated: Use XXX instead
+-/
+#guard_msgs in
+def my_func2_deprecated := my_func2
+
+[[deprecated "Use XXX instead"]]
+noir_struct_def FooStruct<I: Type> {
+  I,
+  I
+}
+
+/--
+warning: `FooStruct` has been deprecated: Use XXX instead
+-/
+#guard_msgs in
+def FooStruct_deprecated := FooStruct
+

--- a/src/lean/ast.rs
+++ b/src/lean/ast.rs
@@ -101,19 +101,50 @@ pub struct WhereClause {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Deprecation {
+    pub is_deprecated: bool,
+    pub message:       Option<String>,
+}
+impl Deprecation {
+    /// Something that is not deprecated.
+    #[must_use]
+    pub fn undeprecated() -> Self {
+        Self {
+            is_deprecated: false,
+            message:       None,
+        }
+    }
+
+    /// Returns not deprecated if the outer `Option` is `None`, otherwise
+    /// returns deprecated with the optional message.
+    #[must_use]
+    pub fn from_noir(depr_note: Option<Option<String>>) -> Self {
+        match depr_note {
+            None => Self::undeprecated(),
+            Some(message) => Self {
+                is_deprecated: true,
+                message,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct FunctionDefinition {
     pub name:        String,
     pub generics:    Vec<TypePattern>,
     pub parameters:  Vec<ParamDef>,
     pub return_type: Type,
     pub body:        Expression,
+    pub deprecation: Deprecation,
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct StructDefinition {
-    pub name:     String,
-    pub generics: Vec<TypePattern>,
-    pub members:  Vec<Type>,
+    pub name:        String,
+    pub generics:    Vec<TypePattern>,
+    pub members:     Vec<Type>,
+    pub deprecation: Deprecation,
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/src/lean/emit/types.rs
+++ b/src/lean/emit/types.rs
@@ -65,6 +65,15 @@ impl TypesEmitter {
     pub fn emit_struct(&mut self, struct_: &StructDefinition) {
         let mut writer = Writer::new(&mut self.context);
 
+        if struct_.deprecation.is_deprecated {
+            if let Some(msg) = &struct_.deprecation.message {
+                writer.append_to_line(&format!("[[deprecated \"{msg}\"]]"));
+            } else {
+                writer.append_to_line("[[deprecated]]");
+            }
+            writer.end_line();
+        }
+
         writer.append_to_line("noir_struct_def ");
         writer.append_to_line(&struct_.name);
 

--- a/stdlib/lampe/Stdlib/Lib.lean
+++ b/stdlib/lampe/Stdlib/Lib.lean
@@ -5,3 +5,41 @@ namespace Lampe.Stdlib.Lib
 
 open «std-1.0.0-beta.12»
 
+/-- 
+Note that as printing is inherently an unconstrained-only operation, this theorem is not capable of
+asserting actual properties about the printing operation. Instead it simply exists to make it easy
+to step through print calls when verifying your programs.
+-/
+theorem println_spec {p T a}
+  : STHoare p env ⟦⟧
+    («std-1.0.0-beta.12::println».call h![T] h![a])
+    (fun r => r = ()) := by
+  enter_decl
+  step_as (⟦⟧) (fun r => r = ())
+  steps
+  step_as (⟦⟧) (fun r => (r : Tp.denote p .unit) = ())
+  · enter_decl
+    steps
+  · steps
+    simp_all
+
+/-- 
+Note that as printing is inherently an unconstrained-only operation, this theorem is not capable of
+asserting actual properties about the printing operation. Instead it simply exists to make it easy
+to step through print calls when verifying your programs.
+-/
+theorem print_spec {p T a}
+  : STHoare p env ⟦⟧
+    («std-1.0.0-beta.12::print».call h![T] h![a])
+    (fun r => r = ()) := by
+  enter_decl
+  step_as (⟦⟧) (fun r => r = ())
+  steps
+  step_as (⟦⟧) (fun r => (r : Tp.denote p .unit) = ())
+  · enter_decl
+    steps
+  · steps
+    simp_all
+
+-- TODO (#108) verify_proof_with_type
+

--- a/stdlib/lampe/Stdlib/Panic.lean
+++ b/stdlib/lampe/Stdlib/Panic.lean
@@ -5,3 +5,14 @@ namespace Lampe.Stdlib.Panic
 
 open «std-1.0.0-beta.12»
 
+/--
+Note that this theorem exists only to make it easy to steps through calls to `panic` in your code as
+it cannot (and does not) assert any meaningful properties on the functioning of the call to panic.
+-/
+theorem panic_correct {p T U N msg}
+  : STHoare p env ⟦⟧
+    («std-1.0.0-beta.12::panic::panic».call h![T, U, N] h![msg])
+    (fun _ => ⟦⟧) := by
+  enter_decl
+  steps
+

--- a/stdlib/lampe/Stdlib/String.lean
+++ b/stdlib/lampe/Stdlib/String.lean
@@ -3,3 +3,17 @@ import Lampe
 
 namespace Lampe.Stdlib.String
 
+open «std-1.0.0-beta.12»
+open Lampe.Stdlib
+
+-- TODO (#50) as_bytes_vec: depends on Vec being formalized
+
+set_option maxRecDepth 1500 in
+theorem from_spec {p N a}
+  : STHoare p env ⟦⟧
+    («std-1.0.0-beta.12::convert::From».from h![(Tp.u 8).array N] (.str N) h![] h![] h![a])
+    (fun r => r = Lampe.Builtin.arrayAsStr! a) := by
+  resolve_trait
+  steps
+  simp_all
+

--- a/stdlib/lampe/std-1.0.0-beta.12/Extracted/Hash/Mod.lean
+++ b/stdlib/lampe/std-1.0.0-beta.12/Extracted/Hash/Mod.lean
@@ -5,6 +5,7 @@ import Lampe
 
 open Lampe
 
+[[deprecated "This function has been moved to std::hash::keccakf1600"]]
 noir_def «std-1.0.0-beta.12»::hash::keccak::keccakf1600<>(input: Array<u64, 25: u32>) -> Array<u64, 25: u32> := {
   (#_keccakf1600 returning Array<u64, 25: u32>)(input)
 }
@@ -259,5 +260,5 @@ noir_def «std-1.0.0-beta.12»::hash::assert_pedersen<>() -> Unit := {
 }
 
 def «std-1.0.0-beta.12».Hash.Mod.env : Env := Env.mk
-  [«std-1.0.0-beta.12::hash::keccak::keccakf1600», «std-1.0.0-beta.12::hash::blake3», «std-1.0.0-beta.12::hash::pedersen_commitment», «std-1.0.0-beta.12::hash::pedersen_commitment_with_separator», «std-1.0.0-beta.12::hash::pedersen_hash», «std-1.0.0-beta.12::hash::pedersen_hash_with_separator», «std-1.0.0-beta.12::hash::derive_generators», «std-1.0.0-beta.12::hash::from_field_unsafe», «std-1.0.0-beta.12::hash::assert_pedersen»]
+  [«std-1.0.0-beta.12::hash::blake3», «std-1.0.0-beta.12::hash::pedersen_commitment», «std-1.0.0-beta.12::hash::pedersen_commitment_with_separator», «std-1.0.0-beta.12::hash::pedersen_hash», «std-1.0.0-beta.12::hash::pedersen_hash_with_separator», «std-1.0.0-beta.12::hash::derive_generators», «std-1.0.0-beta.12::hash::from_field_unsafe», «std-1.0.0-beta.12::hash::assert_pedersen»]
   [«std-1.0.0-beta.12».impl_2, «std-1.0.0-beta.12».impl_3, «std-1.0.0-beta.12».impl_4, «std-1.0.0-beta.12».impl_5, «std-1.0.0-beta.12».impl_6, «std-1.0.0-beta.12».impl_7, «std-1.0.0-beta.12».impl_8, «std-1.0.0-beta.12».impl_9, «std-1.0.0-beta.12».impl_10, «std-1.0.0-beta.12».impl_11, «std-1.0.0-beta.12».impl_12, «std-1.0.0-beta.12».impl_13, «std-1.0.0-beta.12».impl_14, «std-1.0.0-beta.12».impl_15, «std-1.0.0-beta.12».impl_16, «std-1.0.0-beta.12».impl_17, «std-1.0.0-beta.12».impl_18, «std-1.0.0-beta.12».impl_19, «std-1.0.0-beta.12».impl_20, «std-1.0.0-beta.12».impl_21, «std-1.0.0-beta.12».impl_22]

--- a/stdlib/lampe/std-1.0.0-beta.12/Extracted/Lib.lean
+++ b/stdlib/lampe/std-1.0.0-beta.12/Extracted/Lib.lean
@@ -32,14 +32,17 @@ noir_def «std-1.0.0-beta.12»::verify_proof_with_type<N: u32, M: u32, K: u32>(v
   #_skip
 }
 
+[[deprecated "wrapping operations should be done with the Wrapping traits. E.g: x.wrapping_add(y)"]]
 noir_def «std-1.0.0-beta.12»::wrapping_add<T: Type>(x: T, y: T) -> T := {
   ((Field as «std-1.0.0-beta.12»::convert::AsPrimitive<T>)::as_<> as λ(Field) -> T)((#_fAdd returning Field)(((T as «std-1.0.0-beta.12»::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(x), ((T as «std-1.0.0-beta.12»::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(y)))
 }
 
+[[deprecated "wrapping operations should be done with the Wrapping traits. E.g: x.wrapping_sub(y)"]]
 noir_def «std-1.0.0-beta.12»::wrapping_sub<T: Type>(x: T, y: T) -> T := {
   ((Field as «std-1.0.0-beta.12»::convert::AsPrimitive<T>)::as_<> as λ(Field) -> T)((#_fSub returning Field)((#_fAdd returning Field)(((T as «std-1.0.0-beta.12»::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(x), (340282366920938463463374607431768211456: Field)), ((T as «std-1.0.0-beta.12»::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(y)))
 }
 
+[[deprecated "wrapping operations should be done with the Wrapping traits. E.g: x.wrapping_mul(y)"]]
 noir_def «std-1.0.0-beta.12»::wrapping_mul<T: Type>(x: T, y: T) -> T := {
   ((Field as «std-1.0.0-beta.12»::convert::AsPrimitive<T>)::as_<> as λ(Field) -> T)((#_fMul returning Field)(((T as «std-1.0.0-beta.12»::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(x), ((T as «std-1.0.0-beta.12»::convert::AsPrimitive<Field>)::as_<> as λ(T) -> Field)(y)))
 }
@@ -67,5 +70,5 @@ noir_def «std-1.0.0-beta.12»::tests::test_wrapping_mul<>() -> Unit := {
 }
 
 def «std-1.0.0-beta.12».Lib.env : Env := Env.mk
-  [«std-1.0.0-beta.12::print_oracle», «std-1.0.0-beta.12::print_unconstrained», «std-1.0.0-beta.12::println», «std-1.0.0-beta.12::print», «std-1.0.0-beta.12::verify_proof_with_type», «std-1.0.0-beta.12::wrapping_add», «std-1.0.0-beta.12::wrapping_sub», «std-1.0.0-beta.12::wrapping_mul», «std-1.0.0-beta.12::tests::test_static_assert_custom_message», «std-1.0.0-beta.12::tests::test_wrapping_mul»]
+  [«std-1.0.0-beta.12::print_oracle», «std-1.0.0-beta.12::print_unconstrained», «std-1.0.0-beta.12::println», «std-1.0.0-beta.12::print», «std-1.0.0-beta.12::verify_proof_with_type», «std-1.0.0-beta.12::tests::test_static_assert_custom_message», «std-1.0.0-beta.12::tests::test_wrapping_mul»]
   []


### PR DESCRIPTION
These can be placed on function and type definitions and are currently used by the extractor to annotate deprecated things in the extracted code. Deprecated items are explicitly _not_ added to the environment to discourage their usage.

This commit also adds a definition for the `arrayAsStrUnchecked` builtin and a few simple proofs.

Partial work toward #50.