### PR TITLE
Formalize `sha256_compression` builtin + stdlib spec + FIPS 180-2 reference

### DIFF
--- a/Lampe/Lampe.lean
+++ b/Lampe/Lampe.lean
@@ -9,6 +9,7 @@ import Lampe.Builtin.Cmp
 import Lampe.Builtin.Crypto.Ecdsa
 import Lampe.Builtin.Crypto.EmbeddedCurve
 import Lampe.Builtin.Crypto.Hash
+import Lampe.Builtin.Crypto.Sha256
 import Lampe.Builtin.Field
 import Lampe.Builtin.Lens
 import Lampe.Builtin.Memory
@@ -26,6 +27,7 @@ import Lampe.Crypto.Secp256k1
 import Lampe.Crypto.Secp256k1.Prime
 import Lampe.Crypto.Secp256r1
 import Lampe.Crypto.Secp256r1.Prime
+import Lampe.Crypto.Sha256
 import Lampe.Data.Digits
 import Lampe.Data.Field
 import Lampe.Data.HList

--- a/Lampe/Lampe/Builtin/Crypto/Sha256.lean
+++ b/Lampe/Lampe/Builtin/Crypto/Sha256.lean
@@ -17,12 +17,6 @@ multiple blocks — this builtin only updates the chaining state by
 absorbing a single pre-parsed message block.
 
 Modeled by the concrete `Crypto.Sha256.compressOne`.
-
-Noir's `std-1.0.0-beta.14` does not currently wrap
-`__sha256_compression` in a separate stdlib helper (in contrast to
-`__blake3` and `__keccakf1600`, which do have wrapper functions to
-spec against). Downstream Lampe proofs reason about this builtin
-directly.
 -/
 def sha256Compression := newTotalPureBuiltin
   ⟨[(Tp.u 32).array (8 : U 32), (Tp.u 32).array (16 : U 32)],

--- a/Lampe/Lampe/Builtin/Crypto/Sha256.lean
+++ b/Lampe/Lampe/Builtin/Crypto/Sha256.lean
@@ -1,0 +1,32 @@
+import Lampe.Builtin.Basic
+import Lampe.Crypto.Sha256
+import Lampe.Data.HList
+import Lampe.Data.Field
+
+namespace Lampe.Builtin
+
+/--
+Noir's `__sha256_compression` foreign builtin.
+
+Signature: `(state: [u32; 8], msg: [u32; 16]) → [u32; 8]`.
+
+Semantics: one round of the SHA-256 compression function `F`
+(FIPS 180-4 Section 6.2.2). The caller is responsible for SHA-256
+padding, length encoding, IV initialisation, and chaining across
+multiple blocks — this builtin only updates the chaining state by
+absorbing a single pre-parsed message block.
+
+Modeled by the concrete `Crypto.Sha256.compressOne`.
+
+Noir's `std-1.0.0-beta.14` does not currently wrap
+`__sha256_compression` in a separate stdlib helper (in contrast to
+`__blake3` and `__keccakf1600`, which do have wrapper functions to
+spec against). Downstream Lampe proofs reason about this builtin
+directly.
+-/
+def sha256Compression := newTotalPureBuiltin
+  ⟨[(Tp.u 32).array (8 : U 32), (Tp.u 32).array (16 : U 32)],
+   (Tp.u 32).array (8 : U 32)⟩
+  (fun h![state, msg] => Crypto.Sha256.compressOne state msg)
+
+end Lampe.Builtin

--- a/Lampe/Lampe/Builtin/Stubs.lean
+++ b/Lampe/Lampe/Builtin/Stubs.lean
@@ -41,7 +41,6 @@ def fmtstrAsCtstring := stub
 def keccakf1600 := stub
 def mkFormatString := stub
 def recursiveAggregation := stub
-def sha256Compression := stub
 def sliceRefcount := stub
 def strAsCtstring := stub
 

