### PR TITLE
feat: Share repeated type annotations during noir_def elaboration

### DIFF
--- a/Lampe/Lampe/Syntax/Builders.lean
+++ b/Lampe/Lampe/Syntax/Builders.lean
@@ -69,8 +69,8 @@ partial def extractFuncSignature [MonadDSL m]
   → m (Array (TSyntax `term) × TSyntax `term)
 | `(noir_type|λ( $paramTypes,* ) → $returnType)
 | `(noir_type|λ( $paramTypes,* ) -> $returnType) => do
-  let paramTypesExtracted ← paramTypes.getElems.mapM fun p => makeNoirType p
-  let returnTypeExtracted ← makeNoirType returnType
+  let paramTypesExtracted ← paramTypes.getElems.mapM fun p => makeNoirTypeShared p
+  let returnTypeExtracted ← makeNoirTypeShared returnType
   pure (paramTypesExtracted, returnTypeExtracted)
 | s => throwError "{s} was not a valid function type expression"
 
@@ -86,7 +86,7 @@ partial def makePat [MonadDSL m] : TSyntax `noir_pat -> m Binder
 def makeLambdaParam [MonadDSL m] (p : TSyntax `noir_lam_param) : m LambdaParam := match p with
 | `(noir_lam_param|$pat:noir_pat : $ty) => do
   let pat ← makePat pat
-  let ty ← makeNoirType ty
+  let ty ← makeNoirTypeShared ty
   pure ⟨pat, ty⟩
 | _ => throwUnsupportedSyntax
 
@@ -162,8 +162,10 @@ partial def makeExpr [MonadDSL m]
   wrapInLet t binder k
 
 -- Literals
-| `(noir_expr|$n:num : $tp) => do wrapInLet (←``(Expr.litNum $(←makeNoirType tp) $n)) binder k
-| `(noir_expr|-$n:num : $tp) => do wrapInLet (←``(Expr.litNum $(←makeNoirType tp) (-$n))) binder k
+| `(noir_expr|$n:num : $tp) => do
+  wrapInLet (←``(Expr.litNum $(←makeNoirTypeShared tp) $n)) binder k
+| `(noir_expr|-$n:num : $tp) => do
+  wrapInLet (←``(Expr.litNum $(←makeNoirTypeShared tp) (-$n))) binder k
 | `(noir_expr|$s:str) => do wrapInLet (←``(Expr.litStr (String.length $s) (NoirStr.of $s))) binder k
 | `(noir_expr|#_true) => do wrapInLet (←``(Expr.litNum Tp.bool 1)) binder k
 | `(noir_expr|#_false) => do wrapInLet (←``(Expr.litNum Tp.bool 0)) binder k
@@ -221,7 +223,7 @@ partial def makeExpr [MonadDSL m]
   let emitBuiltin : m (TSyntax `term) := makeArgs args.getElems fun args => do
     let argVals ← makeHListLit args
     wrapInLet
-      (←``(Expr.callBuiltin _ $(←makeNoirType tp) $(←makeBuiltin name.getId.toString) $argVals))
+      (←``(Expr.callBuiltin _ $(←makeNoirTypeShared tp) $(←makeBuiltin name.getId.toString) $argVals))
       binder
       k
   emitBuiltin
@@ -258,7 +260,7 @@ partial def makeExpr [MonadDSL m]
     let traitName := Syntax.mkStrLit (←makeNoirIdent tName).getId.toString
     let methodName := Syntax.mkStrLit (←makeNoirIdent fName).getId.toString
     let (paramTypes, outType) ← extractFuncSignature tp
-    let selfTp ← makeNoirType selfTp
+    let selfTp ← makeNoirTypeShared selfTp
 
     wrapInLet
       (← ``(Expr.fn
@@ -327,7 +329,7 @@ partial def makeLambda [MonadDSL m]
   → (k : Option $ TSyntax `term → m (TSyntax `term))
   → m (TSyntax `term)
 | `(noir_lambda|fn( $params,* ): $retType := $body), binder, k => do
-  let retType : TSyntax `term ← makeNoirType retType
+  let retType : TSyntax `term ← makeNoirTypeShared retType
   let params ← params.getElems.mapM makeLambdaParam
   let paramTypes ← makeListLit (params.map fun p => p.type)
   let paramNames ← params.mapM fun b => match b.binder with
@@ -396,25 +398,41 @@ partial def makeArgs [MonadDSL m]
 end
 
 
+/-- As `makeFuncParam`, but sharing the parameter's type term via `makeNoirTypeShared`. -/
+def makeFuncParamShared [MonadDSL m]
+    (param : TSyntax `noir_func_param)
+  : m FuncParam := match param with
+| `(noir_func_param|$name:ident : $type) => do pure ⟨name, ←makeNoirTypeShared type⟩
+| `(noir_func_param|_ : $type) => do pure ⟨mkIdent $ Name.mkSimple "_", ←makeNoirTypeShared type⟩
+| _ => throwUnsupportedSyntax
+
 /--
 Builds a function declaration from the provided syntax, or returns an error if the syntax is
 invalid.
+
+The parameter and return types are built in the same DSL-monad run as the body so that all three
+share type terms (see `makeNoirTypeShared`); the shared `let`s are emitted around the
+`⟨argTps, outTp, body⟩` tuple — inside the match on the generics, since the types may mention
+the generic parameters it binds.
 -/
 def makeFnDecl [MonadUtil m] (syn : Syntax) : m (Lean.Ident × TSyntax `term) := match syn with
 | `(noir_fn_def|$name:noir_ident < $generics,* >( $params,* ) → $returnType := $body)
 | `(noir_fn_def|$name:noir_ident < $generics,* >( $params,* ) -> $returnType := $body) => do
   let name ← makeNoirIdent name
   let (genericKinds, genericDefs) ← makeGenericDefTerms generics.getElems
-  let params ← params.getElems.mapM makeFuncParam
-  let body ← MonadDSL.run do
-    makeExpr body none none
+  let inner ← MonadDSL.run do
+    let params ← params.getElems.mapM makeFuncParamShared
+    let returnType ← makeNoirTypeShared returnType
+    let body ← makeExpr body none none
+    let tuple ← `(⟨
+        $(←makeListLit $ params.map fun ⟨_, t⟩ => t),
+        $returnType,
+        fun args => match args with
+        | $(←makeHListLit $ params.map fun ⟨i, _⟩ => (i : TSyntax `term)) => $body
+      ⟩)
+    wrapSharedTypeLets tuple
   let lambda ← ``(fun rep generics => match generics with
-  | $(genericDefs) => ⟨
-      $(←makeListLit $ params.map fun ⟨_, t⟩ => t),
-      $(←makeNoirType returnType),
-      fun args => match args with
-      | $(←makeHListLit $ params.map fun ⟨i, _⟩ => (i : TSyntax `term)) => $body
-    ⟩
+  | $(genericDefs) => $inner
   )
   let syn ← ``(FunctionDecl.mk
               $(Syntax.mkStrLit name.getId.toString) $ Function.mk $genericKinds $lambda)

--- a/Lampe/Lampe/Syntax/Elab.lean
+++ b/Lampe/Lampe/Syntax/Elab.lean
@@ -63,7 +63,8 @@ Elaborates an expression in the Noir eDSL, primarily intended for debugging.
 It is intended to be used with `#check`, such as `#check expr!![1 : u8]`.
 -/
 elab "expr!![" expr:noir_expr "]" : term => do
-  let term ← MonadDSL.run $ makeExpr expr none none
+  let term ← MonadDSL.run do
+    wrapSharedTypeLets (←makeExpr expr none none)
   Elab.Term.elabTerm term none
 
 /--

--- a/Lampe/Lampe/Syntax/State.lean
+++ b/Lampe/Lampe/Syntax/State.lean
@@ -24,6 +24,16 @@ structure LambdaParam where
 /-- The state for the desugaring process from the DSL syntax into native Lean/lampe constructs. -/
 structure DSLState where
   nextFresh : Nat
+  /--
+  Maps the (printed) syntax of a type annotation to the identifier its built term has been bound
+  to, so that repeated annotations reuse one binding. See `makeNoirTypeShared`.
+  -/
+  sharedTypeCache : Std.HashMap String Lean.Ident := {}
+  /--
+  The bindings backing `sharedTypeCache`, in creation order. `wrapSharedTypeLets` emits these as
+  `let`s around the finished term.
+  -/
+  sharedTypeLets : Array (Lean.Ident × TSyntax `term) := #[]
 
 /--
 The monad under which the desugaring operations all operate.
@@ -52,7 +62,68 @@ instance [Monad m] [MonadQuotation m] [MonadExceptOf Exception m] [MonadError m]
 /-- Runs the DSL monad beginning with an empty state. -/
 def MonadDSL.run [Monad m] [MonadQuotation m] [MonadExceptOf Exception m] [MonadError m]
     (a : StateT DSLState m α) : m α :=
-  StateT.run' a ⟨0⟩
+  StateT.run' a ⟨0, {}, #[]⟩
+
+/--
+The number of syntax nodes a type annotation must have before it is worth sharing via
+`makeNoirTypeShared`. Small types (`u32`, generic parameters, …) are cheap to re-elaborate, and
+`let`-binding them would only add noise.
+-/
+def sharedTypeThreshold : Nat := 16
+
+/-- The number of nodes in a syntax tree, used as the size measure for `sharedTypeThreshold`. -/
+private partial def syntaxWeight : Syntax → Nat
+| .node _ _ args => args.foldl (fun acc s => acc + syntaxWeight s) 1
+| _ => 1
+
+/-- Whether the syntax contains a hole (`_`), whose elaboration is context-dependent and which
+therefore can never be shared between use sites. -/
+private partial def containsHole : Syntax → Bool
+| s@(.node _ _ args) => s.isOfKind ``Lean.Parser.Term.hole || args.any containsHole
+| _ => false
+
+/--
+Builds the term for the provided type annotation, sharing the result between identical
+annotations within one run of the DSL monad.
+
+Extracted code repeats the same (frequently enormous) type annotation on every call, builtin,
+and reference that touches the type. Building the term anew for each occurrence makes the
+generated definition — and its elaboration cost — grow with the number of occurrences rather
+than the number of distinct types. Instead, the first occurrence of a sufficiently large type
+binds its term to a fresh identifier (registered in the state; `wrapSharedTypeLets` later emits
+the `let` for it), and every further occurrence elaborates to just that identifier. Since
+`let`-bound variables are definitionally transparent, downstream elaboration and unification
+treat the identifier exactly like the type it abbreviates.
+
+Types below `sharedTypeThreshold`, and types whose built term contains a context-dependent hole
+(`_`), fall back to plain `makeNoirType`.
+-/
+def makeNoirTypeShared [MonadDSL m] (stx : TSyntax `noir_type) : m (TSyntax `term) := do
+  if syntaxWeight stx.raw < sharedTypeThreshold then
+    makeNoirType stx
+  else
+    let key := toString stx.raw
+    if let some ident := (←get).sharedTypeCache[key]? then
+      return ident
+    let t ← makeNoirType stx
+    if containsHole t.raw then
+      return t
+    let ident ← modifyGet fun s =>
+      let ident := mkIdent $ Name.mkSimple s!"#tp_{s.sharedTypeLets.size}"
+      (ident, { s with
+        sharedTypeCache := s.sharedTypeCache.insert key ident
+        sharedTypeLets := s.sharedTypeLets.push (ident, t) })
+    return ident
+
+/--
+Wraps `body` in `let`-bindings for every type shared (via `makeNoirTypeShared`) during the
+current run of the DSL monad. Must be applied to the finished term before it leaves the run —
+and, since the shared types may mention the definition's generic parameters, at a point that is
+still under the generics' binders.
+-/
+def wrapSharedTypeLets [MonadDSL m] (body : TSyntax `term) : m (TSyntax `term) := do
+  (←get).sharedTypeLets.foldrM (init := body) fun (ident, t) acc =>
+    `(let $ident : Lampe.Tp := $t; $acc)
 
 /--
 Retrieves the name if provided, or generates a fresh name if none is available.

--- a/Lampe/Lampe/Tactic/Steps.lean
+++ b/Lampe/Lampe/Tactic/Steps.lean
@@ -413,6 +413,10 @@ Used by `simpOnlyGoal` and the `reduce_fn_body` tactic.
 private partial def reduceBetaIotaMatch (e : Lean.Expr) : Lean.MetaM Lean.Expr := do
   let step (e : Lean.Expr) : Lean.MetaM Lean.Expr := Lean.Meta.withTransparency .all do
     let e := e.headBeta
+    -- Zeta: noir_def bodies `let`-bind their shared type annotations (`makeNoirTypeShared`);
+    -- substituting them away here restores the fully-expanded body shape the rest of the
+    -- machinery expects.
+    let e := if let .letE _ _ v b _ := e then b.instantiate1 v else e
     let e := match ← Lean.Meta.reduceMatcher? e with
       | .reduced e' => e'
       | _ => e
@@ -738,6 +742,8 @@ def elabEnterDecl : Tactic := fun _ => do
     let goalType ← goal.getType
     let reduceOne (e : Lean.Expr) : Lean.MetaM Lean.Expr := do
       let e := e.headBeta
+      -- Zeta for the `let`-bound shared type annotations; see `reduceBetaIotaMatch`.
+      let e := if let .letE _ _ v b _ := e then b.instantiate1 v else e
       let e := match ← Lean.Meta.reduceMatcher? e with
         | .reduced e' => e'
         | _ => e


### PR DESCRIPTION
## Summary

Extracted code repeats the same — often enormous — type annotation on every call, builtin, and reference that touches a type (e.g. `encode_var` in extracted noir_base64 repeats its ~15-operator output-length type over a dozen times). The DSL previously re-built and re-elaborated the type term for every occurrence, so a definition's elaboration cost grew with the number of annotations rather than the number of distinct types.

This PR shares those terms: within one `noir_def`, the first occurrence of a sufficiently large type binds its term to a fresh identifier (`#tp_0`, `#tp_1`, …) and every further occurrence elaborates to just that identifier.

**Benchmark**: elaboration time is halved (918ms → 480ms) on a file of ten definitions each repeating a `encode_var`-sized type sixteen times. Definitions whose types fall below the sharing threshold are unaffected. The win exceeds the raw re-elaboration saving because sharing also shrinks every downstream term: `letIn` binder types, unification problems, and metavariable assignments carry a short identifier instead of a copy of the type.

## How it works

- **`Syntax/State.lean`**: `DSLState` gains a cache from printed type syntax to a generated identifier plus the backing bindings in creation order. `makeNoirTypeShared` builds a type term on first sight and returns the cached identifier on repeats; `wrapSharedTypeLets` emits the collected `let`s. Types under a size threshold (16 syntax nodes) and types containing context-dependent holes (`_`) fall back to plain `makeNoirType`.
- **`Syntax/Builders.lean`**: the type-bearing call sites in expression building (builtin `returning` types, funcref signatures, literals, lambdas, trait self types) go through the shared path. `makeFnDecl` now builds parameter types, return type, and body in a single DSL-monad run and wraps the result tuple in the collected `let`s — inside the generics match, since shared types may mention the generic binders. `let`-bound variables are definitionally transparent, so elaboration semantics are unchanged.
- **`Tactic/Steps.lean`**: the two body-reduction sites (`enter_decl`'s `reduceOne` and `reduceBetaIotaMatch`) now zeta-reduce the head `let` bindings, so proof goals keep exactly their existing fully-expanded shape. The change is invisible to proof authors.

## Validation

- Full `Lampe` and `Tests` builds pass.
- The existing proof tests (`LenBuiltin`, `Syntax`) prove theorems via `enter_decl`/`steps` over definitions that do receive shared types (even `Array<u8, M>` crosses the threshold), so the proof path over shared bindings is exercised by the suite.
- Verified via `#print` that generated definitions bind each large type once and reference it from all use sites, including inferred `callBuiltin` type indices.

## Notes / future work

- The 16-node threshold triggers on modest types as well as giant ones; harmless per the benchmarks, but tunable if the extra bindings bother anyone reading `#print` output.
- Call-site generic *values* (the same giant arithmetic appearing in `f<…, EXPR: u32>` positions) are not yet shared — they would need a typed ascription to be let-bound, and are the natural follow-up if more elaboration speed is wanted.