### PR TITLE
Reuse precomputed `file_path` in `from_user_noir_file`

### DIFF
--- a/src/file_generator/lean/file.rs
+++ b/src/file_generator/lean/file.rs
@@ -77,10 +77,7 @@ impl LeanFile {
             return Err(DuplicateWithGeneratedFile(path.to_path_buf()));
         }
 
-        Ok(LeanFile {
-            file_path: LeanFilePath::from_noir_path(path),
-            content,
-        })
+        Ok(LeanFile { file_path, content })
     }
 
     #[must_use]


### PR DESCRIPTION
Replace the second call to LeanFilePath::from_noir_path(path) with the already computed file_path in LeanFile::from_user_noir_file() 
Rationale: 
from_noir_path is pure and allocations/case conversions are non-trivial. Reusing the value avoids redundant work without changing behavior.
No functional changes; only a minor performance/alloc optimization.
Callers (e.g., project.rs::compile_package) do not rely on recomputation side effects.