--- a/Lampe/Lampe/Crypto/Sha256.lean
+++ b/Lampe/Lampe/Crypto/Sha256.lean
@@ -1,0 +1,291 @@
+import Lampe.Tp
+
+/-!
+# SHA-256 compression — concrete reference semantics
+
+A computable Lean 4 implementation of one round of the SHA-256
+compression function `F` as defined in FIPS 180-4 Section 6.2.2. This
+is *not* the full SHA-256 hash: there is no padding, no length
+encoding, no initial-value injection. The function takes a chaining
+state `H` of 8 u32 words and a pre-parsed 64-byte message block as 16
+u32 big-endian words, and returns the updated chaining state.
+
+This is precisely the shape that Noir's `__sha256_compression`
+foreign builtin exposes.
+
+References:
+- FIPS 180-4, "Secure Hash Standard":
+  https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
+  - §4.1.2 Ch / Maj / Σ_{0,1} / σ_{0,1} definitions for SHA-256
+  - §4.2.2 K[0..63] round constants
+  - §5.3.3 Initial hash value H(0)
+  - §6.2.2 Hash computation (the compression we implement)
+
+Validation: see test vectors at the bottom. They are copied verbatim
+from FIPS 180-2 "Secure Hash Standard" Appendix B — both the single-
+block "abc" example (B.1) and the two-block
+"abcdbcdec...mnopnopq" example (B.2), the latter giving us a
+non-trivial intermediate compression-state target H^(1) as well as the
+final hash H^(2).
+
+  https://csrc.nist.gov/csrc/media/publications/fips/180/2/archive/
+  2002-08-01/documents/fips180-2.pdf
+-/
+
+namespace Lampe.Crypto.Sha256
+
+/-! ### Constants -/
+
+/-- FIPS 180-4 §4.2.2: the 64 round constants K[0..63]. Each is the
+first 32 bits of the fractional part of the cube root of the t-th
+prime. -/
+def roundConstants : List.Vector (BitVec 32) 64 :=
+  ⟨[ 0x428a2f98#32, 0x71374491#32, 0xb5c0fbcf#32, 0xe9b5dba5#32,
+     0x3956c25b#32, 0x59f111f1#32, 0x923f82a4#32, 0xab1c5ed5#32,
+     0xd807aa98#32, 0x12835b01#32, 0x243185be#32, 0x550c7dc3#32,
+     0x72be5d74#32, 0x80deb1fe#32, 0x9bdc06a7#32, 0xc19bf174#32,
+     0xe49b69c1#32, 0xefbe4786#32, 0x0fc19dc6#32, 0x240ca1cc#32,
+     0x2de92c6f#32, 0x4a7484aa#32, 0x5cb0a9dc#32, 0x76f988da#32,
+     0x983e5152#32, 0xa831c66d#32, 0xb00327c8#32, 0xbf597fc7#32,
+     0xc6e00bf3#32, 0xd5a79147#32, 0x06ca6351#32, 0x14292967#32,
+     0x27b70a85#32, 0x2e1b2138#32, 0x4d2c6dfc#32, 0x53380d13#32,
+     0x650a7354#32, 0x766a0abb#32, 0x81c2c92e#32, 0x92722c85#32,
+     0xa2bfe8a1#32, 0xa81a664b#32, 0xc24b8b70#32, 0xc76c51a3#32,
+     0xd192e819#32, 0xd6990624#32, 0xf40e3585#32, 0x106aa070#32,
+     0x19a4c116#32, 0x1e376c08#32, 0x2748774c#32, 0x34b0bcb5#32,
+     0x391c0cb3#32, 0x4ed8aa4a#32, 0x5b9cca4f#32, 0x682e6ff3#32,
+     0x748f82ee#32, 0x78a5636f#32, 0x84c87814#32, 0x8cc70208#32,
+     0x90befffa#32, 0xa4506ceb#32, 0xbef9a3f7#32, 0xc67178f2#32 ],
+   by rfl⟩
+
+/-- FIPS 180-4 §5.3.3: SHA-256 initial hash value `H(0)`. First 32
+bits of the fractional parts of the square roots of the first 8
+primes. Re-exported here for use in test vectors. -/
+def initialHash : List.Vector (BitVec 32) 8 :=
+  ⟨[ 0x6a09e667#32, 0xbb67ae85#32, 0x3c6ef372#32, 0xa54ff53a#32,
+     0x510e527f#32, 0x9b05688c#32, 0x1f83d9ab#32, 0x5be0cd19#32 ],
+   by rfl⟩
+
+/-! ### Bit-mixing helpers (FIPS 180-4 §4.1.2) -/
+
+/-- 32-bit rotate-right. -/
+@[inline] def rotr32 (x : BitVec 32) (n : Nat) : BitVec 32 :=
+  (x >>> n) ||| (x <<< (32 - n))
+
+/-- Logical right shift, expressed at the same arity as `rotr32` for
+symmetry. -/
+@[inline] def shr32 (x : BitVec 32) (n : Nat) : BitVec 32 := x >>> n
+
+/-- FIPS 180-4 §4.1.2:
+`Σ_0(x) = ROTR(x,2) ⊕ ROTR(x,13) ⊕ ROTR(x,22)`. -/
+def bigSigma0 (x : BitVec 32) : BitVec 32 :=
+  rotr32 x 2 ^^^ rotr32 x 13 ^^^ rotr32 x 22
+
+/-- FIPS 180-4 §4.1.2:
+`Σ_1(x) = ROTR(x,6) ⊕ ROTR(x,11) ⊕ ROTR(x,25)`. -/
+def bigSigma1 (x : BitVec 32) : BitVec 32 :=
+  rotr32 x 6 ^^^ rotr32 x 11 ^^^ rotr32 x 25
+
+/-- FIPS 180-4 §4.1.2:
+`σ_0(x) = ROTR(x,7) ⊕ ROTR(x,18) ⊕ SHR(x,3)`. -/
+def smallSigma0 (x : BitVec 32) : BitVec 32 :=
+  rotr32 x 7 ^^^ rotr32 x 18 ^^^ shr32 x 3
+
+/-- FIPS 180-4 §4.1.2:
+`σ_1(x) = ROTR(x,17) ⊕ ROTR(x,19) ⊕ SHR(x,10)`. -/
+def smallSigma1 (x : BitVec 32) : BitVec 32 :=
+  rotr32 x 17 ^^^ rotr32 x 19 ^^^ shr32 x 10
+
+/-- FIPS 180-4 §4.1.2:
+`Ch(x,y,z) = (x AND y) ⊕ ((NOT x) AND z)`. -/
+def ch (x y z : BitVec 32) : BitVec 32 :=
+  (x &&& y) ^^^ ((~~~x) &&& z)
+
+/-- FIPS 180-4 §4.1.2:
+`Maj(x,y,z) = (x AND y) ⊕ (x AND z) ⊕ (y AND z)`. -/
+def maj (x y z : BitVec 32) : BitVec 32 :=
+  (x &&& y) ^^^ (x &&& z) ^^^ (y &&& z)
+
+/-! ### Message schedule and round step -/
+
+/-- FIPS 180-4 §6.2.2 step 1: extend the 16-word message block to the
+64-word message schedule `W[0..63]`.
+
+For `t ∈ [0, 16)`: `W[t] = M[t]`.
+For `t ∈ [16, 64)`:
+`W[t] = σ_1(W[t-2]) + W[t-7] + σ_0(W[t-15]) + W[t-16]`. -/
+def messageSchedule
+    (m : List.Vector (BitVec 32) 16) : List.Vector (BitVec 32) 64 := Id.run do
+  let mut w : Array (BitVec 32) := Array.replicate 64 0
+  for i in [:16] do
+    w := w.set! i (m.toList.getD i 0)
+  for t in [16:64] do
+    let w2  := w[t - 2]!
+    let w7  := w[t - 7]!
+    let w15 := w[t - 15]!
+    let w16 := w[t - 16]!
+    w := w.set! t (smallSigma1 w2 + w7 + smallSigma0 w15 + w16)
+  return List.Vector.ofFn (fun (i : Fin 64) => w.getD i.val 0)
+
+/-- Working-variable bundle for a single SHA-256 round. -/
+structure Vars where
+  a : BitVec 32
+  b : BitVec 32
+  c : BitVec 32
+  d : BitVec 32
+  e : BitVec 32
+  f : BitVec 32
+  g : BitVec 32
+  h : BitVec 32
+
+/-- FIPS 180-4 §6.2.2 step 3: one round of the 64-round main loop.
+
+Given working variables `a..h`, round constant `K[t]` and message
+schedule word `W[t]`, compute the updated variables according to:
+
+```
+T1 = h + Σ_1(e) + Ch(e,f,g) + K[t] + W[t]
+T2 = Σ_0(a) + Maj(a,b,c)
+h ← g; g ← f; f ← e; e ← d + T1; d ← c; c ← b; b ← a; a ← T1 + T2.
+``` -/
+def roundStep (v : Vars) (kt wt : BitVec 32) : Vars :=
+  let T1 := v.h + bigSigma1 v.e + ch v.e v.f v.g + kt + wt
+  let T2 := bigSigma0 v.a + maj v.a v.b v.c
+  { a := T1 + T2
+    b := v.a
+    c := v.b
+    d := v.c
+    e := v.d + T1
+    f := v.e
+    g := v.f
+    h := v.g }
+
+/-- FIPS 180-4 §6.2.2 step 2-4 main loop: run all 64 rounds starting
+from working variables initialised to the input state. -/
+def runRounds
+    (initial : Vars) (w : List.Vector (BitVec 32) 64) : Vars := Id.run do
+  let kArr := roundConstants.toList.toArray
+  let wArr := w.toList.toArray
+  let mut v := initial
+  for t in [:64] do
+    let kt := kArr[t]!
+    let wt := wArr[t]!
+    v := roundStep v kt wt
+  return v
+
+/-! ### Driver -/
+
+/-- FIPS 180-4 §6.2.2: a single SHA-256 compression. Updates the
+8-word chaining state `H` by absorbing one 16-word (64-byte) message
+block `M`.
+
+This matches Noir's `__sha256_compression` foreign builtin: the
+caller is responsible for padding, length encoding, and any chaining
+across multiple blocks. -/
+def compressOne
+    (state : List.Vector (BitVec 32) 8) (msg : List.Vector (BitVec 32) 16) :
+    List.Vector (BitVec 32) 8 :=
+  let w := messageSchedule msg
+  let initial : Vars :=
+    { a := state.get ⟨0, by omega⟩
+      b := state.get ⟨1, by omega⟩
+      c := state.get ⟨2, by omega⟩
+      d := state.get ⟨3, by omega⟩
+      e := state.get ⟨4, by omega⟩
+      f := state.get ⟨5, by omega⟩
+      g := state.get ⟨6, by omega⟩
+      h := state.get ⟨7, by omega⟩ }
+  let v := runRounds initial w
+  ⟨[ state.get ⟨0, by omega⟩ + v.a,
+     state.get ⟨1, by omega⟩ + v.b,
+     state.get ⟨2, by omega⟩ + v.c,
+     state.get ⟨3, by omega⟩ + v.d,
+     state.get ⟨4, by omega⟩ + v.e,
+     state.get ⟨5, by omega⟩ + v.f,
+     state.get ⟨6, by omega⟩ + v.g,
+     state.get ⟨7, by omega⟩ + v.h ],
+   by rfl⟩
+
+/-- Wrapper matching the Noir builtin signature shape:
+`(state: [u32; 8], msg: [u32; 16]) → [u32; 8]`. -/
+def compress
+    {p : Prime}
+    (state : Tp.denote p ((Tp.u 32).array (8 : U 32)))
+    (msg   : Tp.denote p ((Tp.u 32).array (16 : U 32))) :
+    Tp.denote p ((Tp.u 32).array (8 : U 32)) :=
+  compressOne state msg
+
+/-! ### Test vectors
+
+All vectors below are copy-pasted verbatim from FIPS 180-2 Appendix B
+(the SHA-256 worked examples). No third-party / re-derived references
+are involved: the padded message blocks, the intermediate hash value
+H^(1), and the final hash are exactly the byte sequences printed in the
+standard.
+
+- B.1: single-block "abc" example. One compression of the IV against
+  the padded "abc" block produces the published SHA-256("abc").
+- B.2: two-block "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+  example. Block 1 takes the IV to the intermediate state H^(1); block
+  2 takes H^(1) to the final hash H^(2). We test both compressions. -/
+
+/-- FIPS 180-2 §B.1: padded "abc" block. -/
+private def abcMsg : List.Vector (BitVec 32) 16 :=
+  ⟨[ 0x61626380#32, 0x00000000#32, 0x00000000#32, 0x00000000#32,
+     0x00000000#32, 0x00000000#32, 0x00000000#32, 0x00000000#32,
+     0x00000000#32, 0x00000000#32, 0x00000000#32, 0x00000000#32,
+     0x00000000#32, 0x00000000#32, 0x00000000#32, 0x00000018#32 ],
+   by rfl⟩
+
+/-- FIPS 180-2 §B.1: the final hash value (also the published
+SHA-256("abc")). -/
+private def abcOut : List.Vector (BitVec 32) 8 :=
+  ⟨[ 0xba7816bf#32, 0x8f01cfea#32, 0x414140de#32, 0x5dae2223#32,
+     0xb00361a3#32, 0x96177a9c#32, 0xb410ff61#32, 0xf20015ad#32 ],
+   by rfl⟩
+
+theorem sha256_abc_correct :
+    compressOne initialHash abcMsg = abcOut := by native_decide
+
+/-- FIPS 180-2 §B.2: first padded block of the two-block example,
+W_0 through W_15 as printed in the standard. -/
+private def longMsgBlock1 : List.Vector (BitVec 32) 16 :=
+  ⟨[ 0x61626364#32, 0x62636465#32, 0x63646566#32, 0x64656667#32,
+     0x65666768#32, 0x66676869#32, 0x6768696a#32, 0x68696a6b#32,
+     0x696a6b6c#32, 0x6a6b6c6d#32, 0x6b6c6d6e#32, 0x6c6d6e6f#32,
+     0x6d6e6f70#32, 0x6e6f7071#32, 0x80000000#32, 0x00000000#32 ],
+   by rfl⟩
+
+/-- FIPS 180-2 §B.2: intermediate hash value H^(1) after processing
+block 1, copied verbatim from the standard. -/
+private def longMsgIntermediate : List.Vector (BitVec 32) 8 :=
+  ⟨[ 0x85e655d6#32, 0x417a1795#32, 0x3363376a#32, 0x624cde5c#32,
+     0x76e09589#32, 0xcac5f811#32, 0xcc4b32c1#32, 0xf20e533a#32 ],
+   by rfl⟩
+
+theorem sha256_long_msg_block1_correct :
+    compressOne initialHash longMsgBlock1 = longMsgIntermediate := by
+  native_decide
+
+/-- FIPS 180-2 §B.2: second padded block of the two-block example.
+All zeros except the 64-bit length field 0x00000000_000001c0 (448 bits
+in big-endian). -/
+private def longMsgBlock2 : List.Vector (BitVec 32) 16 :=
+  ⟨[ 0x00000000#32, 0x00000000#32, 0x00000000#32, 0x00000000#32,
+     0x00000000#32, 0x00000000#32, 0x00000000#32, 0x00000000#32,
+     0x00000000#32, 0x00000000#32, 0x00000000#32, 0x00000000#32,
+     0x00000000#32, 0x00000000#32, 0x00000000#32, 0x000001c0#32 ],
+   by rfl⟩
+
+/-- FIPS 180-2 §B.2: final hash value H^(2), copied verbatim. Also the
+published SHA-256("abcdbcdec..."). -/
+private def longMsgFinal : List.Vector (BitVec 32) 8 :=
+  ⟨[ 0x248d6a61#32, 0xd20638b8#32, 0xe5c02693#32, 0x0c3e6039#32,
+     0xa33ce459#32, 0x64ff2167#32, 0xf6ecedd4#32, 0x19db06c1#32 ],
+   by rfl⟩
+
+theorem sha256_long_msg_block2_correct :
+    compressOne longMsgIntermediate longMsgBlock2 = longMsgFinal := by
+  native_decide
+
+end Lampe.Crypto.Sha256

--- a/Lampe/Tests/Sha256.lean
+++ b/Lampe/Tests/Sha256.lean
@@ -1,0 +1,60 @@
+import Lampe
+import Lampe.Crypto.Sha256
+
+/-!
+# Sha256 compression — driver-level test vectors
+
+These re-run the FIPS 180-2 Appendix B SHA-256 worked examples through
+the public `Crypto.Sha256.compressOne` entry point. The same vectors are
+also covered (as `private` theorems) inside `Lampe/Crypto/Sha256.lean`;
+duplicating them at the Tests layer makes them visible to `lake test`
+and protects the public surface from accidental regressions.
+
+Reference: FIPS 180-2 "Secure Hash Standard" Appendix B (single-block
+"abc" example in §B.1; two-block "abcdbcdec..." example in §B.2, from
+which we take the final hash).
+
+  https://csrc.nist.gov/csrc/media/publications/fips/180/2/archive/
+  2002-08-01/documents/fips180-2.pdf
+-/
+
+namespace Tests.Sha256
+
+open Lampe.Crypto.Sha256
+
+/-- FIPS 180-2 §B.1: padded "abc" against the IV gives the final
+SHA-256 hash of "abc". -/
+example :
+    compressOne
+        ⟨[ 0x6a09e667#32, 0xbb67ae85#32, 0x3c6ef372#32, 0xa54ff53a#32,
+           0x510e527f#32, 0x9b05688c#32, 0x1f83d9ab#32, 0x5be0cd19#32 ],
+         by rfl⟩
+        ⟨[ 0x61626380#32, 0x00000000#32, 0x00000000#32, 0x00000000#32,
+           0x00000000#32, 0x00000000#32, 0x00000000#32, 0x00000000#32,
+           0x00000000#32, 0x00000000#32, 0x00000000#32, 0x00000000#32,
+           0x00000000#32, 0x00000000#32, 0x00000000#32, 0x00000018#32 ],
+         by rfl⟩
+      =
+    ⟨[ 0xba7816bf#32, 0x8f01cfea#32, 0x414140de#32, 0x5dae2223#32,
+       0xb00361a3#32, 0x96177a9c#32, 0xb410ff61#32, 0xf20015ad#32 ],
+     by rfl⟩ := by native_decide
+
+/-- FIPS 180-2 §B.2: second-block compression of the two-block example
+takes the intermediate H^(1) (also printed in the standard) to the
+final published hash H^(2). -/
+example :
+    compressOne
+        ⟨[ 0x85e655d6#32, 0x417a1795#32, 0x3363376a#32, 0x624cde5c#32,
+           0x76e09589#32, 0xcac5f811#32, 0xcc4b32c1#32, 0xf20e533a#32 ],
+         by rfl⟩
+        ⟨[ 0x00000000#32, 0x00000000#32, 0x00000000#32, 0x00000000#32,
+           0x00000000#32, 0x00000000#32, 0x00000000#32, 0x00000000#32,
+           0x00000000#32, 0x00000000#32, 0x00000000#32, 0x00000000#32,
+           0x00000000#32, 0x00000000#32, 0x00000000#32, 0x000001c0#32 ],
+         by rfl⟩
+      =
+    ⟨[ 0x248d6a61#32, 0xd20638b8#32, 0xe5c02693#32, 0x0c3e6039#32,
+       0xa33ce459#32, 0x64ff2167#32, 0xf6ecedd4#32, 0x19db06c1#32 ],
+     by rfl⟩ := by native_decide
+
+end Tests.Sha256

--- a/stdlib/lampe/Stdlib/Hash/Mod.lean
+++ b/stdlib/lampe/Stdlib/Hash/Mod.lean
@@ -29,6 +29,25 @@ theorem poseidon2_permutation4_spec {p}
   steps [Lampe.Stdlib.Hash.Poseidon2.poseidon2_permutation_builtin_spec]
   assumption
 
+/-- Spec for the `sha256_compression` foreign builtin: returns the
+concrete `Crypto.Sha256.compressOne` round-function output for the
+given 8-word chaining state and 16-word message block.
+
+The Noir signature is `(input: [u32; 16], state: [u32; 8]) -> [u32; 8]`
+whereas the builtin descriptor takes `(state, msg)`; the underlying
+`callBuiltin` therefore receives the two arrays in `(state, msg)`
+order, matching `compressOne state msg`. -/
+theorem sha256_compression_builtin_spec {p}
+    {state : Tp.denote p ((Tp.u 32).array (8 : U 32))}
+    {msg : Tp.denote p ((Tp.u 32).array (16 : U 32))} :
+    STHoare p env ⟦⟧
+      (.callBuiltin [(Tp.u 32).array (8 : U 32), (Tp.u 32).array (16 : U 32)]
+        ((Tp.u 32).array (8 : U 32))
+        Builtin.sha256Compression h![state, msg])
+      (fun r => r = Lampe.Crypto.Sha256.compressOne state msg) := by
+  exact STHoare.genericTotalPureBuiltin_intro Builtin.sha256Compression rfl () p env
+    h![state, msg]
+
 theorem buildHasherDefault_default_spec {p H}
     {h_hasher : Hasher.hasImpl env H}
     {h_default : Default.hasDefaultImpl env H}


### PR DESCRIPTION
Lampe-side semantics for the Noir `sha256_compression` foreign builtin
(the FIPS 180-2 SHA-256 compression step over a single 512-bit message
schedule: 16 × `u32` block + 8 × `u32` state).

- `Lampe/Crypto/Sha256.lean` — concrete reference: round constants
  (K[0..63]), `Σ`/`σ`/`Ch`/`Maj` bit-mixers, message-schedule
  expansion, full 64-round compression.
- `Lampe/Builtin/Crypto/Sha256.lean` — `sha256Compression` total-pure
  builtin descriptor.
- `Lampe/Tests/Sha256.lean` — KAT against NIST one-block test vector.
- `stdlib/lampe/Stdlib/Hash/Mod.lean` — `sha256_compression_builtin_spec`
  giving `r = Crypto.Sha256.compressOne state msg`.

### About the spec shape
Noir's `pub fn sha256_compression(input, state) {}` is `#[foreign(...)]`
with an empty body. The Lampe extractor drops empty-body foreign
functions and rewrites their call sites to direct `BuiltinCallRef`s, so
every extracted reference to `sha256_compression` becomes a
`Builtin.sha256Compression` call. One `_builtin_spec` is therefore the
complete public API. Note the arg-order swap: Noir signature is
`(input, state)`; the builtin descriptor takes `(state, msg)`.