### PR TITLE
fix: Use the crate of the struct in `generate_constructor`

### DIFF
--- a/src/lean/generator.rs
+++ b/src/lean/generator.rs
@@ -24,138 +24,52 @@ use noirc_frontend::{
     },
     hir_def::{
         expr::{
-            HirArrayLiteral,
-            HirBlockExpression,
-            HirCallExpression,
-            HirCastExpression,
-            HirConstrainExpression,
-            HirConstructorExpression,
-            HirExpression,
-            HirIdent,
-            HirIfExpression,
-            HirIndexExpression,
-            HirInfixExpression,
-            HirLambda,
-            HirLiteral,
-            HirMemberAccess,
-            HirPrefixExpression,
+            HirArrayLiteral, HirBlockExpression, HirCallExpression, HirCastExpression,
+            HirConstrainExpression, HirConstructorExpression, HirExpression, HirIdent,
+            HirIfExpression, HirIndexExpression, HirInfixExpression, HirLambda, HirLiteral,
+            HirMemberAccess, HirPrefixExpression,
         },
         function::{FuncMeta, Param},
         stmt::{
-            HirAssignStatement,
-            HirForStatement,
-            HirLValue,
-            HirLetStatement,
-            HirPattern,
+            HirAssignStatement, HirForStatement, HirLValue, HirLetStatement, HirPattern,
             HirStatement,
         },
         traits::{NamedType, TraitConstraint, TraitImpl},
     },
     node_interner::{
-        DefinitionKind,
-        DependencyId,
-        ExprId,
-        FuncId,
-        GlobalId,
-        StmtId,
-        TraitId,
-        TraitImplId,
-        TypeAliasId,
-        TypeId,
+        DefinitionKind, DependencyId, ExprId, FuncId, GlobalId, StmtId, TraitId, TraitImplId,
+        TypeAliasId, TypeId,
     },
     shared::Signedness,
     token::{FunctionAttributeKind, SecondaryAttributeKind},
-    BinaryTypeOperator,
-    DataType,
-    Kind as NoirKind,
-    NamedGeneric,
-    QuotedType,
-    ResolvedGeneric,
-    Shared,
-    StructField,
-    Type as NoirType,
-    TypeBinding,
-    TypeBindings,
-    TypeVariable,
-    TypeVariableId,
+    BinaryTypeOperator, DataType, Kind as NoirKind, NamedGeneric, QuotedType, ResolvedGeneric,
+    Shared, StructField, Type as NoirType, TypeBinding, TypeBindings, TypeVariable, TypeVariableId,
 };
 use petgraph::data::DataMap;
 
 use crate::{
     constants::{
-        LAMPE_STRUCT_METHOD_SEPARATOR,
-        NOIR_PATH_SEPARATOR,
-        NONE_DEPENDENCY_VERSION,
-        STDLIB_TOML,
+        LAMPE_STRUCT_METHOD_SEPARATOR, NOIR_PATH_SEPARATOR, NONE_DEPENDENCY_VERSION, STDLIB_TOML,
     },
     file_generator::to_import_from_noir_path,
     lean::{
         ast::{
-            AssignStatement,
-            Block,
-            BuiltinCallRef,
-            BuiltinTag,
-            BuiltinTypeExpr,
-            Call,
-            Cast,
-            ConstGenericLiteral,
-            Crate,
-            DeclCallRef,
-            Deprecation,
-            Expression,
-            ForStatement,
-            FunctionDefinition,
-            GlobalCallRef,
-            GlobalDefinition,
-            IdentCallRef,
-            Identifier,
-            IfThenElse,
-            Kind,
-            LValue,
-            Lambda,
-            LetStatement,
-            Literal,
-            MemberAccess,
-            Module,
-            ModuleDefinition,
-            NumericLiteral,
-            ParamDef,
-            Pattern,
-            Statement,
-            StructDefinition,
-            StructPattern,
-            TraitCallRef,
-            TraitDefinition,
-            TraitImplementation,
-            TraitMethodDeclaration,
-            Type,
-            TypeAlias,
-            TypeArithOp,
-            TypeDefinition,
-            TypeExpr,
-            TypePattern,
-            WhereClause,
+            AssignStatement, Block, BuiltinCallRef, BuiltinTag, BuiltinTypeExpr, Call, Cast,
+            ConstGenericLiteral, Crate, DeclCallRef, Deprecation, Expression, ForStatement,
+            FunctionDefinition, GlobalCallRef, GlobalDefinition, IdentCallRef, Identifier,
+            IfThenElse, Kind, LValue, Lambda, LetStatement, Literal, MemberAccess, Module,
+            ModuleDefinition, NumericLiteral, ParamDef, Pattern, Statement, StructDefinition,
+            StructPattern, TraitCallRef, TraitDefinition, TraitImplementation,
+            TraitMethodDeclaration, Type, TypeAlias, TypeArithOp, TypeDefinition, TypeExpr,
+            TypePattern, WhereClause,
         },
         builtin::{
-            self,
-            make_bor,
-            make_ordering_const,
-            make_ordering_type,
-            BuiltinType,
-            ASSERT_BUILTIN_NAME,
-            MAKE_ARRAY_BUILTIN_NAME,
-            MAKE_EQUAL_NAME,
-            MAKE_GREATER_NAME,
-            MAKE_LESS_NAME,
-            MAKE_REPEATED_ARRAY_BUILTIN_NAME,
-            MAKE_REPEATED_SLICE_BUILTIN_NAME,
-            MAKE_SLICE_BUILTIN_NAME,
-            MAKE_STRUCT_BUILTIN_NAME,
-            UNIT_TYPE_NAME,
+            self, make_bor, make_ordering_const, make_ordering_type, BuiltinType,
+            ASSERT_BUILTIN_NAME, MAKE_ARRAY_BUILTIN_NAME, MAKE_EQUAL_NAME, MAKE_GREATER_NAME,
+            MAKE_LESS_NAME, MAKE_REPEATED_ARRAY_BUILTIN_NAME, MAKE_REPEATED_SLICE_BUILTIN_NAME,
+            MAKE_SLICE_BUILTIN_NAME, MAKE_STRUCT_BUILTIN_NAME, UNIT_TYPE_NAME,
         },
-        conflicts_with_lean_keyword,
-        LEAN_QUOTE_END,
-        LEAN_QUOTE_START,
+        conflicts_with_lean_keyword, LEAN_QUOTE_END, LEAN_QUOTE_START,
     },
 };
 
@@ -831,9 +745,9 @@ impl LeanGenerator<'_, '_, '_> {
             NoirKind::Any,
         );
         let dummy_generic = NoirType::NamedGeneric(NamedGeneric {
-            type_var:             dummy_tv.clone(),
-            name:                 Rc::new("LOOKUP_DUMMY".to_string()),
-            implicit:             false,
+            type_var: dummy_tv.clone(),
+            name: Rc::new("LOOKUP_DUMMY".to_string()),
+            implicit: false,
             original_type_var_id: None,
         });
 
@@ -910,9 +824,9 @@ impl LeanGenerator<'_, '_, '_> {
                         .iter()
                         .map(|g| {
                             NoirType::NamedGeneric(NamedGeneric {
-                                type_var:             g.type_var.clone(),
-                                name:                 g.name.clone(),
-                                implicit:             false,
+                                type_var: g.type_var.clone(),
+                                name: g.name.clone(),
+                                implicit: false,
                                 original_type_var_id: None,
                             })
                         })
@@ -1000,7 +914,7 @@ impl LeanGenerator<'_, '_, '_> {
         let functions = functions.into_iter().sorted().collect_vec();
 
         ModuleDefs {
-            func_defs:   functions,
+            func_defs: functions,
             global_defs: globals,
         }
     }
