### PR TITLE
fix: extract comptime globals bound to simple identifiers

### DIFF
--- a/src/lean/generator.rs
+++ b/src/lean/generator.rs
@@ -1380,12 +1380,15 @@ impl LeanGenerator<'_, '_, '_> {
         let global_data = self.context.def_interner.get_global(*id);
         let statement = self.context.def_interner.statement(&global_data.let_statement);
         let def_info = self.context.def_interner.definition(global_data.definition_id);
-        if def_info.comptime {
-            return None;
-        }
 
         match statement {
             HirStatement::Let(binding) => {
+                // Skip comptime globals with non-identifier patterns (e.g. tuple
+                // destructuring) as they cannot be represented as named globals.
+                if def_info.comptime && !matches!(binding.pattern, HirPattern::Identifier(_)) {
+                    return None;
+                }
+
                 let name = self.fully_qualified_global_name(id);
                 let typ = self.generate_lean_type_value(&binding.r#type, None);
                 let expr = self.generate_expr(binding.expression);

--- a/stdlib/lampe/std-1.0.0-beta.12/Extracted/Compat.lean
+++ b/stdlib/lampe/std-1.0.0-beta.12/Extracted/Compat.lean
@@ -5,10 +5,12 @@ import Lampe
 
 open Lampe
 
+noir_global_def «std-1.0.0-beta.12»::compat::BN254_MODULUS_BE_BYTES: Slice<u8> = (#_mkSlice returning Slice<u8>)((48: u8), (100: u8), (78: u8), (114: u8), (225: u8), (49: u8), (160: u8), (41: u8), (184: u8), (80: u8), (69: u8), (182: u8), (129: u8), (129: u8), (88: u8), (93: u8), (40: u8), (51: u8), (232: u8), (72: u8), (121: u8), (185: u8), (112: u8), (145: u8), (67: u8), (225: u8), (245: u8), (147: u8), (240: u8), (0: u8), (0: u8), (1: u8));
+
 noir_def «std-1.0.0-beta.12»::compat::is_bn254<>() -> bool := {
   #_true
 }
 
 def «std-1.0.0-beta.12».Compat.env : Env := Env.mk
-  [«std-1.0.0-beta.12::compat::is_bn254»]
+  [«std-1.0.0-beta.12::compat::BN254_MODULUS_BE_BYTES», «std-1.0.0-beta.12::compat::is_bn254»]
   []

--- a/stdlib/lampe/std-1.0.0-beta.12/Extracted/Hash/Poseidon2.lean
+++ b/stdlib/lampe/std-1.0.0-beta.12/Extracted/Hash/Poseidon2.lean
@@ -5,6 +5,8 @@ import Lampe
 
 open Lampe
 
+noir_global_def «std-1.0.0-beta.12»::hash::poseidon2::RATE: u32 = (3: u32);
+
 noir_def «std-1.0.0-beta.12»::hash::poseidon2::Poseidon2::hash<N: u32>(input: Array<Field, N: u32>, message_size: u32) -> Field := {
   («std-1.0.0-beta.12»::hash::poseidon2::Poseidon2::hash_internal<N: u32> as λ(Array<Field, N: u32>, u32, bool) -> Field)(input, message_size, (#_uNeq returning bool)(message_size, uConst!(N: u32)))
 }
@@ -92,5 +94,5 @@ noir_trait_impl[«std-1.0.0-beta.12».impl_1]<> «std-1.0.0-beta.12»::default::
 }
 
 def «std-1.0.0-beta.12».Hash.Poseidon2.env : Env := Env.mk
-  [«std-1.0.0-beta.12::hash::poseidon2::Poseidon2::hash», «std-1.0.0-beta.12::hash::poseidon2::Poseidon2::new», «std-1.0.0-beta.12::hash::poseidon2::Poseidon2::perform_duplex», «std-1.0.0-beta.12::hash::poseidon2::Poseidon2::absorb», «std-1.0.0-beta.12::hash::poseidon2::Poseidon2::squeeze», «std-1.0.0-beta.12::hash::poseidon2::Poseidon2::hash_internal»]
+  [«std-1.0.0-beta.12::hash::poseidon2::RATE», «std-1.0.0-beta.12::hash::poseidon2::Poseidon2::hash», «std-1.0.0-beta.12::hash::poseidon2::Poseidon2::new», «std-1.0.0-beta.12::hash::poseidon2::Poseidon2::perform_duplex», «std-1.0.0-beta.12::hash::poseidon2::Poseidon2::absorb», «std-1.0.0-beta.12::hash::poseidon2::Poseidon2::squeeze», «std-1.0.0-beta.12::hash::poseidon2::Poseidon2::hash_internal»]
   [«std-1.0.0-beta.12».impl_0, «std-1.0.0-beta.12».impl_1]


### PR DESCRIPTION
Comptime globals like `RATE: u32 = 3` were unconditionally skipped,
but the extracted code still referenced them, leaving dangling symbols.

Now we extract comptime globals that bind a simple identifier.

Found while proving `Poseidon2`: `RATE` was missing from extraction
but referenced in `new`, `perform_duplex`, and `absorb`.