### PR TITLE
probe: slash-branch fork PR without rewrite and without lake-packages cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -347,6 +347,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/lake-packages"
           echo "LAKE_PKG_DIR=$RUNNER_TEMP/lake-packages" >> "$GITHUB_ENV"
       - name: Restore Lake Packages Cache
+        if: ${{ false }}
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.LAKE_PKG_DIR }}

--- a/README.md
+++ b/README.md
@@ -109,3 +109,4 @@ to this repository, please take a look at our [contributing](./docs/CONTRIBUTING
 It provides an overview of how to get up and running, as well as what the contribution process looks
 like for this repository.
 
+<!-- Fork CI slash baseline no-cache probe -->


### PR DESCRIPTION
Fork repro with a slash branch name and E2E lake-packages cache disabled to expose the branch-name dependency bug.