@@ -1086,7 +1000,7 @@ impl LeanGenerator<'_, '_, '_> {
         return_type: Type,
     ) -> Expression {
         let call_identifier = Expression::BuiltinCallRef(BuiltinCallRef {
-            name:        name.to_string(),
+            name: name.to_string(),
             return_type: return_type.clone(),
         });
         let params = params
@@ -1683,7 +1597,7 @@ impl LeanGenerator<'_, '_, '_> {
         let return_type = Type::tuple(&elem_types);
 
         let call_ref = Expression::BuiltinCallRef(BuiltinCallRef {
-            name:        MAKE_STRUCT_BUILTIN_NAME.to_string(),
+            name: MAKE_STRUCT_BUILTIN_NAME.to_string(),
             return_type: return_type.clone(),
         });
 
@@ -1704,7 +1618,7 @@ impl LeanGenerator<'_, '_, '_> {
         let else_expr = cond.alternative.map(|e| Box::new(self.generate_expr(e)));
 
         let ite = IfThenElse {
-            condition:   Box::new(if_cond),
+            condition: Box::new(if_cond),
             then_branch: Box::new(then_expr),
             else_branch: else_expr,
         };
@@ -1720,8 +1634,8 @@ impl LeanGenerator<'_, '_, '_> {
         let constraint_expr = self.generate_expr(constrain.0);
         let builtin_ref = Expression::builtin_call_ref(ASSERT_BUILTIN_NAME, output_type);
         let call = Call {
-            function:    Box::new(builtin_ref),
-            params:      vec![constraint_expr],
+            function: Box::new(builtin_ref),
+            params: vec![constraint_expr],
             return_type: output_type.clone(),
         };
 
@@ -1797,7 +1711,7 @@ impl LeanGenerator<'_, '_, '_> {
     pub fn generate_constructor(&self, constructor: &HirConstructorExpression) -> Expression {
         let struct_def = &constructor.r#type;
         let struct_def = struct_def.borrow();
-        let crate_id = self.root_crate;
+        let crate_id = struct_def.id.krate();
         let name = self.fully_qualified_struct_path(&crate_id, &struct_def.id);
         let fields = &constructor.fields;
 
@@ -1821,7 +1735,7 @@ impl LeanGenerator<'_, '_, '_> {
         let return_type = Type::data_type(&name, generic_args);
 
         let call_ref = Expression::BuiltinCallRef(BuiltinCallRef {
-            name:        MAKE_STRUCT_BUILTIN_NAME.to_string(),
+            name: MAKE_STRUCT_BUILTIN_NAME.to_string(),
             return_type: return_type.clone(),
         });
 
@@ -1864,32 +1778,32 @@ impl LeanGenerator<'_, '_, '_> {
                                 index_expr
                             } else {
                                 Expression::Cast(Cast {
-                                    lhs:    Box::new(index_expr),
+                                    lhs: Box::new(index_expr),
                                     target: Type::integer(32, false),
                                 })
                             }
                         }
                         _ => Expression::Cast(Cast {
-                            lhs:    Box::new(index_expr),
+                            lhs: Box::new(index_expr),
                             target: Type::integer(32, false),
                         }),
                     },
                     _ => Expression::Cast(Cast {
-                        lhs:    Box::new(index_expr),
+                        lhs: Box::new(index_expr),
                         target: Type::integer(32, false),
                     }),
                 },
                 _ => panic!("Non numeric literal {lit:?} encountered as index in index expression"),
             },
             _ => Expression::Cast(Cast {
-                lhs:    Box::new(index_expr),
+                lhs: Box::new(index_expr),
                 target: Type::integer(32, false),
             }),
         };
 
         let call = Call {
-            function:    Box::new(call_target),
-            params:      vec![collection_expr, index_expr],
+            function: Box::new(call_target),
+            params: vec![collection_expr, index_expr],
             return_type: output_type.clone(),
         };
 
@@ -1916,8 +1830,8 @@ impl LeanGenerator<'_, '_, '_> {
         if let Some(builtin_name) = maybe_builtin {
             let builtin_target = Expression::builtin_call_ref(builtin_name.as_str(), output_type);
             let call = Call {
-                function:    Box::new(builtin_target),
-                params:      vec![lhs, rhs],
+                function: Box::new(builtin_target),
+                params: vec![lhs, rhs],
                 return_type: output_type.clone(),
             };
             Expression::Call(call)
@@ -1972,12 +1886,12 @@ impl LeanGenerator<'_, '_, '_> {
                     });
 
                     let negation_call_ref = Expression::BuiltinCallRef(BuiltinCallRef {
-                        name:        "bNot".to_string(),
+                        name: "bNot".to_string(),
                         return_type: Type::bool(),
                     });
                     Expression::Call(Call {
-                        function:    Box::new(negation_call_ref),
-                        params:      vec![eq_call],
+                        function: Box::new(negation_call_ref),
+                        params: vec![eq_call],
                         return_type: Type::bool(),
                     })
                 }
@@ -2002,11 +1916,11 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let cmp_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let cmp_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(cmp_result_ident.clone()),
-                        typ:        ordering_type.clone(),
+                        pattern: Pattern::Identifier(cmp_result_ident.clone()),
+                        typ: ordering_type.clone(),
                         expression: Box::new(cmp_call),
                     });
 
@@ -2016,25 +1930,25 @@ impl LeanGenerator<'_, '_, '_> {
                     );
                     let make_less_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let make_less_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(make_less_result_ident.clone()),
