### PR TITLE
fix(readme): `cargo build` should be used instead of `cargo install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To install and test the `lampe` tool, please ensure that you have both Rust's `c
 2. **Set Up the Rust Version:** Enter the directory using `cd lampe` and run `rustup install` to set
    up the correct rust toolchain.
 
-3. **Build the Lampe CLI:** Run `cargo install` to build the CLI and make it available on your path.
+3. **Build the Lampe CLI:** Run `cargo build --release` to build the CLI and make it available on your path.
 
 4. **Build the Lean Project:** While not strictly necessary at this stage, this will ensure that you
    have all the necessary dependencies and the correct lean toolchain. Please be aware that this
@@ -108,4 +108,3 @@ If you would like to contribute code or documentation (non-code contributions ar
 to this repository, please take a look at our [contributing](./docs/CONTRIBUTING.md) documentation.
 It provides an overview of how to get up and running, as well as what the contribution process looks
 like for this repository.
-


### PR DESCRIPTION
To build the Lampe CLI the readme says to run `cargo install`. However, that gives the following error:

```
error: Using `cargo install` to install the binaries from the package in current working directory is no longer supported, use `cargo install --path .` instead. Use `cargo build` if you want to simply build the package.
```

I think the intention was to say to use `cargo build` for this. I also added `--release` because it doesn't take much longer and it's probably better to have a faster binary created.