### PR TITLE
ci: fix fork GitDepWithLampe handling and stdlib cache production

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -306,9 +306,18 @@ jobs:
         run: chmod +x target/release/lampe
       - name: Test Stdlib Extraction
         if: ${{ steps.stdlib-build-cache.outputs.cache-hit != 'true' }}
-        env:
-          LAMPE_EXPORT_BUILD_CACHE: "1"
         run: ./stdlib/test.xsh
+      - name: Point Stdlib Lake Packages At Shared Cache
+        if: ${{ steps.stdlib-build-cache.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p stdlib/lampe/.lake
+          rm -rf stdlib/lampe/.lake/packages
+          ln -s "$LAKE_PKG_DIR" stdlib/lampe/.lake/packages
+      - name: Build Stdlib In Place
+        if: ${{ steps.stdlib-build-cache.outputs.cache-hit != 'true' }}
+        run: |
+          cd stdlib/lampe
+          lake build
       - name: Check Lake Packages Cache Contents
         id: lake-packages-content
         if: ${{ steps.stdlib-build-cache.outputs.cache-hit != 'true' && steps.lake-packages-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -234,7 +234,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI_IMAGE: ghcr.io/reilabs/lampe-ci:${{ needs.build-ci-image.outputs.image_tag }}
-      LAMPE_TEST_CURRENT_COMMIT_SHA: ${{ github.head_ref || github.ref_name }}
       LAMPE_KEEP_LAKE_CACHE: "1"
     container:
       image: ghcr.io/reilabs/lampe-ci:${{ needs.build-ci-image.outputs.image_tag }}
@@ -332,7 +331,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI_IMAGE: ghcr.io/reilabs/lampe-ci:${{ needs.build-ci-image.outputs.image_tag }}
-      LAMPE_TEST_CURRENT_COMMIT_SHA: ${{ github.head_ref || github.ref_name }}
       LAMPE_KEEP_LAKE_CACHE: "1"
     container:
       image: ghcr.io/reilabs/lampe-ci:${{ needs.build-ci-image.outputs.image_tag }}

--- a/scripts/test.xsh
+++ b/scripts/test.xsh
@@ -143,9 +143,6 @@ def run_tests(dir):
 
     selected_test = args.test or ""
     update_mode = args.update
-    if 'LAMPE_TEST_CURRENT_COMMIT_SHA' not in ${...}:
-        $LAMPE_TEST_CURRENT_COMMIT_SHA=$(git rev-parse HEAD)
-
     ensure_cli()
 
     if selected_test == "":
@@ -309,9 +306,6 @@ def run_test_in_dir(working_dir, original_dir, update_mode):
                 set_manifest_packages_dir(manifest_path, packages_dir)
                 change_manifest_required_dep_to_path_by_regex(manifest_path, '^Lampe$', lampe_path)
                 change_manifest_required_dep_to_path_by_regex(manifest_path, '^«std-.*»$', stdlib_path)
-
-            rev = $LAMPE_TEST_CURRENT_COMMIT_SHA
-            change_toml_required_dep_to_rev_by_regex(lakefile_path, '^GitDepWithLampe-.*$', rev)
 
         build_lake(lampe_dir)
         cleanup_ci_lake_build(lampe_dir)

--- a/scripts/utils.xsh
+++ b/scripts/utils.xsh
@@ -92,28 +92,10 @@ def change_required_dep_to_path_by_regex(toml, name_regex, path):
 
     return toml
 
-def change_required_dep_to_rev_by_regex(toml, name_regex, rev):
-    compiled_name_regex = re.compile(name_regex)
-
-    for i, v in enumerate(toml['require']):
-        if not compiled_name_regex.match(v['name']):
-                continue
-
-        v['rev'] = rev
-
-    return toml
-
 def change_toml_required_dep_to_path_by_regex(toml_path, name_regex, path):
     lakefile_toml = load_toml(toml_path)
 
     change_required_dep_to_path_by_regex(lakefile_toml, name_regex, path)
-
-    write_toml(toml_path, lakefile_toml)
-
-def change_toml_required_dep_to_rev_by_regex(toml_path, name_regex, rev):
-    lakefile_toml = load_toml(toml_path)
-
-    change_required_dep_to_rev_by_regex(lakefile_toml, name_regex, rev)
 
     write_toml(toml_path, lakefile_toml)
 


### PR DESCRIPTION
## summary
- stop rewriting `GitDepWithLampe-*` revisions in extracted lakefiles during CI
- build stdlib in place before saving its build cache

## why
the existing CI test harness rewrites `GitDepWithLampe-*` requirements to the current branch/ref. That breaks fork PRs because the generated lakefile still points at `https://github.com/reilabs/lampe` while the branch name only exists in the fork.

the stdlib cache was also being produced by copying `.lake/build` out of a temp extraction run. This changes CI to validate extraction first, then produce the reusable stdlib cache from an in-place `stdlib/lampe` build using the shared Lake package cache.

## validation
- fork behavior validated on a private fork before opening this PR
- stdlib cache behavior validated on a private probe repo before opening this PR