-                        typ:        ordering_type.clone(),
+                        pattern: Pattern::Identifier(make_less_result_ident.clone()),
+                        typ: ordering_type.clone(),
                         expression: Box::new(make_less_call),
                     });
 
                     let eq_call = Expression::Call(Call {
-                        function:    Box::new(Expression::TraitCallRef(TraitCallRef {
-                            trait_name:     format!("{stdlib_name}::cmp::Eq"),
-                            function_name:  "eq".to_string(),
-                            self_type:      ordering_type.clone(),
+                        function: Box::new(Expression::TraitCallRef(TraitCallRef {
+                            trait_name: format!("{stdlib_name}::cmp::Eq"),
+                            function_name: "eq".to_string(),
+                            self_type: ordering_type.clone(),
                             trait_generics: vec![],
-                            fun_generics:   vec![],
-                            param_types:    vec![ordering_type.clone(), ordering_type.clone()],
-                            return_type:    Type::bool(),
+                            fun_generics: vec![],
+                            param_types: vec![ordering_type.clone(), ordering_type.clone()],
+                            return_type: Type::bool(),
                         })),
-                        params:      vec![
+                        params: vec![
                             Expression::Ident(cmp_result_ident),
                             Expression::Ident(make_less_result_ident),
                         ],
@@ -2067,11 +1981,11 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let cmp_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let cmp_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(cmp_result_ident.clone()),
-                        typ:        ordering_type.clone(),
+                        pattern: Pattern::Identifier(cmp_result_ident.clone()),
+                        typ: ordering_type.clone(),
                         expression: Box::new(cmp_call),
                     });
 
@@ -2081,25 +1995,25 @@ impl LeanGenerator<'_, '_, '_> {
                     );
                     let make_greater_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let make_greater_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(make_greater_result_ident.clone()),
-                        typ:        ordering_type.clone(),
+                        pattern: Pattern::Identifier(make_greater_result_ident.clone()),
+                        typ: ordering_type.clone(),
                         expression: Box::new(make_greater_call),
                     });
 
                     let eq_call = Expression::Call(Call {
-                        function:    Box::new(Expression::TraitCallRef(TraitCallRef {
-                            trait_name:     format!("{stdlib_name}::cmp::Eq"),
-                            function_name:  "eq".to_string(),
-                            self_type:      ordering_type.clone(),
+                        function: Box::new(Expression::TraitCallRef(TraitCallRef {
+                            trait_name: format!("{stdlib_name}::cmp::Eq"),
+                            function_name: "eq".to_string(),
+                            self_type: ordering_type.clone(),
                             trait_generics: vec![],
-                            fun_generics:   vec![],
-                            param_types:    vec![ordering_type.clone(), ordering_type.clone()],
-                            return_type:    Type::bool(),
+                            fun_generics: vec![],
+                            param_types: vec![ordering_type.clone(), ordering_type.clone()],
+                            return_type: Type::bool(),
                         })),
-                        params:      vec![
+                        params: vec![
                             Expression::Ident(cmp_result_ident),
                             Expression::Ident(make_greater_result_ident),
                         ],
@@ -2133,11 +2047,11 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let cmp_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let cmp_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(cmp_result_ident.clone()),
-                        typ:        ordering_type.clone(),
+                        pattern: Pattern::Identifier(cmp_result_ident.clone()),
+                        typ: ordering_type.clone(),
                         expression: Box::new(cmp_call),
                     });
 
@@ -2147,11 +2061,11 @@ impl LeanGenerator<'_, '_, '_> {
                     );
                     let make_less_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let make_less_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(make_less_result_ident.clone()),
-                        typ:        ordering_type.clone(),
+                        pattern: Pattern::Identifier(make_less_result_ident.clone()),
+                        typ: ordering_type.clone(),
                         expression: Box::new(make_less_call),
                     });
 
@@ -2161,25 +2075,25 @@ impl LeanGenerator<'_, '_, '_> {
                     );
                     let make_eq_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let make_eq_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(make_eq_result_ident.clone()),
-                        typ:        ordering_type.clone(),
+                        pattern: Pattern::Identifier(make_eq_result_ident.clone()),
+                        typ: ordering_type.clone(),
                         expression: Box::new(make_eq_call),
                     });
 
                     let eq_to_less_call = Expression::Call(Call {
-                        function:    Box::new(Expression::TraitCallRef(TraitCallRef {
-                            trait_name:     format!("{stdlib_name}::cmp::Eq"),
-                            function_name:  "eq".to_string(),
-                            self_type:      ordering_type.clone(),
+                        function: Box::new(Expression::TraitCallRef(TraitCallRef {
+                            trait_name: format!("{stdlib_name}::cmp::Eq"),
+                            function_name: "eq".to_string(),
+                            self_type: ordering_type.clone(),
                             trait_generics: vec![],
-                            fun_generics:   vec![],
-                            param_types:    vec![ordering_type.clone(), ordering_type.clone()],
-                            return_type:    Type::bool(),
+                            fun_generics: vec![],
+                            param_types: vec![ordering_type.clone(), ordering_type.clone()],
+                            return_type: Type::bool(),
                         })),
-                        params:      vec![
+                        params: vec![
                             Expression::Ident(cmp_result_ident.clone()),
                             Expression::Ident(make_less_result_ident),
                         ],
@@ -2187,25 +2101,25 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let eq_to_less_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let make_eq_to_less_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(eq_to_less_result_ident.clone()),
-                        typ:        Type::bool(),
+                        pattern: Pattern::Identifier(eq_to_less_result_ident.clone()),
+                        typ: Type::bool(),
                         expression: Box::new(eq_to_less_call),
                     });
 
                     let eq_to_eq_call = Expression::Call(Call {
-                        function:    Box::new(Expression::TraitCallRef(TraitCallRef {
-                            trait_name:     format!("{stdlib_name}::cmp::Eq"),
-                            function_name:  "eq".to_string(),
-                            self_type:      ordering_type.clone(),
+                        function: Box::new(Expression::TraitCallRef(TraitCallRef {
+                            trait_name: format!("{stdlib_name}::cmp::Eq"),
+                            function_name: "eq".to_string(),
+                            self_type: ordering_type.clone(),
                             trait_generics: vec![],
-                            fun_generics:   vec![],
-                            param_types:    vec![ordering_type.clone(), ordering_type.clone()],
-                            return_type:    Type::bool(),
+                            fun_generics: vec![],
+                            param_types: vec![ordering_type.clone(), ordering_type.clone()],
+                            return_type: Type::bool(),
                         })),
-                        params:      vec![
+                        params: vec![
                             Expression::Ident(cmp_result_ident.clone()),
                             Expression::Ident(make_eq_result_ident),
                         ],
@@ -2213,11 +2127,11 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let eq_to_eq_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let make_eq_to_eq_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(eq_to_eq_result_ident.clone()),
-                        typ:        Type::bool(),
+                        pattern: Pattern::Identifier(eq_to_eq_result_ident.clone()),
+                        typ: Type::bool(),
                         expression: Box::new(eq_to_eq_call),
                     });
 
@@ -2259,11 +2173,11 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let cmp_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let cmp_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(cmp_result_ident.clone()),
-                        typ:        ordering_type.clone(),
+                        pattern: Pattern::Identifier(cmp_result_ident.clone()),
+                        typ: ordering_type.clone(),
                         expression: Box::new(cmp_call),
                     });
 
@@ -2273,11 +2187,11 @@ impl LeanGenerator<'_, '_, '_> {
                     );
                     let make_greater_result_id = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let make_greater_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(make_greater_result_id.clone()),
-                        typ:        ordering_type.clone(),
+                        pattern: Pattern::Identifier(make_greater_result_id.clone()),
+                        typ: ordering_type.clone(),
                         expression: Box::new(make_greater_call),
                     });
 
@@ -2287,25 +2201,25 @@ impl LeanGenerator<'_, '_, '_> {
                     );
                     let make_eq_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let make_eq_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(make_eq_result_ident.clone()),
-                        typ:        ordering_type.clone(),
+                        pattern: Pattern::Identifier(make_eq_result_ident.clone()),
+                        typ: ordering_type.clone(),
                         expression: Box::new(make_eq_call),
                     });
 
                     let eq_to_greater_call = Expression::Call(Call {
-                        function:    Box::new(Expression::TraitCallRef(TraitCallRef {
-                            trait_name:     format!("{stdlib_name}::cmp::Eq"),
-                            function_name:  "eq".to_string(),
-                            self_type:      ordering_type.clone(),
+                        function: Box::new(Expression::TraitCallRef(TraitCallRef {
+                            trait_name: format!("{stdlib_name}::cmp::Eq"),
+                            function_name: "eq".to_string(),
+                            self_type: ordering_type.clone(),
                             trait_generics: vec![],
-                            fun_generics:   vec![],
-                            param_types:    vec![ordering_type.clone(), ordering_type.clone()],
-                            return_type:    Type::bool(),
+                            fun_generics: vec![],
+                            param_types: vec![ordering_type.clone(), ordering_type.clone()],
+                            return_type: Type::bool(),
                         })),
-                        params:      vec![
+                        params: vec![
                             Expression::Ident(cmp_result_ident.clone()),
                             Expression::Ident(make_greater_result_id),
                         ],
@@ -2313,25 +2227,25 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let eq_to_greater_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let make_eq_to_greater_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(eq_to_greater_result_ident.clone()),
-                        typ:        Type::bool(),
+                        pattern: Pattern::Identifier(eq_to_greater_result_ident.clone()),
+                        typ: Type::bool(),
                         expression: Box::new(eq_to_greater_call),
                     });
 
                     let eq_to_eq_call = Expression::Call(Call {
-                        function:    Box::new(Expression::TraitCallRef(TraitCallRef {
-                            trait_name:     format!("{stdlib_name}::cmp::Eq"),
-                            function_name:  "eq".to_string(),
-                            self_type:      ordering_type.clone(),
+                        function: Box::new(Expression::TraitCallRef(TraitCallRef {
+                            trait_name: format!("{stdlib_name}::cmp::Eq"),
+                            function_name: "eq".to_string(),
+                            self_type: ordering_type.clone(),
                             trait_generics: vec![],
-                            fun_generics:   vec![],
-                            param_types:    vec![ordering_type.clone(), ordering_type.clone()],
-                            return_type:    Type::bool(),
+                            fun_generics: vec![],
+                            param_types: vec![ordering_type.clone(), ordering_type.clone()],
+                            return_type: Type::bool(),
                         })),
-                        params:      vec![
+                        params: vec![
                             Expression::Ident(cmp_result_ident.clone()),
                             Expression::Ident(make_eq_result_ident),
                         ],
@@ -2339,11 +2253,11 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let eq_to_eq_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ:  ordering_type.clone(),
+                        typ: ordering_type.clone(),
                     };
                     let make_eq_to_eq_result = Statement::Let(LetStatement {
-                        pattern:    Pattern::Identifier(eq_to_eq_result_ident.clone()),
-                        typ:        Type::bool(),
+                        pattern: Pattern::Identifier(eq_to_eq_result_ident.clone()),
+                        typ: Type::bool(),
                         expression: Box::new(eq_to_eq_call),
                     });
 
@@ -2402,8 +2316,8 @@ impl LeanGenerator<'_, '_, '_> {
         {
             let builtin_target = Expression::builtin_call_ref(builtin_name.as_str(), output_type);
             let call = Call {
-                function:    Box::new(builtin_target),
-                params:      vec![rhs],
+                function: Box::new(builtin_target),
+                params: vec![rhs],
                 return_type: output_type.clone(),
             };
             Expression::Call(call)
@@ -2435,8 +2349,8 @@ impl LeanGenerator<'_, '_, '_> {
             };
 
             let call = Call {
-                function:    Box::new(Expression::TraitCallRef(call_target)),
-                params:      vec![rhs],
+                function: Box::new(Expression::TraitCallRef(call_target)),
+                params: vec![rhs],
                 return_type: output_type.clone(),
             };
 
@@ -2457,11 +2371,11 @@ impl LeanGenerator<'_, '_, '_> {
                 HirArrayLiteral::Standard(elems) => {
                     let elems = elems.iter().map(|e| self.generate_expr(*e)).collect_vec();
                     let call = Call {
-                        function:    Box::new(Expression::builtin_call_ref(
+                        function: Box::new(Expression::builtin_call_ref(
                             MAKE_ARRAY_BUILTIN_NAME,
                             output_type,
                         )),
-                        params:      elems,
+                        params: elems,
                         return_type: output_type.clone(),
                     };
                     Expression::Call(call)
@@ -2471,11 +2385,11 @@ impl LeanGenerator<'_, '_, '_> {
                 } => {
                     let elem_expr = self.generate_expr(*repeated_element);
                     let call = Call {
-                        function:    Box::new(Expression::builtin_call_ref(
+                        function: Box::new(Expression::builtin_call_ref(
                             MAKE_REPEATED_ARRAY_BUILTIN_NAME,
                             output_type,
                         )),
-                        params:      vec![elem_expr],
+                        params: vec![elem_expr],
                         return_type: output_type.clone(),
                     };
                     Expression::Call(call)
@@ -2485,11 +2399,11 @@ impl LeanGenerator<'_, '_, '_> {
                 HirArrayLiteral::Standard(elems) => {
                     let elems = elems.iter().map(|e| self.generate_expr(*e)).collect_vec();
                     let call = Call {
-                        function:    Box::new(Expression::builtin_call_ref(
+                        function: Box::new(Expression::builtin_call_ref(
                             MAKE_SLICE_BUILTIN_NAME,
                             output_type,
                         )),
-                        params:      elems,
+                        params: elems,
                         return_type: output_type.clone(),
                     };
                     Expression::Call(call)
@@ -2506,7 +2420,7 @@ impl LeanGenerator<'_, '_, '_> {
                     let length_lit = match length.expr {
                         TypeExpr::NumericConst(n) => Literal::Numeric(NumericLiteral {
                             value: n,
-                            typ:   length.kind.into_type(),
+                            typ: length.kind.into_type(),
                         }),
                         TypeExpr::TypeVariable(name) => {
                             Literal::ConstGeneric(ConstGenericLiteral {
@@ -2558,11 +2472,8 @@ impl LeanGenerator<'_, '_, '_> {
                 let all_vars = vec![template].into_iter().chain(vars).collect_vec();
 
                 let call = Call {
-                    function:    Box::new(Expression::builtin_call_ref(
-                        "mkFormatString",
-                        output_type,
-                    )),
-                    params:      all_vars,
+                    function: Box::new(Expression::builtin_call_ref("mkFormatString", output_type)),
+                    params: all_vars,
                     return_type: output_type.clone(),
                 };
                 Expression::Call(call)
@@ -2741,7 +2652,7 @@ impl LeanGenerator<'_, '_, '_> {
 
                 let global_call = GlobalCallRef {
                     name: global_name,
-                    typ:  global_type,
+                    typ: global_type,
                 };
 
                 Expression::GlobalCallRef(global_call)
@@ -2751,7 +2662,7 @@ impl LeanGenerator<'_, '_, '_> {
 
                 if let TypeExpr::Function(_) = &typ.expr {
                     let ident = IdentCallRef {
-                        name:      sanitize_variable_name(&name),
+                        name: sanitize_variable_name(&name),
                         func_type: typ.expr,
                     };
 
@@ -2759,7 +2670,7 @@ impl LeanGenerator<'_, '_, '_> {
                 } else {
                     let identifier = Identifier {
                         name: sanitize_variable_name(&name),
-                        typ:  output_type.clone(),
+                        typ: output_type.clone(),
                     };
 
                     Expression::Ident(identifier)
@@ -2890,7 +2801,7 @@ impl LeanGenerator<'_, '_, '_> {
         match lvalue {
             HirLValue::Ident(ident, typ) => LValue::Ident(Identifier {
                 name: self.context.def_interner.definition_name(ident.id).to_string(),
-                typ:  self.generate_lean_type_value(typ, None),
+                typ: self.generate_lean_type_value(typ, None),
             }),
             HirLValue::MemberAccess {
                 object,
@@ -3043,12 +2954,12 @@ impl LeanGenerator<'_, '_, '_> {
                         .iter()
                         .map(|t| self.substitute_bindings(t, bindings))
                         .collect(),
-                    named:   generics
+                    named: generics
                         .named
                         .iter()
                         .map(|t| NamedType {
                             name: t.name.clone(),
-                            typ:  self.substitute_bindings(&t.typ, bindings),
+                            typ: self.substitute_bindings(&t.typ, bindings),
                         })
                         .collect(),
                 },

--- a/src/lean/generator.rs
+++ b/src/lean/generator.rs
@@ -24,52 +24,138 @@ use noirc_frontend::{
     },
     hir_def::{
         expr::{
-            HirArrayLiteral, HirBlockExpression, HirCallExpression, HirCastExpression,
-            HirConstrainExpression, HirConstructorExpression, HirExpression, HirIdent,
-            HirIfExpression, HirIndexExpression, HirInfixExpression, HirLambda, HirLiteral,
-            HirMemberAccess, HirPrefixExpression,
+            HirArrayLiteral,
+            HirBlockExpression,
+            HirCallExpression,
+            HirCastExpression,
+            HirConstrainExpression,
+            HirConstructorExpression,
+            HirExpression,
+            HirIdent,
+            HirIfExpression,
+            HirIndexExpression,
+            HirInfixExpression,
+            HirLambda,
+            HirLiteral,
+            HirMemberAccess,
+            HirPrefixExpression,
         },
         function::{FuncMeta, Param},
         stmt::{
-            HirAssignStatement, HirForStatement, HirLValue, HirLetStatement, HirPattern,
+            HirAssignStatement,
+            HirForStatement,
+            HirLValue,
+            HirLetStatement,
+            HirPattern,
             HirStatement,
         },
         traits::{NamedType, TraitConstraint, TraitImpl},
     },
     node_interner::{
-        DefinitionKind, DependencyId, ExprId, FuncId, GlobalId, StmtId, TraitId, TraitImplId,
-        TypeAliasId, TypeId,
+        DefinitionKind,
+        DependencyId,
+        ExprId,
+        FuncId,
+        GlobalId,
+        StmtId,
+        TraitId,
+        TraitImplId,
+        TypeAliasId,
+        TypeId,
     },
     shared::Signedness,
     token::{FunctionAttributeKind, SecondaryAttributeKind},
-    BinaryTypeOperator, DataType, Kind as NoirKind, NamedGeneric, QuotedType, ResolvedGeneric,
-    Shared, StructField, Type as NoirType, TypeBinding, TypeBindings, TypeVariable, TypeVariableId,
+    BinaryTypeOperator,
+    DataType,
+    Kind as NoirKind,
+    NamedGeneric,
+    QuotedType,
+    ResolvedGeneric,
+    Shared,
+    StructField,
+    Type as NoirType,
+    TypeBinding,
+    TypeBindings,
+    TypeVariable,
+    TypeVariableId,
 };
 use petgraph::data::DataMap;
 
 use crate::{
     constants::{
-        LAMPE_STRUCT_METHOD_SEPARATOR, NOIR_PATH_SEPARATOR, NONE_DEPENDENCY_VERSION, STDLIB_TOML,
+        LAMPE_STRUCT_METHOD_SEPARATOR,
+        NOIR_PATH_SEPARATOR,
+        NONE_DEPENDENCY_VERSION,
+        STDLIB_TOML,
     },
     file_generator::to_import_from_noir_path,
     lean::{
         ast::{
-            AssignStatement, Block, BuiltinCallRef, BuiltinTag, BuiltinTypeExpr, Call, Cast,
-            ConstGenericLiteral, Crate, DeclCallRef, Deprecation, Expression, ForStatement,
-            FunctionDefinition, GlobalCallRef, GlobalDefinition, IdentCallRef, Identifier,
-            IfThenElse, Kind, LValue, Lambda, LetStatement, Literal, MemberAccess, Module,
-            ModuleDefinition, NumericLiteral, ParamDef, Pattern, Statement, StructDefinition,
-            StructPattern, TraitCallRef, TraitDefinition, TraitImplementation,
-            TraitMethodDeclaration, Type, TypeAlias, TypeArithOp, TypeDefinition, TypeExpr,
-            TypePattern, WhereClause,
+            AssignStatement,
+            Block,
+            BuiltinCallRef,
+            BuiltinTag,
+            BuiltinTypeExpr,
+            Call,
+            Cast,
+            ConstGenericLiteral,
+            Crate,
+            DeclCallRef,
+            Deprecation,
+            Expression,
+            ForStatement,
+            FunctionDefinition,
+            GlobalCallRef,
+            GlobalDefinition,
+            IdentCallRef,
+            Identifier,
+            IfThenElse,
+            Kind,
+            LValue,
+            Lambda,
+            LetStatement,
+            Literal,
+            MemberAccess,
+            Module,
+            ModuleDefinition,
+            NumericLiteral,
+            ParamDef,
+            Pattern,
+            Statement,
+            StructDefinition,
+            StructPattern,
+            TraitCallRef,
+            TraitDefinition,
+            TraitImplementation,
+            TraitMethodDeclaration,
+            Type,
+            TypeAlias,
+            TypeArithOp,
+            TypeDefinition,
+            TypeExpr,
+            TypePattern,
+            WhereClause,
         },
         builtin::{
-            self, make_bor, make_ordering_const, make_ordering_type, BuiltinType,
-            ASSERT_BUILTIN_NAME, MAKE_ARRAY_BUILTIN_NAME, MAKE_EQUAL_NAME, MAKE_GREATER_NAME,
-            MAKE_LESS_NAME, MAKE_REPEATED_ARRAY_BUILTIN_NAME, MAKE_REPEATED_SLICE_BUILTIN_NAME,
-            MAKE_SLICE_BUILTIN_NAME, MAKE_STRUCT_BUILTIN_NAME, UNIT_TYPE_NAME,
+            self,
+            make_bor,
+            make_ordering_const,
+            make_ordering_type,
+            BuiltinType,
+            ASSERT_BUILTIN_NAME,
+            MAKE_ARRAY_BUILTIN_NAME,
+            MAKE_EQUAL_NAME,
+            MAKE_GREATER_NAME,
+            MAKE_LESS_NAME,
+            MAKE_REPEATED_ARRAY_BUILTIN_NAME,
+            MAKE_REPEATED_SLICE_BUILTIN_NAME,
+            MAKE_SLICE_BUILTIN_NAME,
+            MAKE_STRUCT_BUILTIN_NAME,
+            UNIT_TYPE_NAME,
         },
-        conflicts_with_lean_keyword, LEAN_QUOTE_END, LEAN_QUOTE_START,
+        conflicts_with_lean_keyword,
+        LEAN_QUOTE_END,
+        LEAN_QUOTE_START,
     },
 };
 
@@ -745,9 +831,9 @@ impl LeanGenerator<'_, '_, '_> {
             NoirKind::Any,
         );
         let dummy_generic = NoirType::NamedGeneric(NamedGeneric {
-            type_var: dummy_tv.clone(),
-            name: Rc::new("LOOKUP_DUMMY".to_string()),
-            implicit: false,
+            type_var:             dummy_tv.clone(),
+            name:                 Rc::new("LOOKUP_DUMMY".to_string()),
+            implicit:             false,
             original_type_var_id: None,
         });
 
@@ -824,9 +910,9 @@ impl LeanGenerator<'_, '_, '_> {
                         .iter()
                         .map(|g| {
                             NoirType::NamedGeneric(NamedGeneric {
-                                type_var: g.type_var.clone(),
-                                name: g.name.clone(),
-                                implicit: false,
+                                type_var:             g.type_var.clone(),
+                                name:                 g.name.clone(),
+                                implicit:             false,
                                 original_type_var_id: None,
                             })
                         })
@@ -914,7 +1000,7 @@ impl LeanGenerator<'_, '_, '_> {
         let functions = functions.into_iter().sorted().collect_vec();
 
         ModuleDefs {
-            func_defs: functions,
+            func_defs:   functions,
             global_defs: globals,
         }
     }
@@ -1000,7 +1086,7 @@ impl LeanGenerator<'_, '_, '_> {
         return_type: Type,
     ) -> Expression {
         let call_identifier = Expression::BuiltinCallRef(BuiltinCallRef {
-            name: name.to_string(),
+            name:        name.to_string(),
             return_type: return_type.clone(),
         });
         let params = params
@@ -1597,7 +1683,7 @@ impl LeanGenerator<'_, '_, '_> {
         let return_type = Type::tuple(&elem_types);
 
         let call_ref = Expression::BuiltinCallRef(BuiltinCallRef {
-            name: MAKE_STRUCT_BUILTIN_NAME.to_string(),
+            name:        MAKE_STRUCT_BUILTIN_NAME.to_string(),
             return_type: return_type.clone(),
         });
 
@@ -1618,7 +1704,7 @@ impl LeanGenerator<'_, '_, '_> {
         let else_expr = cond.alternative.map(|e| Box::new(self.generate_expr(e)));
 
         let ite = IfThenElse {
-            condition: Box::new(if_cond),
+            condition:   Box::new(if_cond),
             then_branch: Box::new(then_expr),
             else_branch: else_expr,
         };
@@ -1634,8 +1720,8 @@ impl LeanGenerator<'_, '_, '_> {
         let constraint_expr = self.generate_expr(constrain.0);
         let builtin_ref = Expression::builtin_call_ref(ASSERT_BUILTIN_NAME, output_type);
         let call = Call {
-            function: Box::new(builtin_ref),
-            params: vec![constraint_expr],
+            function:    Box::new(builtin_ref),
+            params:      vec![constraint_expr],
             return_type: output_type.clone(),
         };
 
@@ -1735,7 +1821,7 @@ impl LeanGenerator<'_, '_, '_> {
         let return_type = Type::data_type(&name, generic_args);
 
         let call_ref = Expression::BuiltinCallRef(BuiltinCallRef {
-            name: MAKE_STRUCT_BUILTIN_NAME.to_string(),
+            name:        MAKE_STRUCT_BUILTIN_NAME.to_string(),
             return_type: return_type.clone(),
         });
 
@@ -1778,32 +1864,32 @@ impl LeanGenerator<'_, '_, '_> {
                                 index_expr
                             } else {
                                 Expression::Cast(Cast {
-                                    lhs: Box::new(index_expr),
+                                    lhs:    Box::new(index_expr),
                                     target: Type::integer(32, false),
                                 })
                             }
                         }
                         _ => Expression::Cast(Cast {
-                            lhs: Box::new(index_expr),
+                            lhs:    Box::new(index_expr),
                             target: Type::integer(32, false),
                         }),
                     },
                     _ => Expression::Cast(Cast {
-                        lhs: Box::new(index_expr),
+                        lhs:    Box::new(index_expr),
                         target: Type::integer(32, false),
                     }),
                 },
                 _ => panic!("Non numeric literal {lit:?} encountered as index in index expression"),
             },
             _ => Expression::Cast(Cast {
-                lhs: Box::new(index_expr),
+                lhs:    Box::new(index_expr),
                 target: Type::integer(32, false),
             }),
         };
 
         let call = Call {
-            function: Box::new(call_target),
-            params: vec![collection_expr, index_expr],
+            function:    Box::new(call_target),
+            params:      vec![collection_expr, index_expr],
             return_type: output_type.clone(),
         };
 
@@ -1830,8 +1916,8 @@ impl LeanGenerator<'_, '_, '_> {
         if let Some(builtin_name) = maybe_builtin {
             let builtin_target = Expression::builtin_call_ref(builtin_name.as_str(), output_type);
             let call = Call {
-                function: Box::new(builtin_target),
-                params: vec![lhs, rhs],
+                function:    Box::new(builtin_target),
+                params:      vec![lhs, rhs],
                 return_type: output_type.clone(),
             };
             Expression::Call(call)
@@ -1886,12 +1972,12 @@ impl LeanGenerator<'_, '_, '_> {
                     });
 
                     let negation_call_ref = Expression::BuiltinCallRef(BuiltinCallRef {
-                        name: "bNot".to_string(),
+                        name:        "bNot".to_string(),
                         return_type: Type::bool(),
                     });
                     Expression::Call(Call {
-                        function: Box::new(negation_call_ref),
-                        params: vec![eq_call],
+                        function:    Box::new(negation_call_ref),
+                        params:      vec![eq_call],
                         return_type: Type::bool(),
                     })
                 }
@@ -1916,11 +2002,11 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let cmp_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let cmp_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(cmp_result_ident.clone()),
-                        typ: ordering_type.clone(),
+                        pattern:    Pattern::Identifier(cmp_result_ident.clone()),
+                        typ:        ordering_type.clone(),
                         expression: Box::new(cmp_call),
                     });
 
@@ -1930,25 +2016,25 @@ impl LeanGenerator<'_, '_, '_> {
                     );
                     let make_less_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let make_less_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(make_less_result_ident.clone()),
-                        typ: ordering_type.clone(),
+                        pattern:    Pattern::Identifier(make_less_result_ident.clone()),
+                        typ:        ordering_type.clone(),
                         expression: Box::new(make_less_call),
                     });
 
                     let eq_call = Expression::Call(Call {
-                        function: Box::new(Expression::TraitCallRef(TraitCallRef {
-                            trait_name: format!("{stdlib_name}::cmp::Eq"),
-                            function_name: "eq".to_string(),
-                            self_type: ordering_type.clone(),
+                        function:    Box::new(Expression::TraitCallRef(TraitCallRef {
+                            trait_name:     format!("{stdlib_name}::cmp::Eq"),
+                            function_name:  "eq".to_string(),
+                            self_type:      ordering_type.clone(),
                             trait_generics: vec![],
-                            fun_generics: vec![],
-                            param_types: vec![ordering_type.clone(), ordering_type.clone()],
-                            return_type: Type::bool(),
+                            fun_generics:   vec![],
+                            param_types:    vec![ordering_type.clone(), ordering_type.clone()],
+                            return_type:    Type::bool(),
                         })),
-                        params: vec![
+                        params:      vec![
                             Expression::Ident(cmp_result_ident),
                             Expression::Ident(make_less_result_ident),
                         ],
@@ -1981,11 +2067,11 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let cmp_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let cmp_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(cmp_result_ident.clone()),
-                        typ: ordering_type.clone(),
+                        pattern:    Pattern::Identifier(cmp_result_ident.clone()),
+                        typ:        ordering_type.clone(),
                         expression: Box::new(cmp_call),
                     });
 
@@ -1995,25 +2081,25 @@ impl LeanGenerator<'_, '_, '_> {
                     );
                     let make_greater_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let make_greater_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(make_greater_result_ident.clone()),
-                        typ: ordering_type.clone(),
+                        pattern:    Pattern::Identifier(make_greater_result_ident.clone()),
+                        typ:        ordering_type.clone(),
                         expression: Box::new(make_greater_call),
                     });
 
                     let eq_call = Expression::Call(Call {
-                        function: Box::new(Expression::TraitCallRef(TraitCallRef {
-                            trait_name: format!("{stdlib_name}::cmp::Eq"),
-                            function_name: "eq".to_string(),
-                            self_type: ordering_type.clone(),
+                        function:    Box::new(Expression::TraitCallRef(TraitCallRef {
+                            trait_name:     format!("{stdlib_name}::cmp::Eq"),
+                            function_name:  "eq".to_string(),
+                            self_type:      ordering_type.clone(),
                             trait_generics: vec![],
-                            fun_generics: vec![],
-                            param_types: vec![ordering_type.clone(), ordering_type.clone()],
-                            return_type: Type::bool(),
+                            fun_generics:   vec![],
+                            param_types:    vec![ordering_type.clone(), ordering_type.clone()],
+                            return_type:    Type::bool(),
                         })),
-                        params: vec![
+                        params:      vec![
                             Expression::Ident(cmp_result_ident),
                             Expression::Ident(make_greater_result_ident),
                         ],
@@ -2047,11 +2133,11 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let cmp_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let cmp_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(cmp_result_ident.clone()),
-                        typ: ordering_type.clone(),
+                        pattern:    Pattern::Identifier(cmp_result_ident.clone()),
+                        typ:        ordering_type.clone(),
                         expression: Box::new(cmp_call),
                     });
 
@@ -2061,11 +2147,11 @@ impl LeanGenerator<'_, '_, '_> {
                     );
                     let make_less_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let make_less_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(make_less_result_ident.clone()),
-                        typ: ordering_type.clone(),
+                        pattern:    Pattern::Identifier(make_less_result_ident.clone()),
+                        typ:        ordering_type.clone(),
                         expression: Box::new(make_less_call),
                     });
 
@@ -2075,25 +2161,25 @@ impl LeanGenerator<'_, '_, '_> {
                     );
                     let make_eq_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let make_eq_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(make_eq_result_ident.clone()),
-                        typ: ordering_type.clone(),
+                        pattern:    Pattern::Identifier(make_eq_result_ident.clone()),
+                        typ:        ordering_type.clone(),
                         expression: Box::new(make_eq_call),
                     });
 
                     let eq_to_less_call = Expression::Call(Call {
-                        function: Box::new(Expression::TraitCallRef(TraitCallRef {
-                            trait_name: format!("{stdlib_name}::cmp::Eq"),
-                            function_name: "eq".to_string(),
-                            self_type: ordering_type.clone(),
+                        function:    Box::new(Expression::TraitCallRef(TraitCallRef {
+                            trait_name:     format!("{stdlib_name}::cmp::Eq"),
+                            function_name:  "eq".to_string(),
+                            self_type:      ordering_type.clone(),
                             trait_generics: vec![],
-                            fun_generics: vec![],
-                            param_types: vec![ordering_type.clone(), ordering_type.clone()],
-                            return_type: Type::bool(),
+                            fun_generics:   vec![],
+                            param_types:    vec![ordering_type.clone(), ordering_type.clone()],
+                            return_type:    Type::bool(),
                         })),
-                        params: vec![
+                        params:      vec![
                             Expression::Ident(cmp_result_ident.clone()),
                             Expression::Ident(make_less_result_ident),
                         ],
@@ -2101,25 +2187,25 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let eq_to_less_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let make_eq_to_less_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(eq_to_less_result_ident.clone()),
-                        typ: Type::bool(),
+                        pattern:    Pattern::Identifier(eq_to_less_result_ident.clone()),
+                        typ:        Type::bool(),
                         expression: Box::new(eq_to_less_call),
                     });
 
                     let eq_to_eq_call = Expression::Call(Call {
-                        function: Box::new(Expression::TraitCallRef(TraitCallRef {
-                            trait_name: format!("{stdlib_name}::cmp::Eq"),
-                            function_name: "eq".to_string(),
-                            self_type: ordering_type.clone(),
+                        function:    Box::new(Expression::TraitCallRef(TraitCallRef {
+                            trait_name:     format!("{stdlib_name}::cmp::Eq"),
+                            function_name:  "eq".to_string(),
+                            self_type:      ordering_type.clone(),
                             trait_generics: vec![],
-                            fun_generics: vec![],
-                            param_types: vec![ordering_type.clone(), ordering_type.clone()],
-                            return_type: Type::bool(),
+                            fun_generics:   vec![],
+                            param_types:    vec![ordering_type.clone(), ordering_type.clone()],
+                            return_type:    Type::bool(),
                         })),
-                        params: vec![
+                        params:      vec![
                             Expression::Ident(cmp_result_ident.clone()),
                             Expression::Ident(make_eq_result_ident),
                         ],
@@ -2127,11 +2213,11 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let eq_to_eq_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let make_eq_to_eq_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(eq_to_eq_result_ident.clone()),
-                        typ: Type::bool(),
+                        pattern:    Pattern::Identifier(eq_to_eq_result_ident.clone()),
+                        typ:        Type::bool(),
                         expression: Box::new(eq_to_eq_call),
                     });
 
@@ -2173,11 +2259,11 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let cmp_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let cmp_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(cmp_result_ident.clone()),
-                        typ: ordering_type.clone(),
+                        pattern:    Pattern::Identifier(cmp_result_ident.clone()),
+                        typ:        ordering_type.clone(),
                         expression: Box::new(cmp_call),
                     });
 
@@ -2187,11 +2273,11 @@ impl LeanGenerator<'_, '_, '_> {
                     );
                     let make_greater_result_id = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let make_greater_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(make_greater_result_id.clone()),
-                        typ: ordering_type.clone(),
+                        pattern:    Pattern::Identifier(make_greater_result_id.clone()),
+                        typ:        ordering_type.clone(),
                         expression: Box::new(make_greater_call),
                     });
 
@@ -2201,25 +2287,25 @@ impl LeanGenerator<'_, '_, '_> {
                     );
                     let make_eq_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let make_eq_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(make_eq_result_ident.clone()),
-                        typ: ordering_type.clone(),
+                        pattern:    Pattern::Identifier(make_eq_result_ident.clone()),
+                        typ:        ordering_type.clone(),
                         expression: Box::new(make_eq_call),
                     });
 
                     let eq_to_greater_call = Expression::Call(Call {
-                        function: Box::new(Expression::TraitCallRef(TraitCallRef {
-                            trait_name: format!("{stdlib_name}::cmp::Eq"),
-                            function_name: "eq".to_string(),
-                            self_type: ordering_type.clone(),
+                        function:    Box::new(Expression::TraitCallRef(TraitCallRef {
+                            trait_name:     format!("{stdlib_name}::cmp::Eq"),
+                            function_name:  "eq".to_string(),
+                            self_type:      ordering_type.clone(),
                             trait_generics: vec![],
-                            fun_generics: vec![],
-                            param_types: vec![ordering_type.clone(), ordering_type.clone()],
-                            return_type: Type::bool(),
+                            fun_generics:   vec![],
+                            param_types:    vec![ordering_type.clone(), ordering_type.clone()],
+                            return_type:    Type::bool(),
                         })),
-                        params: vec![
+                        params:      vec![
                             Expression::Ident(cmp_result_ident.clone()),
                             Expression::Ident(make_greater_result_id),
                         ],
@@ -2227,25 +2313,25 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let eq_to_greater_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let make_eq_to_greater_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(eq_to_greater_result_ident.clone()),
-                        typ: Type::bool(),
+                        pattern:    Pattern::Identifier(eq_to_greater_result_ident.clone()),
+                        typ:        Type::bool(),
                         expression: Box::new(eq_to_greater_call),
                     });
 
                     let eq_to_eq_call = Expression::Call(Call {
-                        function: Box::new(Expression::TraitCallRef(TraitCallRef {
-                            trait_name: format!("{stdlib_name}::cmp::Eq"),
-                            function_name: "eq".to_string(),
-                            self_type: ordering_type.clone(),
+                        function:    Box::new(Expression::TraitCallRef(TraitCallRef {
+                            trait_name:     format!("{stdlib_name}::cmp::Eq"),
+                            function_name:  "eq".to_string(),
+                            self_type:      ordering_type.clone(),
                             trait_generics: vec![],
-                            fun_generics: vec![],
-                            param_types: vec![ordering_type.clone(), ordering_type.clone()],
-                            return_type: Type::bool(),
+                            fun_generics:   vec![],
+                            param_types:    vec![ordering_type.clone(), ordering_type.clone()],
+                            return_type:    Type::bool(),
                         })),
-                        params: vec![
+                        params:      vec![
                             Expression::Ident(cmp_result_ident.clone()),
                             Expression::Ident(make_eq_result_ident),
                         ],
@@ -2253,11 +2339,11 @@ impl LeanGenerator<'_, '_, '_> {
                     });
                     let eq_to_eq_result_ident = Identifier {
                         name: self.name_supply.get_name(),
-                        typ: ordering_type.clone(),
+                        typ:  ordering_type.clone(),
                     };
                     let make_eq_to_eq_result = Statement::Let(LetStatement {
-                        pattern: Pattern::Identifier(eq_to_eq_result_ident.clone()),
-                        typ: Type::bool(),
+                        pattern:    Pattern::Identifier(eq_to_eq_result_ident.clone()),
+                        typ:        Type::bool(),
                         expression: Box::new(eq_to_eq_call),
                     });
 
@@ -2316,8 +2402,8 @@ impl LeanGenerator<'_, '_, '_> {
         {
             let builtin_target = Expression::builtin_call_ref(builtin_name.as_str(), output_type);
             let call = Call {
-                function: Box::new(builtin_target),
-                params: vec![rhs],
+                function:    Box::new(builtin_target),
+                params:      vec![rhs],
                 return_type: output_type.clone(),
             };
             Expression::Call(call)
@@ -2349,8 +2435,8 @@ impl LeanGenerator<'_, '_, '_> {
             };
 
             let call = Call {
-                function: Box::new(Expression::TraitCallRef(call_target)),
-                params: vec![rhs],
+                function:    Box::new(Expression::TraitCallRef(call_target)),
+                params:      vec![rhs],
                 return_type: output_type.clone(),
             };
 
@@ -2371,11 +2457,11 @@ impl LeanGenerator<'_, '_, '_> {
                 HirArrayLiteral::Standard(elems) => {
                     let elems = elems.iter().map(|e| self.generate_expr(*e)).collect_vec();
                     let call = Call {
-                        function: Box::new(Expression::builtin_call_ref(
+                        function:    Box::new(Expression::builtin_call_ref(
                             MAKE_ARRAY_BUILTIN_NAME,
                             output_type,
                         )),
-                        params: elems,
+                        params:      elems,
                         return_type: output_type.clone(),
                     };
                     Expression::Call(call)
@@ -2385,11 +2471,11 @@ impl LeanGenerator<'_, '_, '_> {
                 } => {
                     let elem_expr = self.generate_expr(*repeated_element);
                     let call = Call {
-                        function: Box::new(Expression::builtin_call_ref(
+                        function:    Box::new(Expression::builtin_call_ref(
                             MAKE_REPEATED_ARRAY_BUILTIN_NAME,
                             output_type,
                         )),
-                        params: vec![elem_expr],
+                        params:      vec![elem_expr],
                         return_type: output_type.clone(),
                     };
                     Expression::Call(call)
@@ -2399,11 +2485,11 @@ impl LeanGenerator<'_, '_, '_> {
                 HirArrayLiteral::Standard(elems) => {
                     let elems = elems.iter().map(|e| self.generate_expr(*e)).collect_vec();
                     let call = Call {
-                        function: Box::new(Expression::builtin_call_ref(
+                        function:    Box::new(Expression::builtin_call_ref(
                             MAKE_SLICE_BUILTIN_NAME,
                             output_type,
                         )),
-                        params: elems,
+                        params:      elems,
                         return_type: output_type.clone(),
                     };
                     Expression::Call(call)
@@ -2420,7 +2506,7 @@ impl LeanGenerator<'_, '_, '_> {
                     let length_lit = match length.expr {
                         TypeExpr::NumericConst(n) => Literal::Numeric(NumericLiteral {
                             value: n,
-                            typ: length.kind.into_type(),
+                            typ:   length.kind.into_type(),
                         }),
                         TypeExpr::TypeVariable(name) => {
                             Literal::ConstGeneric(ConstGenericLiteral {
@@ -2472,8 +2558,11 @@ impl LeanGenerator<'_, '_, '_> {
                 let all_vars = vec![template].into_iter().chain(vars).collect_vec();
 
                 let call = Call {
-                    function: Box::new(Expression::builtin_call_ref("mkFormatString", output_type)),
-                    params: all_vars,
+                    function:    Box::new(Expression::builtin_call_ref(
+                        "mkFormatString",
+                        output_type,
+                    )),
+                    params:      all_vars,
                     return_type: output_type.clone(),
                 };
                 Expression::Call(call)
@@ -2652,7 +2741,7 @@ impl LeanGenerator<'_, '_, '_> {
 
                 let global_call = GlobalCallRef {
                     name: global_name,
-                    typ: global_type,
+                    typ:  global_type,
                 };
 
                 Expression::GlobalCallRef(global_call)
@@ -2662,7 +2751,7 @@ impl LeanGenerator<'_, '_, '_> {
 
                 if let TypeExpr::Function(_) = &typ.expr {
                     let ident = IdentCallRef {
-                        name: sanitize_variable_name(&name),
+                        name:      sanitize_variable_name(&name),
                         func_type: typ.expr,
                     };
 
@@ -2670,7 +2759,7 @@ impl LeanGenerator<'_, '_, '_> {
                 } else {
                     let identifier = Identifier {
                         name: sanitize_variable_name(&name),
-                        typ: output_type.clone(),
+                        typ:  output_type.clone(),
                     };
 
                     Expression::Ident(identifier)
@@ -2801,7 +2890,7 @@ impl LeanGenerator<'_, '_, '_> {
         match lvalue {
             HirLValue::Ident(ident, typ) => LValue::Ident(Identifier {
                 name: self.context.def_interner.definition_name(ident.id).to_string(),
-                typ: self.generate_lean_type_value(typ, None),
+                typ:  self.generate_lean_type_value(typ, None),
             }),
             HirLValue::MemberAccess {
                 object,
@@ -2954,12 +3043,12 @@ impl LeanGenerator<'_, '_, '_> {
                         .iter()
                         .map(|t| self.substitute_bindings(t, bindings))
                         .collect(),
-                    named: generics
+                    named:   generics
                         .named
                         .iter()
                         .map(|t| NamedType {
                             name: t.name.clone(),
-                            typ: self.substitute_bindings(&t.typ, bindings),
+                            typ:  self.substitute_bindings(&t.typ, bindings),
                         })
                         .collect(),
                 },

--- a/testing/TestDep/lampe/TestDep-0.0.0/Extracted/Main.lean
+++ b/testing/TestDep/lampe/TestDep-0.0.0/Extracted/Main.lean
@@ -5,6 +5,10 @@ import Lampe
 
 open Lampe
 
+noir_def «TestDep-0.0.0»::make_point<>(x: Field, y: Field) -> «LocalDep-0.0.0»::Point<> := {
+  (#_makeData returning «TestDep-0.0.0»::local_dependency::Point<>)(x, y)
+}
+
 noir_def «TestDep-0.0.0»::main<>(x: Field, y: Field) -> Unit := {
   (#_assert returning Unit)((#_fNeq returning bool)(x, y));
   #_skip
@@ -16,5 +20,5 @@ noir_def «TestDep-0.0.0»::test_main<>() -> Unit := {
 }
 
 def «TestDep-0.0.0».Main.env : Env := Env.mk
-  [«TestDep-0.0.0::main», «TestDep-0.0.0::test_main»]
+  [«TestDep-0.0.0::make_point», «TestDep-0.0.0::main», «TestDep-0.0.0::test_main»]
   []

--- a/testing/TestDep/lampe/TestDep-0.0.0/Extracted/Main.lean
+++ b/testing/TestDep/lampe/TestDep-0.0.0/Extracted/Main.lean
@@ -6,7 +6,7 @@ import Lampe
 open Lampe
 
 noir_def «TestDep-0.0.0»::make_point<>(x: Field, y: Field) -> «LocalDep-0.0.0»::Point<> := {
-  (#_makeData returning «TestDep-0.0.0»::local_dependency::Point<>)(x, y)
+  (#_makeData returning «LocalDep-0.0.0»::Point<>)(x, y)
 }
 
 noir_def «TestDep-0.0.0»::main<>(x: Field, y: Field) -> Unit := {

--- a/testing/TestDep/lampe/deps/LocalDep-0.0.0/lampe/LocalDep-0.0.0/Extracted/GeneratedTypes.lean
+++ b/testing/TestDep/lampe/deps/LocalDep-0.0.0/lampe/LocalDep-0.0.0/Extracted/GeneratedTypes.lean
@@ -5,3 +5,8 @@ import Lampe
 
 open Lampe
 
+noir_struct_def «LocalDep-0.0.0»::Point<> {
+  Field,
+  Field,
+}
+

--- a/testing/TestDep/src/main.nr
+++ b/testing/TestDep/src/main.nr
@@ -1,3 +1,9 @@
+use local_dependency::Point;
+
+fn make_point(x: Field, y: Field) -> Point {
+    Point { x, y }
+}
+
 fn main(x: Field, y: pub Field) {
     assert(x != y);
 }

--- a/testing/TestDep/testing/LocalDep/src/lib.nr
+++ b/testing/TestDep/testing/LocalDep/src/lib.nr
@@ -1,3 +1,8 @@
+pub struct Point {
+    pub x: Field,
+    pub y: Field,
+}
+
 fn not_equal(x: Field, y: Field) -> bool {
     x != y
 }


### PR DESCRIPTION
Fixes https://github.com/reilabs/lampe/issues/255

Updated `TestDep` to have an example of this. When I first ran `./testing/test.xsh --test TestDep --update` to establish the baseline it was okay, but on subsequent commits failed with `git`, so I updated `Main.lean` manually 🤞 
