### PR TITLE
chore(ci): upgrade checkout to v6

### DIFF
--- a/.github/workflows/ci-noir.yaml
+++ b/.github/workflows/ci-noir.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Noir repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: noir-lang/noir
           ref: 9a5b3695b42e391fa27c48e87b9bbb07523d664d
@@ -30,7 +30,7 @@ jobs:
         working-directory: noir/test_programs
         run: ./rebuild.sh
       - name: Checkout Lampe repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: lampe
       - name: Install xonsh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Install xonsh
         run: |
           export DEBIAN_FRONTEND=noninteractive
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (sparse)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             Lampe
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (sparse)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Install xonsh
         run: |
           export DEBIAN_FRONTEND=noninteractive
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: lampe
       - name: Set up Rust
@@ -103,7 +103,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install rust
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: lampe
       - name: Set up Rust
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: lampe
       - name: Set up Rust
@@ -165,7 +165,7 @@ jobs:
       LAMPE_TEST_CURRENT_COMMIT_SHA: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: lampe
       - name: Install xonsh
@@ -204,7 +204,7 @@ jobs:
       LAMPE_TEST_CURRENT_COMMIT_SHA: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: lampe
       - name: Install xonsh


### PR DESCRIPTION
Updates `actions/checkout` to v6 in CI workflows. No code changes.

https://github.com/actions/checkout/releases/tag/v6.0.0